### PR TITLE
feat: add listinsightsjobs to list all insights jobs for a session

### DIFF
--- a/insights.go
+++ b/insights.go
@@ -74,6 +74,15 @@ type GetInsightsReportParams struct {
 	IncludeRuns bool
 }
 
+// ListInsightsJobs returns all insights jobs for a session (project).
+func (r *Client) ListInsightsJobs(ctx context.Context, projectID string, opts ...option.RequestOption) ([]SessionInsightListResponseItem, error) {
+	jobs, err := r.Sessions.Insights.List(ctx, projectID, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("langsmith: list insights jobs: %w", err)
+	}
+	return jobs, nil
+}
+
 // GenerateInsights generates an insights report from a list of chat histories.
 //
 // The method:

--- a/insights_test.go
+++ b/insights_test.go
@@ -343,6 +343,41 @@ func TestGetInsightsReport(t *testing.T) {
 	}
 }
 
+func TestListInsightsJobs(t *testing.T) {
+	sessionID := "aaaabbbb-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	job1ID := "11112222-1111-1111-1111-111111111111"
+	job2ID := "22223333-2222-2222-2222-222222222222"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/sessions/"+sessionID+"/insights" {
+			http.Error(w, "unexpected: "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": job1ID, "name": "job-one", "status": "success", "created_at": "2026-01-01T00:00:00Z", "clusters": []interface{}{}},
+			{"id": job2ID, "name": "job-two", "status": "pending", "created_at": "2026-01-02T00:00:00Z", "clusters": []interface{}{}},
+		})
+	}))
+	defer srv.Close()
+
+	client := newInsightsTestClient(t, srv)
+
+	jobs, err := client.ListInsightsJobs(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("ListInsightsJobs error: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("want 2 jobs, got %d", len(jobs))
+	}
+	if jobs[0].ID != job1ID || jobs[0].Name != "job-one" || jobs[0].Status != "success" {
+		t.Errorf("unexpected first job: %+v", jobs[0])
+	}
+	if jobs[1].ID != job2ID || jobs[1].Status != "pending" {
+		t.Errorf("unexpected second job: %+v", jobs[1])
+	}
+}
+
 func TestGetInsightsReport_MutuallyExclusive(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/sessioninsight.go
+++ b/sessioninsight.go
@@ -384,7 +384,6 @@ func (r sessionInsightGetJobResponseReportHighlightedTraceJSON) RawJSON() string
 	return r.raw
 }
 
-// An item returned when listing all insights jobs for a session.
 type SessionInsightListResponseItem struct {
 	ID        string                                `json:"id" api:"required" format:"uuid"`
 	Name      string                                `json:"name" api:"required"`

--- a/sessioninsight.go
+++ b/sessioninsight.go
@@ -81,6 +81,18 @@ func (r *SessionInsightService) Delete(ctx context.Context, sessionID string, jo
 	return res, err
 }
 
+// List all insights jobs for a session.
+func (r *SessionInsightService) List(ctx context.Context, sessionID string, opts ...option.RequestOption) (res []SessionInsightListResponseItem, err error) {
+	opts = slices.Concat(r.Options, opts)
+	if sessionID == "" {
+		err = errors.New("missing required session_id parameter")
+		return nil, err
+	}
+	path := fmt.Sprintf("api/v1/sessions/%s/insights", sessionID)
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
+	return res, err
+}
+
 // Get a specific cluster job for a session.
 func (r *SessionInsightService) GetJob(ctx context.Context, sessionID string, jobID string, opts ...option.RequestOption) (res *SessionInsightGetJobResponse, err error) {
 	opts = slices.Concat(r.Options, opts)
@@ -369,6 +381,46 @@ func (r *SessionInsightGetJobResponseReportHighlightedTrace) UnmarshalJSON(data 
 }
 
 func (r sessionInsightGetJobResponseReportHighlightedTraceJSON) RawJSON() string {
+	return r.raw
+}
+
+// An item returned when listing all insights jobs for a session.
+type SessionInsightListResponseItem struct {
+	ID        string                                `json:"id" api:"required" format:"uuid"`
+	Name      string                                `json:"name" api:"required"`
+	Status    string                                `json:"status" api:"required"`
+	CreatedAt time.Time                             `json:"created_at" api:"required" format:"date-time"`
+	ConfigID  string                                `json:"config_id" api:"nullable" format:"uuid"`
+	EndTime   time.Time                             `json:"end_time" api:"nullable" format:"date-time"`
+	Error     string                                `json:"error" api:"nullable"`
+	Metadata  map[string]interface{}                `json:"metadata" api:"nullable"`
+	Shape     map[string]int64                      `json:"shape" api:"nullable"`
+	StartTime time.Time                             `json:"start_time" api:"nullable" format:"date-time"`
+	Clusters  []SessionInsightGetJobResponseCluster `json:"clusters"`
+	JSON      sessionInsightListResponseItemJSON    `json:"-"`
+}
+
+type sessionInsightListResponseItemJSON struct {
+	ID          apijson.Field
+	Name        apijson.Field
+	Status      apijson.Field
+	CreatedAt   apijson.Field
+	ConfigID    apijson.Field
+	EndTime     apijson.Field
+	Error       apijson.Field
+	Metadata    apijson.Field
+	Shape       apijson.Field
+	StartTime   apijson.Field
+	Clusters    apijson.Field
+	raw         string
+	ExtraFields map[string]apijson.Field
+}
+
+func (r *SessionInsightListResponseItem) UnmarshalJSON(data []byte) (err error) {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r sessionInsightListResponseItemJSON) RawJSON() string {
 	return r.raw
 }
 


### PR DESCRIPTION
Implements GET /api/v1/sessions/{sessionID}/insights via SessionInsightService.List and the higher-level Client.ListInsightsJobs, consistent with the existing insights API surface.