### PR TITLE
Fix duration calculation in middleware example

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ func Logger(req *http.Request, next option.MiddlewareNext) (res *http.Response, 
 
 	// Handle stuff after the request
 	end := time.Now()
-	LogRes(res, err, start - end)
+	LogRes(res, err, end - start)
 
     return res, err
 }


### PR DESCRIPTION
Fixes the duration calculation in the middleware example from start - end to end - start to correctly compute elapsed time.