### PR TITLE
feat: added high level tracer initialization

### DIFF
--- a/examples/e2e_eval/main.go
+++ b/examples/e2e_eval/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sashabaranov/go-openai"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -130,7 +129,7 @@ func run() error {
 	openaiClient := openai.NewClient(openaiKey)
 
 	// 6. Run experiments
-	if err := runExperiments(ctx, openaiClient, testCases, examples, session.ID); err != nil {
+	if err := runExperiments(ctx, ls, openaiClient, testCases, examples, session.ID); err != nil {
 		return err
 	}
 
@@ -290,7 +289,7 @@ func createExperimentSession(ctx context.Context, client *langsmith.Client, data
 }
 
 // runExperiments runs the agent against each test case with OpenTelemetry tracing.
-func runExperiments(ctx context.Context, client *openai.Client, testCases []testCase, examples []langsmith.Example, sessionID string) error {
+func runExperiments(ctx context.Context, ls *langsmith.Tracer, client *openai.Client, testCases []testCase, examples []langsmith.Example, sessionID string) error {
 	if len(testCases) != len(examples) {
 		return fmt.Errorf("test cases count (%d) does not match examples count (%d)", len(testCases), len(examples))
 	}
@@ -300,7 +299,7 @@ func runExperiments(ctx context.Context, client *openai.Client, testCases []test
 	fmt.Println("   linked to the corresponding dataset example.")
 	fmt.Println()
 
-	tracer := otel.Tracer(serviceName)
+	tracer := ls.Tracer(serviceName)
 
 	for i, tc := range testCases {
 		example := examples[i]

--- a/examples/otel_anthropic/main.go
+++ b/examples/otel_anthropic/main.go
@@ -83,7 +83,7 @@ func run() error {
 	// The traceanthropic.Client() wraps the HTTP client to automatically trace all requests
 	client := anthropic.NewClient(
 		option.WithAPIKey(anthropicKey),
-		option.WithHTTPClient(traceanthropic.Client()),
+		option.WithHTTPClient(traceanthropic.Client(traceanthropic.WithTracerProvider(ls.TracerProvider()))),
 	)
 
 	fmt.Println("✓ Anthropic client configured with automatic tracing")

--- a/examples/otel_go_client_openai/main.go
+++ b/examples/otel_go_client_openai/main.go
@@ -11,13 +11,9 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-go/examples/otel_go_client_openai/traceopenai"
 )
 
@@ -39,11 +35,9 @@ import (
 //	go run ./examples/otel_go_client_openai
 
 const (
-	defaultProjectName    = "default"
-	serviceName           = "langsmith-go-openai-auto"
-	traceFlushWait        = 2 * time.Second
-	tracerShutdownTimeout = 10 * time.Second
-	batchTimeout          = 1 * time.Second
+	defaultProjectName = "default"
+	serviceName        = "langsmith-go-openai-auto"
+	traceFlushWait     = 2 * time.Second
 )
 
 func main() {
@@ -76,11 +70,15 @@ func run() error {
 	fmt.Println()
 
 	// Initialize OpenTelemetry tracer
-	shutdown, err := initTracer(langsmithKey, projectName)
+	ls, err := langsmith.NewTracer(
+		langsmith.WithAPIKey(langsmithKey),
+		langsmith.WithProjectName(projectName),
+		langsmith.WithServiceName(serviceName),
+	)
 	if err != nil {
 		return fmt.Errorf("initializing tracer: %w", err)
 	}
-	defer shutdown()
+	defer ls.Shutdown(context.Background())
 
 	fmt.Println("✓ OpenTelemetry configured for LangSmith")
 	fmt.Println()
@@ -88,7 +86,7 @@ func run() error {
 	// Create OpenAI client with automatic tracing
 	// The traceopenai.Client() wraps the HTTP client to automatically trace all requests
 	cfg := openai.DefaultConfig(openaiKey)
-	cfg.HTTPClient = traceopenai.Client()
+	cfg.HTTPClient = traceopenai.Client(traceopenai.WithTracerProvider(ls.TracerProvider()))
 	client := openai.NewClientWithConfig(cfg)
 
 	fmt.Println("✓ OpenAI client configured with automatic tracing")
@@ -124,7 +122,7 @@ func run() error {
 	bag1, _ := baggage.New(member1)
 	ctx1 = baggage.ContextWithBaggage(ctx1, bag1)
 	
-	ctx1, trace1Root := tracer.Start(ctx1, "agent.chain",
+	ctx1, trace1Root := tracer.Start(ctx1, "trace.1.initial_question",
 		trace.WithAttributes(
 			attribute.String("gen_ai.operation.name", "chat"),
 			attribute.String("service.name", serviceName),
@@ -194,7 +192,7 @@ func run() error {
 	bag2, _ := baggage.New(member2)
 	ctx2 = baggage.ContextWithBaggage(ctx2, bag2)
 	
-	ctx2, trace2Root := tracer.Start(ctx2, "agent.chain",
+	ctx2, trace2Root := tracer.Start(ctx2, "trace.2.simple_math",
 		trace.WithAttributes(
 			attribute.String("gen_ai.operation.name", "chat"),
 			attribute.String("service.name", serviceName),
@@ -262,7 +260,7 @@ func run() error {
 	bag3, _ := baggage.New(member3)
 	ctx3 = baggage.ContextWithBaggage(ctx3, bag3)
 	
-	ctx3, trace3Root := tracer.Start(ctx3, "agent.chain",
+	ctx3, trace3Root := tracer.Start(ctx3, "trace.3.famous_scientist",
 		trace.WithAttributes(
 			attribute.String("gen_ai.operation.name", "chat"),
 			attribute.String("service.name", serviceName),
@@ -329,55 +327,6 @@ func run() error {
 	return nil
 }
 
-// initTracer initializes the OpenTelemetry tracer with LangSmith OTLP exporter.
-func initTracer(apiKey, projectName string) (func(), error) {
-	ctx := context.Background()
-
-	// Create resource with service name
-	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName(serviceName),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating resource: %w", err)
-	}
-
-	// Create OTLP HTTP exporter with LangSmith endpoint and headers
-	exporter, err := otlptracehttp.New(ctx,
-		otlptracehttp.WithEndpoint("api.smith.langchain.com"),
-		otlptracehttp.WithURLPath("/otel/v1/traces"),
-		otlptracehttp.WithHeaders(map[string]string{
-			"x-api-key":         apiKey,
-			"Langsmith-Project": projectName,
-		}),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating OTLP exporter: %w", err)
-	}
-
-	// Create tracer provider
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter, sdktrace.WithBatchTimeout(batchTimeout)),
-		sdktrace.WithResource(res),
-	)
-
-	// Set global tracer provider
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
-
-	// Return shutdown function
-	return func() {
-		shutdownCtx, cancel := context.WithTimeout(ctx, tracerShutdownTimeout)
-		defer cancel()
-		if err := tp.Shutdown(shutdownCtx); err != nil {
-			fmt.Fprintf(os.Stderr, "Error shutting down tracer: %v\n", err)
-		}
-	}, nil
-}
 
 // getProjectName returns the project name from environment or default.
 func getProjectName() string {

--- a/examples/otel_go_client_openai/main.go
+++ b/examples/otel_go_client_openai/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sashabaranov/go-openai"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/trace"
@@ -101,7 +100,7 @@ func run() error {
 	fmt.Println("  Each API call will be its own trace, all grouped into this thread")
 	fmt.Println()
 
-	tracer := otel.Tracer(serviceName)
+	tracer := ls.Tracer(serviceName)
 
 	fmt.Println("Creating separate traces for each API call (grouped in thread)...")
 	fmt.Println()

--- a/examples/otel_ingestion/main.go
+++ b/examples/otel_ingestion/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -71,7 +70,7 @@ func run() error {
 
 	// Create spans
 	ctx := context.Background()
-	tracer := otel.Tracer(tracerName)
+	tracer := ls.Tracer(tracerName)
 	sessionID := uuid.New().String()
 
 	printWaterfallStructure()

--- a/examples/otel_ingestion/main.go
+++ b/examples/otel_ingestion/main.go
@@ -8,14 +8,10 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/google/uuid"
+	"github.com/langchain-ai/langsmith-go"
 )
 
 // Demonstrates how to send OpenTelemetry traces to LangSmith UI.
@@ -32,16 +28,15 @@ import (
 //	go run ./examples/otel_ingestion
 
 const (
-	defaultProjectName    = "default"
-	otelEndpoint         = "https://api.smith.langchain.com/otel/v1/traces"
-	serviceName          = "langsmith-go"
-	tracerName           = "langsmith.go.example"
-	traceFlushWait       = 2 * time.Second
-	tracerShutdownTimeout = 5 * time.Second
-	llmSpan1Duration     = 500 * time.Millisecond
-	toolSpanDuration     = 300 * time.Millisecond
-	retrieverSpanDuration = 200 * time.Millisecond
-	llmSpan2Duration     = 400 * time.Millisecond
+	defaultProjectName     = "default"
+	otelEndpoint           = "https://api.smith.langchain.com/otel/v1/traces"
+	serviceName            = "langsmith-go"
+	tracerName             = "langsmith.go.example"
+	traceFlushWait         = 2 * time.Second
+	llmSpan1Duration       = 500 * time.Millisecond
+	toolSpanDuration       = 300 * time.Millisecond
+	retrieverSpanDuration  = 200 * time.Millisecond
+	llmSpan2Duration       = 400 * time.Millisecond
 )
 
 func main() {
@@ -64,11 +59,15 @@ func run() error {
 	printConfig(cfg)
 
 	// Initialize OpenTelemetry tracer
-	shutdown, err := initTracer(cfg.apiKey, cfg.projectName)
+	ls, err := langsmith.NewTracer(
+		langsmith.WithAPIKey(cfg.apiKey),
+		langsmith.WithProjectName(cfg.projectName),
+		langsmith.WithServiceName(serviceName),
+	)
 	if err != nil {
 		return fmt.Errorf("initializing tracer: %w", err)
 	}
-	defer shutdown()
+	defer ls.Shutdown(context.Background())
 
 	// Create spans
 	ctx := context.Background()
@@ -237,54 +236,4 @@ func flushTraces() {
 	time.Sleep(traceFlushWait)
 }
 
-// initTracer initializes the OpenTelemetry tracer with LangSmith OTLP exporter.
-func initTracer(apiKey, projectName string) (func(), error) {
-	ctx := context.Background()
-
-	// Create resource with service name
-	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName(serviceName),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating resource: %w", err)
-	}
-
-	// Create OTLP HTTP exporter with LangSmith endpoint and headers
-	// WithEndpoint expects just the hostname (without protocol)
-	exporter, err := otlptracehttp.New(ctx,
-		otlptracehttp.WithEndpoint("api.smith.langchain.com"),
-		otlptracehttp.WithURLPath("/otel/v1/traces"),
-		otlptracehttp.WithHeaders(map[string]string{
-			"x-api-key":         apiKey,
-			"Langsmith-Project": projectName,
-		}),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating OTLP exporter: %w", err)
-	}
-
-	// Create tracer provider
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(res),
-	)
-
-	// Set global tracer provider
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
-
-	// Return shutdown function
-	return func() {
-		shutdownCtx, cancel := context.WithTimeout(ctx, tracerShutdownTimeout)
-		defer cancel()
-		if err := tp.Shutdown(shutdownCtx); err != nil {
-			fmt.Fprintf(os.Stderr, "Error shutting down tracer: %v\n", err)
-		}
-	}, nil
-}
 

--- a/examples/otel_openai/main.go
+++ b/examples/otel_openai/main.go
@@ -12,12 +12,9 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/langchain-ai/langsmith-go"
 )
 
 // Demonstrates how to make real OpenAI API calls with OpenTelemetry tracing to LangSmith.
@@ -43,8 +40,6 @@ const (
 	serviceName            = "langsmith-go-openai-example"
 	separator              = "============================================================"
 	traceFlushWaitDuration = 2 * time.Second
-	tracerShutdownTimeout  = 10 * time.Second
-	batchTimeout           = 1 * time.Second
 )
 
 func main() {
@@ -67,11 +62,15 @@ func run() error {
 	printConfig(cfg)
 
 	// Initialize OpenTelemetry tracer
-	shutdown, err := initTracer(cfg.langsmithKey, cfg.projectName)
+	ls, err := langsmith.NewTracer(
+		langsmith.WithAPIKey(cfg.langsmithKey),
+		langsmith.WithProjectName(cfg.projectName),
+		langsmith.WithServiceName(serviceName),
+	)
 	if err != nil {
 		return fmt.Errorf("initializing tracer: %w", err)
 	}
-	defer shutdown()
+	defer ls.Shutdown(context.Background())
 
 	fmt.Println("✓ OpenTelemetry configured for LangSmith")
 	fmt.Println()
@@ -438,53 +437,4 @@ func executeWeatherTool(args map[string]interface{}) string {
 	return string(resultJSON)
 }
 
-// initTracer initializes the OpenTelemetry tracer with LangSmith OTLP exporter.
-func initTracer(apiKey, projectName string) (func(), error) {
-	ctx := context.Background()
-
-	// Create resource with service name
-	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName(serviceName),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating resource: %w", err)
-	}
-
-	// Create OTLP HTTP exporter with LangSmith endpoint and headers
-	exporter, err := otlptracehttp.New(ctx,
-		otlptracehttp.WithEndpoint("api.smith.langchain.com"),
-		otlptracehttp.WithURLPath("/otel/v1/traces"),
-		otlptracehttp.WithHeaders(map[string]string{
-			"x-api-key":         apiKey,
-			"Langsmith-Project": projectName,
-		}),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating OTLP exporter: %w", err)
-	}
-
-	// Create tracer provider with simple processor for immediate export
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter, sdktrace.WithBatchTimeout(batchTimeout)),
-		sdktrace.WithResource(res),
-	)
-
-	// Set global tracer provider
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
-
-	// Return shutdown function
-	return func() {
-		shutdownCtx, cancel := context.WithTimeout(ctx, tracerShutdownTimeout)
-		defer cancel()
-		if err := tp.Shutdown(shutdownCtx); err != nil {
-			fmt.Fprintf(os.Stderr, "Error shutting down tracer: %v\n", err)
-		}
-	}, nil
-}
 

--- a/examples/otel_openai/main.go
+++ b/examples/otel_openai/main.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/sashabaranov/go-openai"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -80,7 +79,7 @@ func run() error {
 
 	// Run the agent workflow
 	ctx := context.Background()
-	tracer := otel.Tracer(serviceName)
+	tracer := ls.Tracer(serviceName)
 
 	ctx, workflowSpan := tracer.Start(ctx, "openai_agent_workflow",
 		trace.WithAttributes(

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/langchain-ai/langsmith-go
 go 1.23.0
 
 require (
+	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/google/uuid v1.6.0
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/tidwall/gjson v1.18.0
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.19.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adO
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
-github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/tracer.go
+++ b/tracer.go
@@ -1,0 +1,151 @@
+package langsmith
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	defaultEndpoint     = "api.smith.langchain.com"
+	defaultURLPath      = "/otel/v1/traces"
+	defaultBatchTimeout = 1 * time.Second
+	defaultShutdownTimeout = 10 * time.Second
+)
+
+// TracerOption configures a Tracer.
+type TracerOption func(*tracerConfig)
+
+type tracerConfig struct {
+	apiKey       string
+	projectName  string
+	serviceName  string
+	endpoint     string
+	batchTimeout time.Duration
+}
+
+// WithAPIKey sets the LangSmith API key.
+func WithAPIKey(apiKey string) TracerOption {
+	return func(c *tracerConfig) {
+		c.apiKey = apiKey
+	}
+}
+
+// WithProjectName sets the LangSmith project name.
+func WithProjectName(projectName string) TracerOption {
+	return func(c *tracerConfig) {
+		c.projectName = projectName
+	}
+}
+
+// WithServiceName sets the service name for the tracer.
+func WithServiceName(serviceName string) TracerOption {
+	return func(c *tracerConfig) {
+		c.serviceName = serviceName
+	}
+}
+
+// WithEndpoint sets the LangSmith endpoint URL.
+func WithEndpoint(endpoint string) TracerOption {
+	return func(c *tracerConfig) {
+		c.endpoint = endpoint
+	}
+}
+
+// WithBatchTimeout sets the batch timeout for trace exports.
+func WithBatchTimeout(timeout time.Duration) TracerOption {
+	return func(c *tracerConfig) {
+		c.batchTimeout = timeout
+	}
+}
+
+// Tracer manages an OpenTelemetry tracer provider for LangSmith.
+type Tracer struct {
+	tp *sdktrace.TracerProvider
+}
+
+// NewTracer creates a new Tracer with the given options.
+func NewTracer(opts ...TracerOption) (*Tracer, error) {
+	cfg := &tracerConfig{
+		endpoint:     defaultEndpoint,
+		batchTimeout: defaultBatchTimeout,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	if cfg.apiKey == "" {
+		return nil, fmt.Errorf("API key is required (use WithAPIKey)")
+	}
+
+	if cfg.projectName == "" {
+		return nil, fmt.Errorf("project name is required (use WithProjectName)")
+	}
+
+	ctx := context.Background()
+
+	// Create resource with service name if provided
+	var res *resource.Resource
+	var err error
+	if cfg.serviceName != "" {
+		res, err = resource.New(ctx,
+			resource.WithAttributes(
+				semconv.ServiceName(cfg.serviceName),
+			),
+		)
+	} else {
+		res, err = resource.New(ctx)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("creating resource: %w", err)
+	}
+
+	// Create OTLP HTTP exporter with LangSmith endpoint and headers
+	exporter, err := otlptracehttp.New(ctx,
+		otlptracehttp.WithEndpoint(cfg.endpoint),
+		otlptracehttp.WithURLPath(defaultURLPath),
+		otlptracehttp.WithHeaders(map[string]string{
+			"x-api-key":         cfg.apiKey,
+			"Langsmith-Project": cfg.projectName,
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating OTLP exporter: %w", err)
+	}
+
+	// Create tracer provider
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter, sdktrace.WithBatchTimeout(cfg.batchTimeout)),
+		sdktrace.WithResource(res),
+	)
+
+	// Set global tracer provider (for backward compatibility)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return &Tracer{tp: tp}, nil
+}
+
+// TracerProvider returns the underlying trace.TracerProvider.
+func (t *Tracer) TracerProvider() trace.TracerProvider {
+	return t.tp
+}
+
+// Shutdown gracefully shuts down the tracer provider.
+func (t *Tracer) Shutdown(ctx context.Context) error {
+	shutdownCtx, cancel := context.WithTimeout(ctx, defaultShutdownTimeout)
+	defer cancel()
+	return t.tp.Shutdown(shutdownCtx)
+}


### PR DESCRIPTION
### Summary

Adds langsmith.NewTracer() to simplify OpenTelemetry setup for LangSmith.
Updated examples by removing old boiler plate.

### Changes

- New tracer.go with NewTracer() and functional options
- Enhanced traceopenai wrapper to support custom tracer providers
- Updated 5 OpenTelemetry examples to use the new API

### Testing

Tested each example locally by sending traces to Langsmith.