### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - '!generated'
       - '!codegen/**'
       - 'codegen/stl/**'
-  pull_request_target:
+  pull_request:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,13 @@ on:
       - '!generated'
       - '!codegen/**'
       - 'codegen/stl/**'
-  pull_request:
+  pull_request_target:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to `ci.yml` (Rule 1: every workflow must declare explicit permissions)

## Test plan
- [x] Verify CI workflow runs correctly on push events
