### PR TITLE
chore: update dependabot.yml to comply with posture checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "monthly"
     groups:
@@ -18,6 +19,7 @@ updates:
           - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
## Summary

- Add `target-branch: "next"` to `gomod` and `github-actions` entries
- Required for Stainless-managed repos so Dependabot PRs open against `next` instead of `main`, following the Stainless promotion pipeline

## Test plan
- [x] Verify Dependabot PRs created after merge target the `next` branch