### PR TITLE
chore: rename langchain_base_url to langsmith_endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The client can be configured using environment variables or by passing options d
 | `LANGSMITH_BEARER_TOKEN` | Optional* | Bearer token for authentication (alternative to API key) |
 | `LANGSMITH_TENANT_ID` | Optional | Your LangSmith tenant ID |
 | `LANGSMITH_ORGANIZATION_ID` | Optional | Your LangSmith organization ID |
-| `LANGCHAIN_BASE_URL` | Optional | Custom base URL for the LangSmith API (defaults to `https://api.smith.langchain.com`) |
+| `LANGSMITH_ENDPOINT` | Optional | Custom base URL for the LangSmith API (defaults to `https://api.smith.langchain.com`).
 
 \* Either `LANGSMITH_API_KEY` or `LANGSMITH_BEARER_TOKEN` is required for authentication.
 

--- a/client.go
+++ b/client.go
@@ -31,10 +31,13 @@ type Client struct {
 
 // DefaultClientOptions read from the environment (LANGSMITH_API_KEY,
 // LANGSMITH_TENANT_ID, LANGSMITH_BEARER_TOKEN, LANGSMITH_ORGANIZATION_ID,
-// LANGCHAIN_BASE_URL). This should be used to initialize new clients.
+// LANGSMITH_ENDPOINT). This should be used to initialize new clients.
 func DefaultClientOptions() []option.RequestOption {
 	defaults := []option.RequestOption{option.WithEnvironmentProduction()}
-	if o, ok := os.LookupEnv("LANGCHAIN_BASE_URL"); ok {
+	// Check LANGSMITH_ENDPOINT first, then fall back to LANGCHAIN_BASE_URL for backward compatibility
+	if o, ok := os.LookupEnv("LANGSMITH_ENDPOINT"); ok {
+		defaults = append(defaults, option.WithBaseURL(o))
+	} else if o, ok := os.LookupEnv("LANGCHAIN_BASE_URL"); ok {
 		defaults = append(defaults, option.WithBaseURL(o))
 	}
 	if o, ok := os.LookupEnv("LANGSMITH_API_KEY"); ok {
@@ -54,7 +57,7 @@ func DefaultClientOptions() []option.RequestOption {
 
 // NewClient generates a new client with the default option read from the
 // environment (LANGSMITH_API_KEY, LANGSMITH_TENANT_ID, LANGSMITH_BEARER_TOKEN,
-// LANGSMITH_ORGANIZATION_ID, LANGCHAIN_BASE_URL). The option passed in as
+// LANGSMITH_ORGANIZATION_ID, LANGSMITH_ENDPOINT). The option passed in as
 // arguments are applied after these default arguments, and all option will be
 // passed down to the services and requests that this client makes.
 func NewClient(opts ...option.RequestOption) (r *Client) {

--- a/client.go
+++ b/client.go
@@ -34,10 +34,7 @@ type Client struct {
 // LANGSMITH_ENDPOINT). This should be used to initialize new clients.
 func DefaultClientOptions() []option.RequestOption {
 	defaults := []option.RequestOption{option.WithEnvironmentProduction()}
-	// Check LANGSMITH_ENDPOINT first, then fall back to LANGCHAIN_BASE_URL for backward compatibility
 	if o, ok := os.LookupEnv("LANGSMITH_ENDPOINT"); ok {
-		defaults = append(defaults, option.WithBaseURL(o))
-	} else if o, ok := os.LookupEnv("LANGCHAIN_BASE_URL"); ok {
 		defaults = append(defaults, option.WithBaseURL(o))
 	}
 	if o, ok := os.LookupEnv("LANGSMITH_API_KEY"); ok {

--- a/examples/prompt_management/main.go
+++ b/examples/prompt_management/main.go
@@ -23,7 +23,7 @@ import (
 // Prerequisites:
 //   - LANGSMITH_API_KEY: Your LangSmith API key
 //   - LANGSMITH_OWNER: Your LangSmith owner (defaults to "-" if not set)
-//   - LANGCHAIN_BASE_URL: LangSmith API URL (https://api.smith.langchain.com)
+//   - LANGSMITH_ENDPOINT: LangSmith API URL (https://api.smith.langchain.com)
 //
 // Running:
 //


### PR DESCRIPTION
Rename LANGCHAIN_BASE_URL to LANGSMITH_ENDPOINT.