### PR TITLE
chore: dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,34 @@
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: /
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "monthly"
     groups:
-      go-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    groups:
-      github-actions:
+        update-types:
+          - "minor"
+          - "patch"
+      major:
         patterns:
           - "*"
+        update-types:
+          - "major"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for `gomod` and `github-actions` ecosystems
- Uses monthly schedule to reduce PR noise (security updates still arrive immediately via GitHub's separate security update feature)
- Groups split by `update-types`: major bumps in one PR, minor+patch in another — keeps breaking changes separate from safe updates

## Dependabot Posture Check

| Rule | Status |
|------|--------|
| `version: 2` | PASS |
| Monthly schedule | PASS |
| Grouped updates with update-type split | PASS |
| Full ecosystem coverage (gomod, github-actions) | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)