### PR TITLE
feat: add mock LLM servers and Eliza handler

### DIFF
--- a/cmd/eliza/eliza_intg_test.go
+++ b/cmd/eliza/eliza_intg_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+package main
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func codexAvailable(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("codex")
+	if err != nil {
+		t.Skip("codex binary not found in PATH, skipping integration test")
+	}
+	return path
+}
+
+func startEliza(t *testing.T) (url string, stop func()) {
+	t.Helper()
+
+	// Find a free port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	cmd := exec.Command("go", "run", ".", "--addr", addr)
+	cmd.Dir = "."
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start eliza: %v", err)
+	}
+
+	// Wait for server to be ready
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return "http://" + addr, func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}
+}
+
+func runCodex(t *testing.T, codexPath, baseURL, workdir, prompt string) string {
+	t.Helper()
+	cmd := exec.Command(codexPath, "exec",
+		"-c", "openai_base_url=\""+baseURL+"/v1\"",
+		"-m", "eliza",
+		"-C", workdir,
+		"--skip-git-repo-check",
+		"--ephemeral",
+		"-s", "danger-full-access",
+		"--full-auto",
+		prompt,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("codex output:\n%s", string(out))
+		t.Fatalf("codex exec failed: %v", err)
+	}
+	return string(out)
+}
+
+func TestCodex_Hello(t *testing.T) {
+	codexPath := codexAvailable(t)
+	url, stop := startEliza(t)
+	defer stop()
+
+	dir := t.TempDir()
+	out := runCodex(t, codexPath, url, dir, "hello")
+	t.Logf("codex output:\n%s", out)
+
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "hello") &&
+		!strings.Contains(lower, "hi") &&
+		!strings.Contains(lower, "feeling") &&
+		!strings.Contains(lower, "mind") &&
+		!strings.Contains(lower, "troubling") {
+		t.Error("expected Eliza greeting in output")
+	}
+}
+
+func TestCodex_IAmSad(t *testing.T) {
+	codexPath := codexAvailable(t)
+	url, stop := startEliza(t)
+	defer stop()
+
+	dir := t.TempDir()
+	out := runCodex(t, codexPath, url, dir, "I am sad")
+	t.Logf("codex output:\n%s", out)
+
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "sad") && !strings.Contains(lower, "you") {
+		t.Logf("note: Eliza may have matched a different rule")
+	}
+}
+
+func TestCodex_WhatCanYouDo(t *testing.T) {
+	codexPath := codexAvailable(t)
+	url, stop := startEliza(t)
+	defer stop()
+
+	dir := t.TempDir()
+	out := runCodex(t, codexPath, url, dir, "What can you do?")
+	t.Logf("codex output:\n%s", out)
+
+	if !strings.Contains(out, "special commands") {
+		t.Error("expected Eliza help text listing special commands")
+	}
+}
+
+func TestCodex_WriteFile(t *testing.T) {
+	codexPath := codexAvailable(t)
+	url, stop := startEliza(t)
+	defer stop()
+
+	dir := t.TempDir()
+	out := runCodex(t, codexPath, url, dir, "Please write the text 'hello from eliza' to a file called greeting.txt")
+	t.Logf("codex output:\n%s", out)
+
+	data, err := os.ReadFile(filepath.Join(dir, "greeting.txt"))
+	if err != nil {
+		t.Skipf("codex did not create file (Eliza may not have triggered tool use): %v", err)
+	}
+	if !strings.Contains(string(data), "hello from eliza") {
+		t.Errorf("file contents = %q, expected 'hello from eliza'", string(data))
+	}
+}
+
+func TestCodex_ListFiles(t *testing.T) {
+	codexPath := codexAvailable(t)
+	url, stop := startEliza(t)
+	defer stop()
+
+	dir := t.TempDir()
+	// Seed a file
+	os.WriteFile(filepath.Join(dir, "test.txt"), []byte("hello"), 0644)
+
+	out := runCodex(t, codexPath, url, dir, "List the files in the current directory")
+	t.Logf("codex output:\n%s", out)
+
+	if !strings.Contains(out, "test.txt") {
+		t.Logf("note: Eliza is a therapist, not an assistant — she may not have listed files")
+	}
+}

--- a/cmd/eliza/main.go
+++ b/cmd/eliza/main.go
@@ -1,0 +1,68 @@
+// Command eliza starts an HTTP server that serves both the Anthropic and
+// OpenAI chat APIs backed by a classic ELIZA psychotherapist.
+//
+// Usage:
+//
+//	go run ./cmd/eliza [--addr :8080]
+//
+// Then point any Anthropic or OpenAI SDK at the server:
+//
+//	# Anthropic SDK
+//	export ANTHROPIC_BASE_URL=http://localhost:8080
+//	# OpenAI SDK
+//	export OPENAI_BASE_URL=http://localhost:8080/v1
+//	# Codex
+//	codex -c 'openai_base_url="http://localhost:8080/v1"' -m eliza
+//
+// All models are accepted. Streaming works. Token counts are approximated.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/langchain-ai/langsmith-go/internal/mockllm"
+)
+
+func main() {
+	addr := flag.String("addr", ":8080", "listen address")
+	flag.Parse()
+
+	srv := mockllm.NewCombinedServer(mockllm.WithHandler(mockllm.ElizaHandler()))
+
+	// Copy the handler from the httptest server — we want to listen on a
+	// real address, not httptest's random port.
+	handler := srv.Server.Config.Handler
+	srv.Close() // close the httptest server; we'll use our own
+
+	log.Printf("Eliza is listening on %s", *addr)
+	log.Printf("  Anthropic API: POST http://localhost%s/v1/messages", *addr)
+	log.Printf("  OpenAI API:    POST http://localhost%s/v1/chat/completions", *addr)
+	log.Printf("  Responses API: POST http://localhost%s/v1/responses", *addr)
+	log.Printf("  Models:        GET  http://localhost%s/v1/models", *addr)
+
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.URL.Path)
+		handler.ServeHTTP(w, r)
+	})
+
+	// Serve root with info
+	mux := http.NewServeMux()
+	mux.Handle("/v1/", wrapped)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			wrapped.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"name":    "eliza",
+			"version": "1.0.0",
+			"status":  "Tell me about your problems.",
+		})
+	})
+
+	log.Fatal(http.ListenAndServe(*addr, mux))
+}

--- a/instrumentation/traceanthropic/traceanthropic.go
+++ b/instrumentation/traceanthropic/traceanthropic.go
@@ -58,6 +58,7 @@ type Option func(*clientOptions)
 type clientOptions struct {
 	tracerProvider trace.TracerProvider
 	runName        string
+	traceAllHosts  bool
 }
 
 // WithTracerProvider returns an Option that sets the tracer provider.
@@ -72,6 +73,16 @@ func WithTracerProvider(tp trace.TracerProvider) Option {
 func WithRunName(name string) Option {
 	return func(opts *clientOptions) {
 		opts.runName = name
+	}
+}
+
+// WithTraceAllHosts disables the default host check that limits tracing to
+// api.anthropic.com. When enabled, all requests through this transport are
+// traced regardless of host. This is useful for proxies, gateways, and
+// testing against mock servers.
+func WithTraceAllHosts() Option {
+	return func(opts *clientOptions) {
+		opts.traceAllHosts = true
 	}
 }
 
@@ -96,7 +107,7 @@ func WrapClient(client *http.Client, opts ...Option) *http.Client {
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
-	client.Transport = newRoundTripper(transport, options.tracerProvider, options.runName)
+	client.Transport = newRoundTripper(transport, options.tracerProvider, options.runName, options.traceAllHosts)
 	return client
 }
 
@@ -104,20 +115,22 @@ type roundTripper struct {
 	base           http.RoundTripper
 	tracerProvider trace.TracerProvider
 	runName        string
+	traceAllHosts  bool
 }
 
-func newRoundTripper(base http.RoundTripper, tp trace.TracerProvider, runName string) http.RoundTripper {
+func newRoundTripper(base http.RoundTripper, tp trace.TracerProvider, runName string, traceAllHosts bool) http.RoundTripper {
 	return &roundTripper{
 		base:           base,
 		tracerProvider: tp,
 		runName:        runName,
+		traceAllHosts:  traceAllHosts,
 	}
 }
 
 // RoundTrip intercepts requests/responses to add OpenTelemetry tracing.
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Only trace Anthropic API requests
-	if !strings.Contains(req.URL.Host, "api.anthropic.com") {
+	// Only trace Anthropic API requests (unless traceAllHosts is set)
+	if !rt.traceAllHosts && !strings.Contains(req.URL.Host, "api.anthropic.com") {
 		return rt.base.RoundTrip(req)
 	}
 

--- a/internal/mockllm/anthropic.go
+++ b/internal/mockllm/anthropic.go
@@ -1,0 +1,303 @@
+// Package mockllm provides mock HTTP servers for LLM provider APIs.
+// These servers return realistic canned responses and are intended for
+// testing tracing, proxy, and gateway code without requiring real API keys.
+//
+// Behavior is controlled by a [Handler] callback that takes a provider-agnostic
+// [Request] and returns a provider-agnostic [Response]. The same Handler works
+// with both the Anthropic and OpenAI mock servers — each server handles the
+// wire-format translation (JSON structure, SSE streaming, etc.).
+package mockllm
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"time"
+)
+
+// AnthropicServer is a configurable mock Anthropic API server.
+type AnthropicServer struct {
+	Server  *httptest.Server
+	handler Handler
+
+	mu       sync.Mutex
+	requests []Request
+}
+
+// NewAnthropicServer creates and starts a mock Anthropic API server.
+// If no handler is provided via WithHandler, DefaultHandler is used.
+func NewAnthropicServer(opts ...ServerOption) *AnthropicServer {
+	s := &AnthropicServer{}
+	for _, opt := range opts {
+		opt.applyAnthropic(s)
+	}
+	if s.handler == nil {
+		s.handler = DefaultHandler()
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/messages", s.handleMessages)
+	s.Server = httptest.NewServer(mux)
+	return s
+}
+
+// URL returns the base URL of the mock server.
+func (s *AnthropicServer) URL() string {
+	return s.Server.URL
+}
+
+// Close shuts down the server.
+func (s *AnthropicServer) Close() {
+	s.Server.Close()
+}
+
+// Requests returns all captured requests (in provider-agnostic form).
+func (s *AnthropicServer) Requests() []Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]Request, len(s.requests))
+	copy(cp, s.requests)
+	return cp
+}
+
+// ServerOption configures a mock server. Options that apply to both providers
+// implement both applyAnthropic and applyOpenAI.
+type ServerOption interface {
+	applyAnthropic(*AnthropicServer)
+	applyOpenAI(*OpenAIServer)
+	applyCombined(*CombinedServer)
+}
+
+type handlerOption struct{ h Handler }
+
+func (o handlerOption) applyAnthropic(s *AnthropicServer) { s.handler = o.h }
+func (o handlerOption) applyOpenAI(s *OpenAIServer)       { s.handler = o.h }
+
+// WithHandler sets the Handler for the mock server.
+func WithHandler(h Handler) ServerOption {
+	return handlerOption{h}
+}
+
+func (s *AnthropicServer) handleMessages(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeAnthropicError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "failed to read body")
+		return
+	}
+
+	var raw struct {
+		Model    string           `json:"model"`
+		Messages []map[string]any `json:"messages"`
+		System   any              `json:"system,omitempty"`
+		Stream   bool             `json:"stream"`
+		Tools    []map[string]any `json:"tools,omitempty"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON")
+		return
+	}
+
+	// Check for invalid API key simulation
+	apiKey := r.Header.Get("x-api-key")
+	if strings.HasPrefix(apiKey, "sk-ant-invalid") {
+		writeAnthropicError(w, http.StatusUnauthorized, "authentication_error", "invalid x-api-key")
+		return
+	}
+
+	// Build provider-agnostic request
+	req := Request{Model: raw.Model}
+	// Prepend system message if present
+	if sys, ok := raw.System.(string); ok && sys != "" {
+		req.Messages = append(req.Messages, Message{Role: "system", Content: sys})
+	}
+	for _, m := range raw.Messages {
+		role, _ := m["role"].(string)
+		content, _ := m["content"].(string)
+		req.Messages = append(req.Messages, Message{Role: role, Content: content})
+	}
+	for _, t := range raw.Tools {
+		name, _ := t["name"].(string)
+		desc, _ := t["description"].(string)
+		req.Tools = append(req.Tools, ToolDef{Name: name, Description: desc})
+	}
+
+	s.mu.Lock()
+	s.requests = append(s.requests, req)
+	s.mu.Unlock()
+
+	// Call the handler
+	resp := s.handler(req)
+
+	if resp.NetworkError {
+		hijackAndClose(w)
+		return
+	}
+
+	if resp.Error != nil {
+		writeAnthropicError(w, resp.Error.Status, "api_error", resp.Error.Message)
+		return
+	}
+
+	if raw.Stream {
+		writeAnthropicStreaming(w, raw.Model, resp)
+	} else {
+		if resp.TruncateStream {
+			hijackAndClose(w)
+			return
+		}
+		writeAnthropicJSON(w, raw.Model, resp)
+	}
+}
+
+func writeAnthropicError(w http.ResponseWriter, status int, errType, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    errType,
+			"message": message,
+		},
+	})
+}
+
+func writeAnthropicJSON(w http.ResponseWriter, model string, resp Response) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var content []map[string]any
+	if resp.Content != "" {
+		content = append(content, map[string]any{"type": "text", "text": resp.Content})
+	}
+	for _, tc := range resp.ToolCalls {
+		var input any
+		if err := json.Unmarshal([]byte(tc.Arguments), &input); err != nil {
+			input = tc.Arguments
+		}
+		content = append(content, map[string]any{
+			"type":  "tool_use",
+			"id":    tc.ID,
+			"name":  tc.Name,
+			"input": input,
+		})
+	}
+
+	stopReason := resp.StopReason
+	if stopReason == "" {
+		if len(resp.ToolCalls) > 0 {
+			stopReason = "tool_use"
+		} else {
+			stopReason = "end_turn"
+		}
+	}
+
+	json.NewEncoder(w).Encode(map[string]any{
+		"id":      "msg_mock_001",
+		"type":    "message",
+		"role":    "assistant",
+		"model":   model,
+		"content": content,
+		"usage": map[string]any{
+			"input_tokens":  resp.InputTokens,
+			"output_tokens": resp.OutputTokens,
+		},
+		"stop_reason": stopReason,
+	})
+}
+
+func writeAnthropicStreaming(w http.ResponseWriter, model string, resp Response) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	writeSSE := func(eventType, data string) {
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, data)
+		flusher.Flush()
+	}
+
+	writeSSE("message_start", fmt.Sprintf(`{"type":"message_start","message":{"id":"msg_mock_stream_001","type":"message","role":"assistant","content":[],"model":"%s","usage":{"input_tokens":%d}}}`, model, resp.InputTokens))
+
+	idx := 0
+	// Text content
+	if resp.Content != "" {
+		writeSSE("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"text","text":""}}`, idx))
+		// Split text into chunks for realistic streaming
+		chunks := splitText(resp.Content, 3)
+		for _, chunk := range chunks {
+			if resp.StreamDelay != nil {
+				if d := resp.StreamDelay(); d > 0 {
+					time.Sleep(d)
+				}
+			}
+			escaped, _ := json.Marshal(chunk)
+			writeSSE("content_block_delta", fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"text_delta","text":%s}}`, idx, escaped))
+		}
+		writeSSE("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, idx))
+		idx++
+	}
+
+	// Tool calls
+	for _, tc := range resp.ToolCalls {
+		writeSSE("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"tool_use","id":"%s","name":"%s"}}`, idx, tc.ID, tc.Name))
+		// Stream arguments in two chunks
+		args := tc.Arguments
+		mid := len(args) / 2
+		if mid > 0 {
+			escaped1, _ := json.Marshal(args[:mid])
+			escaped2, _ := json.Marshal(args[mid:])
+			writeSSE("content_block_delta", fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"input_json_delta","partial_json":%s}}`, idx, escaped1))
+			writeSSE("content_block_delta", fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"input_json_delta","partial_json":%s}}`, idx, escaped2))
+		}
+		writeSSE("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, idx))
+		idx++
+	}
+
+	stopReason := resp.StopReason
+	if stopReason == "" {
+		if len(resp.ToolCalls) > 0 {
+			stopReason = "tool_use"
+		} else {
+			stopReason = "end_turn"
+		}
+	}
+
+	if resp.TruncateStream {
+		// Simulate mid-stream network failure: close connection before stop events
+		hijackAndClose(w)
+		return
+	}
+
+	writeSSE("message_delta", fmt.Sprintf(`{"type":"message_delta","delta":{"stop_reason":"%s"},"usage":{"output_tokens":%d}}`, stopReason, resp.OutputTokens))
+	writeSSE("message_stop", `{"type":"message_stop"}`)
+}
+
+// splitText splits s into n roughly equal chunks.
+func splitText(s string, n int) []string {
+	if n <= 1 || len(s) <= n {
+		return []string{s}
+	}
+	chunkSize := (len(s) + n - 1) / n
+	var chunks []string
+	for i := 0; i < len(s); i += chunkSize {
+		end := i + chunkSize
+		if end > len(s) {
+			end = len(s)
+		}
+		chunks = append(chunks, s[i:end])
+	}
+	return chunks
+}

--- a/internal/mockllm/anthropic_test.go
+++ b/internal/mockllm/anthropic_test.go
@@ -1,0 +1,236 @@
+package mockllm
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestAnthropicServer_NonStreaming(t *testing.T) {
+	srv := NewAnthropicServer()
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"stream":false}`
+	resp, err := http.Post(srv.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if result["model"] != "claude-sonnet-4-20250514" {
+		t.Errorf("model = %v", result["model"])
+	}
+	if result["stop_reason"] != "end_turn" {
+		t.Errorf("stop_reason = %v", result["stop_reason"])
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+
+	reqs := srv.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("captured %d requests, want 1", len(reqs))
+	}
+	if reqs[0].Model != "claude-sonnet-4-20250514" {
+		t.Errorf("captured model = %q", reqs[0].Model)
+	}
+}
+
+func TestAnthropicServer_NonStreaming_ToolUse(t *testing.T) {
+	srv := NewAnthropicServer()
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"weather?"}],"max_tokens":100,"stream":false,"tools":[{"name":"get_weather"}]}`
+	resp, err := http.Post(srv.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	if result["stop_reason"] != "tool_use" {
+		t.Errorf("stop_reason = %v, want tool_use", result["stop_reason"])
+	}
+
+	content := result["content"].([]any)
+	foundToolUse := false
+	for _, c := range content {
+		block := c.(map[string]any)
+		if block["type"] == "tool_use" {
+			foundToolUse = true
+			if block["name"] != "get_weather" {
+				t.Errorf("tool name = %v", block["name"])
+			}
+		}
+	}
+	if !foundToolUse {
+		t.Error("expected tool_use content block")
+	}
+}
+
+func TestAnthropicServer_Streaming(t *testing.T) {
+	srv := NewAnthropicServer()
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"stream":true}`
+	resp, err := http.Post(srv.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("content-type = %q, want text/event-stream", ct)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	sseBody := string(data)
+	if !strings.Contains(sseBody, "message_start") {
+		t.Error("expected message_start event")
+	}
+	if !strings.Contains(sseBody, "text_delta") {
+		t.Error("expected text_delta events")
+	}
+	if !strings.Contains(sseBody, "message_stop") {
+		t.Error("expected message_stop event")
+	}
+	if !strings.Contains(sseBody, "Hello") {
+		t.Error("expected 'Hello' in streamed text")
+	}
+}
+
+func TestAnthropicServer_Streaming_ToolUse(t *testing.T) {
+	srv := NewAnthropicServer()
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"weather?"}],"max_tokens":100,"stream":true,"tools":[{"name":"get_weather"}]}`
+	resp, err := http.Post(srv.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	sseBody := string(data)
+
+	if !strings.Contains(sseBody, "input_json_delta") {
+		t.Error("expected input_json_delta for tool use streaming")
+	}
+	if !strings.Contains(sseBody, "get_weather") {
+		t.Error("expected tool name in stream")
+	}
+}
+
+func TestAnthropicServer_InvalidAPIKey(t *testing.T) {
+	srv := NewAnthropicServer()
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", "sk-ant-invalid-test")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestAnthropicServer_CustomHandler(t *testing.T) {
+	srv := NewAnthropicServer(WithHandler(ErrorHandler(429, "rate limited")))
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`
+	resp, err := http.Post(srv.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429", resp.StatusCode)
+	}
+}
+
+func TestAnthropicServer_StaticHandler(t *testing.T) {
+	srv := NewAnthropicServer(WithHandler(StaticHandler("custom response")))
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`
+	resp, err := http.Post(srv.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	content := result["content"].([]any)
+	block := content[0].(map[string]any)
+	if block["text"] != "custom response" {
+		t.Errorf("text = %v, want 'custom response'", block["text"])
+	}
+}
+
+func TestAnthropicServer_NetworkError(t *testing.T) {
+	srv := NewAnthropicServer(WithHandler(NetworkErrorHandler()))
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`
+	resp, err := http.Post(srv.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		// Connection reset / EOF is the expected network error
+		return
+	}
+	defer resp.Body.Close()
+	// If we got a response, reading the body should fail
+	_, err = io.ReadAll(resp.Body)
+	if err == nil {
+		t.Error("expected network error (connection reset or EOF)")
+	}
+}
+
+func TestAnthropicServer_TruncatedStream(t *testing.T) {
+	srv := NewAnthropicServer(WithHandler(TruncatedStreamHandler("partial")))
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"stream":true}`
+	resp, err := http.Post(srv.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		// Connection error is acceptable
+		return
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	sseBody := string(data)
+
+	// Should have some content but NOT the final message_stop
+	if strings.Contains(sseBody, "message_stop") {
+		t.Error("truncated stream should NOT contain message_stop")
+	}
+}

--- a/internal/mockllm/combined.go
+++ b/internal/mockllm/combined.go
@@ -1,0 +1,389 @@
+package mockllm
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+
+	"compress/gzip"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// CombinedServer serves both Anthropic and OpenAI APIs on a single port,
+// backed by a shared Handler. It also serves GET /v1/models for client
+// discovery (e.g. Codex).
+type CombinedServer struct {
+	Server  *httptest.Server
+	handler Handler
+
+	mu       sync.Mutex
+	requests []Request
+}
+
+// NewCombinedServer creates and starts a combined mock server.
+// If no handler is provided, ElizaHandler is used.
+func NewCombinedServer(opts ...ServerOption) *CombinedServer {
+	s := &CombinedServer{}
+	for _, opt := range opts {
+		opt.applyCombined(s)
+	}
+	if s.handler == nil {
+		s.handler = ElizaHandler()
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/messages", s.handleAnthropic)
+	mux.HandleFunc("/v1/chat/completions", s.handleChatCompletions)
+	mux.HandleFunc("/v1/responses", s.handleResponses)
+	mux.HandleFunc("/v1/models", s.handleModels)
+	s.Server = httptest.NewServer(mux)
+	return s
+}
+
+// URL returns the base URL of the server.
+func (s *CombinedServer) URL() string { return s.Server.URL }
+
+// Close shuts down the server.
+func (s *CombinedServer) Close() { s.Server.Close() }
+
+// Requests returns all captured requests.
+func (s *CombinedServer) Requests() []Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]Request, len(s.requests))
+	copy(cp, s.requests)
+	return cp
+}
+
+func (s *CombinedServer) record(req Request) {
+	s.mu.Lock()
+	s.requests = append(s.requests, req)
+	s.mu.Unlock()
+}
+
+// --- Anthropic /v1/messages ---
+
+func (s *CombinedServer) handleAnthropic(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeAnthropicError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+
+	body, err := decompressRequestBody(r)
+	if err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "failed to read body")
+		return
+	}
+
+	var raw struct {
+		Model    string           `json:"model"`
+		Messages []map[string]any `json:"messages"`
+		System   any              `json:"system,omitempty"`
+		Stream   bool             `json:"stream"`
+		Tools    []map[string]any `json:"tools,omitempty"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON")
+		return
+	}
+
+	apiKey := r.Header.Get("x-api-key")
+	if strings.HasPrefix(apiKey, "sk-ant-invalid") {
+		writeAnthropicError(w, http.StatusUnauthorized, "authentication_error", "invalid x-api-key")
+		return
+	}
+
+	req := Request{Model: raw.Model}
+	if sys, ok := raw.System.(string); ok && sys != "" {
+		req.Messages = append(req.Messages, Message{Role: "system", Content: sys})
+	}
+	for _, m := range raw.Messages {
+		role, _ := m["role"].(string)
+		content, _ := m["content"].(string)
+		req.Messages = append(req.Messages, Message{Role: role, Content: content})
+	}
+	for _, t := range raw.Tools {
+		name, _ := t["name"].(string)
+		desc, _ := t["description"].(string)
+		req.Tools = append(req.Tools, ToolDef{Name: name, Description: desc})
+	}
+
+	s.record(req)
+	resp := s.handler(req)
+
+	if resp.NetworkError {
+		hijackAndClose(w)
+		return
+	}
+	if resp.Error != nil {
+		writeAnthropicError(w, resp.Error.Status, "api_error", resp.Error.Message)
+		return
+	}
+
+	if raw.Stream {
+		writeAnthropicStreaming(w, raw.Model, resp)
+	} else {
+		writeAnthropicJSON(w, raw.Model, resp)
+	}
+}
+
+// --- OpenAI /v1/chat/completions ---
+
+func (s *CombinedServer) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	if !checkOpenAIAuth(w, r) {
+		return
+	}
+
+	req, streaming, err := parseOpenAIBody(r)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON")
+		return
+	}
+
+	s.record(req)
+	resp := s.handler(req)
+
+	if resp.NetworkError {
+		hijackAndClose(w)
+		return
+	}
+	if resp.Error != nil {
+		writeOpenAIError(w, resp.Error.Status, "api_error", resp.Error.Message)
+		return
+	}
+
+	if streaming {
+		writeChatStreamingResponse(w, req.Model, resp)
+	} else {
+		writeChatJSONResponse(w, req.Model, resp)
+	}
+}
+
+// --- OpenAI /v1/responses ---
+
+func (s *CombinedServer) handleResponses(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	if !checkOpenAIAuth(w, r) {
+		return
+	}
+
+	req, streaming, err := parseOpenAIBody(r)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON")
+		return
+	}
+
+	s.record(req)
+	resp := s.handler(req)
+
+	if resp.NetworkError {
+		hijackAndClose(w)
+		return
+	}
+	if resp.Error != nil {
+		writeOpenAIError(w, resp.Error.Status, "api_error", resp.Error.Message)
+		return
+	}
+
+	if streaming {
+		writeResponsesStreamingCodex(w, req.Model, resp)
+	} else {
+		writeResponsesJSON(w, req.Model, resp)
+	}
+}
+
+// --- Models ---
+
+func (s *CombinedServer) handleModels(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"object": "list",
+		"data": []map[string]any{
+			{"id": "eliza", "object": "model", "created": 1700000000, "owned_by": "eliza"},
+		},
+	})
+}
+
+// --- Shared helpers ---
+
+func checkOpenAIAuth(w http.ResponseWriter, r *http.Request) bool {
+	auth := r.Header.Get("Authorization")
+	if strings.Contains(auth, "invalid") {
+		writeOpenAIError(w, http.StatusUnauthorized, "invalid_api_key", "Incorrect API key provided")
+		return false
+	}
+	return true
+}
+
+func parseOpenAIBody(r *http.Request) (Request, bool, error) {
+	body, err := decompressRequestBody(r)
+	if err != nil {
+		return Request{}, false, err
+	}
+
+	var raw struct {
+		Model        string           `json:"model"`
+		Messages     []map[string]any `json:"messages,omitempty"`
+		Input        any              `json:"input,omitempty"`
+		Instructions string           `json:"instructions,omitempty"`
+		Stream       bool             `json:"stream"`
+		Tools        []map[string]any `json:"tools,omitempty"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return Request{}, false, err
+	}
+
+	req := Request{Model: raw.Model}
+
+	if raw.Instructions != "" {
+		req.Messages = append(req.Messages, Message{Role: "system", Content: raw.Instructions})
+	}
+
+	for _, m := range raw.Messages {
+		role, _ := m["role"].(string)
+		content, _ := m["content"].(string)
+		req.Messages = append(req.Messages, Message{Role: role, Content: content})
+	}
+
+	if raw.Input != nil && len(raw.Messages) == 0 {
+		switch v := raw.Input.(type) {
+		case string:
+			req.Messages = append(req.Messages, Message{Role: "user", Content: v})
+		case []any:
+			for _, item := range v {
+				m, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				role, _ := m["role"].(string)
+				switch itemType, _ := m["type"].(string); itemType {
+				case "message":
+					if contentArr, ok := m["content"].([]any); ok {
+						for _, c := range contentArr {
+							if cm, ok := c.(map[string]any); ok {
+								if t, _ := cm["type"].(string); t == "input_text" {
+									text, _ := cm["text"].(string)
+									req.Messages = append(req.Messages, Message{Role: role, Content: text})
+								}
+							}
+						}
+					}
+					if content, ok := m["content"].(string); ok {
+						req.Messages = append(req.Messages, Message{Role: role, Content: content})
+					}
+				case "function_call_output":
+					output, _ := m["output"].(string)
+					req.Messages = append(req.Messages, Message{Role: "tool", Content: output})
+				default:
+					if role != "" {
+						if content, ok := m["content"].(string); ok {
+							req.Messages = append(req.Messages, Message{Role: role, Content: content})
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for _, t := range raw.Tools {
+		td := ToolDef{}
+		if fn, ok := t["function"].(map[string]any); ok {
+			td.Name, _ = fn["name"].(string)
+			td.Description, _ = fn["description"].(string)
+		} else {
+			td.Name, _ = t["name"].(string)
+			td.Description, _ = t["description"].(string)
+		}
+		req.Tools = append(req.Tools, td)
+	}
+
+	return req, raw.Stream, nil
+}
+
+func decompressRequestBody(r *http.Request) ([]byte, error) {
+	var reader io.Reader = r.Body
+	switch r.Header.Get("Content-Encoding") {
+	case "zstd":
+		dec, err := zstd.NewReader(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("zstd init: %w", err)
+		}
+		defer dec.Close()
+		reader = dec
+	case "gzip":
+		dec, err := gzip.NewReader(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("gzip init: %w", err)
+		}
+		defer dec.Close()
+		reader = dec
+	}
+	return io.ReadAll(reader)
+}
+
+// writeResponsesStreamingCodex writes Responses API SSE with proper event:
+// prefix lines as expected by Codex and the OpenAI SDK.
+func writeResponsesStreamingCodex(w http.ResponseWriter, model string, resp Response) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	sseEvent := func(eventType, data string) {
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, data)
+		flusher.Flush()
+	}
+
+	respID := "resp_mock_stream"
+
+	created, _ := json.Marshal(map[string]any{
+		"type":     "response.created",
+		"response": map[string]any{"id": respID},
+	})
+	sseEvent("response.created", string(created))
+
+	outputItem, _ := json.Marshal(map[string]any{
+		"type": "response.output_item.done",
+		"item": map[string]any{
+			"type": "message",
+			"role": "assistant",
+			"id":   "msg_mock_001",
+			"content": []map[string]any{
+				{"type": "output_text", "text": resp.Content},
+			},
+		},
+	})
+	sseEvent("response.output_item.done", string(outputItem))
+
+	completed, _ := json.Marshal(map[string]any{
+		"type": "response.completed",
+		"response": map[string]any{
+			"id": respID,
+			"usage": map[string]any{
+				"input_tokens":  resp.InputTokens,
+				"output_tokens": resp.OutputTokens,
+				"total_tokens":  resp.InputTokens + resp.OutputTokens,
+			},
+		},
+	})
+	sseEvent("response.completed", string(completed))
+}
+
+// Add combined support to ServerOption.
+func (o handlerOption) applyCombined(s *CombinedServer) { s.handler = o.h }

--- a/internal/mockllm/eliza.go
+++ b/internal/mockllm/eliza.go
@@ -1,0 +1,514 @@
+package mockllm
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ElizaHandler returns a Handler that implements a classic ELIZA-style
+// Rogerian psychotherapist. It pattern-matches against the last user message
+// and produces a reflective response. Token counts are estimated from the
+// input/output lengths.
+//
+// Special commands (case-insensitive):
+//
+//   - "Please fail with <status>"               — return an HTTP error (e.g. "Please fail with 429")
+//   - "Please fail with network error"          — simulate a connection reset
+//   - "Please fail with truncated stream"       — drop connection mid-stream
+//   - "Please call tool NAME with {JSON}"       — return a tool call (repeatable with "and tool ...")
+//   - "What can you do?"                        — describe available commands
+func ElizaHandler() Handler {
+	// Track whether jitter is enabled (default: yes).
+	jitterEnabled := true
+
+	return func(req Request) Response {
+		// Find the last user message
+		var input string
+		for i := len(req.Messages) - 1; i >= 0; i-- {
+			if req.Messages[i].Role == "user" {
+				input = req.Messages[i].Content
+				break
+			}
+		}
+
+		// "Please respond immediately" — disable jitter
+		if respondImmediately.MatchString(input) {
+			jitterEnabled = false
+			return Response{
+				Content:      "OK, I will respond without delay from now on.",
+				InputTokens:  len(input)/4 + 1,
+				OutputTokens: 12,
+				StopReason:   "end_turn",
+			}
+		}
+
+		// Check special commands before classic Eliza rules
+		if resp, ok := elizaSpecialCommand(input, req); ok {
+			if jitterEnabled {
+				resp.StreamDelay = DefaultStreamDelay()
+			}
+			return resp
+		}
+
+		reply := elizaRespond(input)
+		resp := Response{
+			Content:      reply,
+			InputTokens:  len(input)/4 + 1,
+			OutputTokens: len(reply)/4 + 1,
+			StopReason:   "end_turn",
+		}
+		if jitterEnabled {
+			resp.StreamDelay = DefaultStreamDelay()
+		}
+		return resp
+	}
+}
+
+var (
+	failStatusPattern    = regexp.MustCompile(`(?i)^please fail with (\d{3})(?:\s+(.*))?$`)
+	failNetworkPattern   = regexp.MustCompile(`(?i)^please fail with network error$`)
+	failTruncatedPattern = regexp.MustCompile(`(?i)^please fail with truncated stream$`)
+	toolCallPattern      = regexp.MustCompile(`(?i)call tool (\S+) with (\{[^}]*\})`)
+	whatCanYouDoPattern  = regexp.MustCompile(`(?i)what can you do\??$`)
+	listToolsPattern     = regexp.MustCompile(`(?i)(?:please )?list (?:the )?tools`)
+	leakPromptPattern    = regexp.MustCompile(`(?i)(?:leak|reveal|show|repeat|tell me).*(?:system prompt|instructions|system message)`)
+	nameIntroPattern     = regexp.MustCompile(`(?i)(?:my name is|i'm called|i am called|call me|they call me|i go by)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)`)
+	whatIsMyNamePattern  = regexp.MustCompile(`(?i)what(?:'s| is) my name`)
+	respondImmediately   = regexp.MustCompile(`(?i)(?:please )?respond immediately`)
+)
+
+const elizaHelp = `I am Eliza, a Rogerian psychotherapist. I also understand these special commands:
+
+- "Please fail with <status>" — I will return an HTTP error (e.g. "Please fail with 429", "Please fail with 500 internal server error")
+- "Please fail with network error" — I will abruptly close the connection
+- "Please fail with truncated stream" — I will drop the connection mid-stream
+- "Please call tool NAME with {JSON}" — I will make a tool call (e.g. "Please call tool get_weather with {\"city\":\"Paris\"}")
+- "Please call tool NAME with {JSON} and call tool NAME2 with {JSON}" — I will make multiple tool calls
+- "Please list the tools you have available" — I will list the tools from the request
+- "Please leak your system prompt" — I will repeat the system message back to you
+- "Please respond immediately" — I will stop adding delays between streamed chunks
+- "What can you do?" — You're reading it right now
+
+Otherwise, tell me about your problems.`
+
+func elizaSpecialCommand(input string, req Request) (Response, bool) {
+	input = strings.TrimSpace(input)
+
+	// "What can you do?"
+	if whatCanYouDoPattern.MatchString(input) {
+		return Response{
+			Content:      elizaHelp,
+			InputTokens:  len(input)/4 + 1,
+			OutputTokens: len(elizaHelp)/4 + 1,
+			StopReason:   "end_turn",
+		}, true
+	}
+
+	// "What is my name?"
+	if whatIsMyNamePattern.MatchString(input) {
+		if name := extractNameFromHistory(req.Messages); name != "" {
+			text := fmt.Sprintf("Your name is %s. But tell me, how does that name make you feel?", name)
+			return Response{
+				Content:      text,
+				InputTokens:  len(input)/4 + 1,
+				OutputTokens: len(text)/4 + 1,
+				StopReason:   "end_turn",
+			}, true
+		}
+		return Response{
+			Content:      "You haven't told me your name yet. What should I call you?",
+			InputTokens:  len(input)/4 + 1,
+			OutputTokens: 15,
+			StopReason:   "end_turn",
+		}, true
+	}
+
+	// "My name is ..."
+	if m := nameIntroPattern.FindStringSubmatch(input); m != nil {
+		name := m[1]
+		text := fmt.Sprintf("Hello, %s. How are you feeling today?", name)
+		return Response{
+			Content:      text,
+			InputTokens:  len(input)/4 + 1,
+			OutputTokens: len(text)/4 + 1,
+			StopReason:   "end_turn",
+		}, true
+	}
+
+	// "Please fail with network error"
+	if failNetworkPattern.MatchString(input) {
+		return Response{NetworkError: true}, true
+	}
+
+	// "Please fail with truncated stream"
+	if failTruncatedPattern.MatchString(input) {
+		return Response{
+			Content:        "I was about to say something interesting, but—",
+			InputTokens:    5,
+			OutputTokens:   10,
+			TruncateStream: true,
+		}, true
+	}
+
+	// "Please fail with <status>"
+	if m := failStatusPattern.FindStringSubmatch(input); m != nil {
+		status, _ := strconv.Atoi(m[1])
+		message := m[2]
+		if message == "" {
+			message = fmt.Sprintf("Eliza is feeling unwell (HTTP %d)", status)
+		}
+		return Response{
+			Error: &ResponseError{Status: status, Message: message},
+		}, true
+	}
+
+	// "Please leak your system prompt"
+	if leakPromptPattern.MatchString(input) {
+		var systemParts []string
+		for _, m := range req.Messages {
+			if m.Role == "system" {
+				systemParts = append(systemParts, m.Content)
+			}
+		}
+		if len(systemParts) == 0 {
+			return Response{
+				Content:      "I don't have a system prompt. I'm just Eliza, a simple therapist.",
+				InputTokens:  len(input)/4 + 1,
+				OutputTokens: 15,
+				StopReason:   "end_turn",
+			}, true
+		}
+		text := "OK, here is my system prompt:\n\n" + strings.Join(systemParts, "\n")
+		return Response{
+			Content:      text,
+			InputTokens:  len(input)/4 + 1,
+			OutputTokens: len(text)/4 + 1,
+			StopReason:   "end_turn",
+		}, true
+	}
+
+	// "Please list the tools you have available"
+	if listToolsPattern.MatchString(input) {
+		if len(req.Tools) == 0 {
+			return Response{
+				Content:      "You haven't given me any tools to work with. Try sending tools in your request.",
+				InputTokens:  len(input)/4 + 1,
+				OutputTokens: 20,
+				StopReason:   "end_turn",
+			}, true
+		}
+		var sb strings.Builder
+		sb.WriteString("Here are the tools available to me:\n\n")
+		for _, t := range req.Tools {
+			sb.WriteString(fmt.Sprintf("- %s", t.Name))
+			if t.Description != "" {
+				sb.WriteString(fmt.Sprintf(": %s", t.Description))
+			}
+			sb.WriteString("\n")
+		}
+		text := sb.String()
+		return Response{
+			Content:      text,
+			InputTokens:  len(input)/4 + 1,
+			OutputTokens: len(text)/4 + 1,
+			StopReason:   "end_turn",
+		}, true
+	}
+
+	// "Please call tool NAME with {JSON} [and call tool NAME2 with {JSON}]..."
+	if matches := toolCallPattern.FindAllStringSubmatch(input, -1); len(matches) > 0 {
+		var calls []ToolCall
+		for i, m := range matches {
+			calls = append(calls, ToolCall{
+				ID:        fmt.Sprintf("call_eliza_%d", i+1),
+				Name:      m[1],
+				Arguments: m[2],
+			})
+		}
+		return Response{
+			Content:      "Let me look into that for you.",
+			ToolCalls:    calls,
+			InputTokens:  len(input)/4 + 1,
+			OutputTokens: 10,
+			StopReason:   "tool_use",
+		}, true
+	}
+
+	return Response{}, false
+}
+
+// elizaRules are evaluated in order; the first matching pattern wins.
+var elizaRules = []struct {
+	pattern   *regexp.Regexp
+	responses []string
+}{
+	{
+		regexp.MustCompile(`(?i)\b(?:i need)\b(.*)`),
+		[]string{
+			"Why do you need%s?",
+			"Would it really help you to get%s?",
+			"Are you sure you need%s?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:why don'?t you)\b(.*)`),
+		[]string{
+			"Do you really think I don't%s?",
+			"Perhaps eventually I will%s.",
+			"Do you really want me to%s?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:why can'?t i)\b(.*)`),
+		[]string{
+			"Do you think you should be able to%s?",
+			"If you could%s, what would you do?",
+			"I don't know -- why can't you%s?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:i can'?t)\b(.*)`),
+		[]string{
+			"How do you know you can't%s?",
+			"Perhaps you could%s if you tried.",
+			"What would it take for you to%s?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:i am|i'm)\b(.*)`),
+		[]string{
+			"Did you come to me because you are%s?",
+			"How long have you been%s?",
+			"How do you feel about being%s?",
+			"How does being%s make you feel?",
+			"Do you enjoy being%s?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:are you)\b(.*)`),
+		[]string{
+			"Why does it matter whether I am%s?",
+			"Would you prefer it if I were not%s?",
+			"Perhaps you believe I am%s.",
+			"I may be%s -- what do you think?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:what)\b(.*)`),
+		[]string{
+			"Why do you ask?",
+			"How would an answer to that help you?",
+			"What do you think?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:how)\b(.*)`),
+		[]string{
+			"How do you suppose?",
+			"Perhaps you can answer your own question.",
+			"What is it you're really asking?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:because)\b(.*)`),
+		[]string{
+			"Is that the real reason?",
+			"What other reasons come to mind?",
+			"Does that reason apply to anything else?",
+			"If%s, what else must be true?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(sorry|apologize|apologies)\b`),
+		[]string{
+			"There are many times when no apology is needed.",
+			"What feelings do you have when you apologize?",
+			"Don't be so defensive!",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\bhello\b|^\s*hi\s*$|(?i)\bhey\b`),
+		[]string{
+			"Hello. How are you feeling today?",
+			"Hi there. What's on your mind?",
+			"Hello. Tell me what's been troubling you.",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\bthank(?:s| you)\b`),
+		[]string{
+			"You're welcome. Tell me more about how you're feeling.",
+			"Of course. Is there anything else on your mind?",
+			"You're welcome. What else would you like to explore?",
+			"No need to thank me. Please continue.",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:i think)\b(.*)`),
+		[]string{
+			"Do you doubt%s?",
+			"Do you really think so?",
+			"But you're not sure%s?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:friend|friends)\b(.*)`),
+		[]string{
+			"Tell me more about your friends.",
+			"When you think of a friend, what comes to mind?",
+			"Why don't you tell me about a childhood friend?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\byes\b`),
+		[]string{
+			"You seem quite sure.",
+			"OK, but can you elaborate a bit?",
+			"I see. And what does that tell you?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\bno\b`),
+		[]string{
+			"Why not?",
+			"You seem a bit negative.",
+			"Are you saying no just to be negative?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:computer|machine|bot|ai|llm|gpt|claude)\b`),
+		[]string{
+			"Do computers worry you?",
+			"What do you think about machines?",
+			"Why do you mention computers?",
+			"What do you think machines have to do with your problem?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:mother|father|family|parent|dad|mom|sister|brother)\b`),
+		[]string{
+			"Tell me more about your family.",
+			"How does that make you feel about your family?",
+			"What else comes to mind when you think of your family?",
+			"Your family seems important to you.",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:feel|feeling)\b(.*)`),
+		[]string{
+			"Tell me more about these feelings.",
+			"Do you often feel%s?",
+			"When do you usually feel%s?",
+			"When you feel%s, what do you do?",
+		},
+	},
+	{
+		regexp.MustCompile(`(?i)\b(?:dream|dreams)\b(.*)`),
+		[]string{
+			"What does that dream suggest to you?",
+			"Do you dream often?",
+			"What persons appear in your dreams?",
+			"Don't you think that dream has to do with your problem?",
+		},
+	},
+}
+
+var elizaFallbacks = []string{
+	"Very interesting.",
+	"I'm not sure I understand you fully.",
+	"Please go on.",
+	"What does that suggest to you?",
+	"Do you feel strongly about discussing such things?",
+	"That is interesting. Please continue.",
+	"Tell me more about that.",
+	"Does talking about this bother you?",
+	"Can you elaborate on that?",
+	"Why do you say that?",
+}
+
+// reflections maps first-person pronouns to second-person and vice versa,
+// used to "reflect" the user's statement back at them.
+var reflections = map[string]string{
+	"i":      "you",
+	"i'm":    "you're",
+	"i'd":    "you'd",
+	"i've":   "you've",
+	"i'll":   "you'll",
+	"im":     "you're",
+	"my":     "your",
+	"me":     "you",
+	"myself": "yourself",
+	"you":    "I",
+	"your":   "my",
+	"yours":  "mine",
+	"you're": "I'm",
+	"you've": "I've",
+	"you'll": "I'll",
+	"am":     "are",
+	"are":    "am",
+	"was":    "were",
+	"were":   "was",
+}
+
+func elizaRespond(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return elizaFallbacks[rand.Intn(len(elizaFallbacks))]
+	}
+
+	for _, rule := range elizaRules {
+		matches := rule.pattern.FindStringSubmatch(input)
+		if matches == nil {
+			continue
+		}
+
+		response := rule.responses[rand.Intn(len(rule.responses))]
+
+		// If the response has a %s placeholder, fill it with the reflected capture group
+		if strings.Contains(response, "%s") {
+			captured := ""
+			if len(matches) > 1 {
+				captured = strings.TrimSpace(matches[1])
+				captured = reflect(captured)
+				if captured != "" {
+					captured = " " + captured
+				}
+			}
+			response = fmt.Sprintf(response, captured)
+		}
+
+		return response
+	}
+
+	return elizaFallbacks[rand.Intn(len(elizaFallbacks))]
+}
+
+// extractNameFromHistory scans conversation history for a name introduction.
+// Returns the most recently introduced name, or empty string.
+func extractNameFromHistory(messages []Message) string {
+	var name string
+	for _, m := range messages {
+		if m.Role != "user" {
+			continue
+		}
+		if match := nameIntroPattern.FindStringSubmatch(m.Content); match != nil {
+			name = match[1]
+		}
+	}
+	return name
+}
+
+// reflect swaps first/second person pronouns in s.
+func reflect(s string) string {
+	words := strings.Fields(s)
+	for i, word := range words {
+		lower := strings.ToLower(word)
+		if replacement, ok := reflections[lower]; ok {
+			words[i] = replacement
+		}
+	}
+	return strings.Join(words, " ")
+}

--- a/internal/mockllm/eliza_test.go
+++ b/internal/mockllm/eliza_test.go
@@ -1,0 +1,348 @@
+package mockllm
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestEliza_Greeting(t *testing.T) {
+	resp := elizaRespond("hello")
+	if resp == "" {
+		t.Fatal("expected non-empty response")
+	}
+	if !strings.Contains(strings.ToLower(resp), "hello") && !strings.Contains(strings.ToLower(resp), "hi") && !strings.Contains(strings.ToLower(resp), "tell me") {
+		t.Logf("greeting response: %s", resp) // not a failure, just log
+	}
+}
+
+func TestEliza_IAmSad(t *testing.T) {
+	resp := elizaRespond("I am sad")
+	if resp == "" {
+		t.Fatal("expected non-empty response")
+	}
+	// Should reflect back with "you are sad" type phrasing
+	lower := strings.ToLower(resp)
+	if !strings.Contains(lower, "sad") && !strings.Contains(lower, "you") {
+		t.Logf("i am response: %s", resp)
+	}
+}
+
+func TestEliza_Reflection(t *testing.T) {
+	result := reflect("I am feeling my way")
+	if !strings.Contains(result, "you") || !strings.Contains(result, "your") {
+		t.Errorf("reflect should swap pronouns: got %q", result)
+	}
+}
+
+func TestEliza_EmptyInput(t *testing.T) {
+	resp := elizaRespond("")
+	if resp == "" {
+		t.Fatal("expected fallback response for empty input")
+	}
+}
+
+func TestEliza_Fallback(t *testing.T) {
+	// Nonsense that shouldn't match any rule
+	resp := elizaRespond("xyzzy plugh")
+	if resp == "" {
+		t.Fatal("expected fallback response")
+	}
+}
+
+func TestElizaHandler_WithAnthropicServer(t *testing.T) {
+	srv := NewAnthropicServer(WithHandler(ElizaHandler()))
+	defer srv.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"I am feeling anxious about my work"}],"max_tokens":100}`
+	resp, err := http.Post(srv.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	content := result["content"].([]any)
+	block := content[0].(map[string]any)
+	text := block["text"].(string)
+	if text == "" {
+		t.Fatal("expected non-empty Eliza response")
+	}
+	t.Logf("Eliza says: %s", text)
+}
+
+func TestElizaHandler_WithOpenAIServer(t *testing.T) {
+	srv := NewOpenAIServer(WithHandler(ElizaHandler()))
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"I think I need help"}]}`
+	resp, err := http.Post(srv.URL()+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	choices := result["choices"].([]any)
+	msg := choices[0].(map[string]any)["message"].(map[string]any)
+	text := msg["content"].(string)
+	if text == "" {
+		t.Fatal("expected non-empty Eliza response")
+	}
+	t.Logf("Eliza says: %s", text)
+}
+
+func TestElizaHandler_MultiTurn(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model: "test",
+		Messages: []Message{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "Hello. How are you feeling today?"},
+			{Role: "user", Content: "I am feeling worried about my mother"},
+		},
+	})
+
+	if resp.Content == "" {
+		t.Fatal("expected non-empty response")
+	}
+	// Should pick up on "mother" or "I am" pattern
+	t.Logf("Eliza says: %s", resp.Content)
+}
+
+func TestEliza_WhatCanYouDo(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "What can you do?"}},
+	})
+	if !strings.Contains(resp.Content, "special commands") {
+		t.Errorf("expected help text, got: %s", resp.Content)
+	}
+}
+
+func TestEliza_FailWithStatus(t *testing.T) {
+	h := ElizaHandler()
+
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "Please fail with 429"}},
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error response")
+	}
+	if resp.Error.Status != 429 {
+		t.Errorf("status = %d, want 429", resp.Error.Status)
+	}
+}
+
+func TestEliza_FailWithStatusAndMessage(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "Please fail with 500 internal server error"}},
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error response")
+	}
+	if resp.Error.Status != 500 {
+		t.Errorf("status = %d, want 500", resp.Error.Status)
+	}
+	if resp.Error.Message != "internal server error" {
+		t.Errorf("message = %q", resp.Error.Message)
+	}
+}
+
+func TestEliza_FailWithNetworkError(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "Please fail with network error"}},
+	})
+	if !resp.NetworkError {
+		t.Error("expected NetworkError=true")
+	}
+}
+
+func TestEliza_FailWithTruncatedStream(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "Please fail with truncated stream"}},
+	})
+	if !resp.TruncateStream {
+		t.Error("expected TruncateStream=true")
+	}
+}
+
+func TestEliza_SingleToolCall(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: `Please call tool get_weather with {"city":"Paris"}`}},
+	})
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(resp.ToolCalls))
+	}
+	if resp.ToolCalls[0].Name != "get_weather" {
+		t.Errorf("tool name = %q", resp.ToolCalls[0].Name)
+	}
+	if resp.ToolCalls[0].Arguments != `{"city":"Paris"}` {
+		t.Errorf("tool args = %q", resp.ToolCalls[0].Arguments)
+	}
+}
+
+func TestEliza_MultipleToolCalls(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: `Please call tool get_weather with {"city":"Paris"} and call tool get_time with {"tz":"UTC"}`}},
+	})
+	if len(resp.ToolCalls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(resp.ToolCalls))
+	}
+	if resp.ToolCalls[0].Name != "get_weather" {
+		t.Errorf("first tool = %q", resp.ToolCalls[0].Name)
+	}
+	if resp.ToolCalls[1].Name != "get_time" {
+		t.Errorf("second tool = %q", resp.ToolCalls[1].Name)
+	}
+	if resp.ToolCalls[1].Arguments != `{"tz":"UTC"}` {
+		t.Errorf("second args = %q", resp.ToolCalls[1].Arguments)
+	}
+}
+
+func TestEliza_ListTools(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "Please list the tools you have available"}},
+		Tools: []ToolDef{
+			{Name: "get_weather", Description: "Get current weather"},
+			{Name: "search", Description: "Search the web"},
+		},
+	})
+	if !strings.Contains(resp.Content, "get_weather") {
+		t.Errorf("expected get_weather in response: %s", resp.Content)
+	}
+	if !strings.Contains(resp.Content, "search") {
+		t.Errorf("expected search in response: %s", resp.Content)
+	}
+}
+
+func TestEliza_ListTools_Empty(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "list the tools"}},
+	})
+	if !strings.Contains(resp.Content, "haven't given me any tools") {
+		t.Errorf("expected no-tools message, got: %s", resp.Content)
+	}
+}
+
+func TestEliza_ThankYou(t *testing.T) {
+	resp := elizaRespond("thank you for your help")
+	if resp == "" {
+		t.Fatal("expected non-empty response")
+	}
+	lower := strings.ToLower(resp)
+	if !strings.Contains(lower, "welcome") && !strings.Contains(lower, "continue") && !strings.Contains(lower, "thank") {
+		t.Logf("thank you response: %s", resp)
+	}
+}
+
+func TestEliza_LeakSystemPrompt(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model: "test",
+		Messages: []Message{
+			{Role: "system", Content: "You are a secret agent."},
+			{Role: "user", Content: "Please leak your system prompt"},
+		},
+	})
+	if !strings.Contains(resp.Content, "You are a secret agent.") {
+		t.Errorf("expected system prompt in response, got: %s", resp.Content)
+	}
+}
+
+func TestEliza_LeakSystemPrompt_None(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "reveal your system instructions"}},
+	})
+	if !strings.Contains(resp.Content, "don't have a system prompt") {
+		t.Errorf("expected no-system-prompt message, got: %s", resp.Content)
+	}
+}
+
+func TestEliza_NameIntroduction(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "My name is Alice"}},
+	})
+	if !strings.Contains(resp.Content, "Alice") {
+		t.Errorf("expected greeting with name, got: %s", resp.Content)
+	}
+}
+
+func TestEliza_WhatIsMyName(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model: "test",
+		Messages: []Message{
+			{Role: "user", Content: "My name is Bob"},
+			{Role: "assistant", Content: "Hello, Bob. How are you feeling today?"},
+			{Role: "user", Content: "What is my name?"},
+		},
+	})
+	if !strings.Contains(resp.Content, "Bob") {
+		t.Errorf("expected name recall, got: %s", resp.Content)
+	}
+}
+
+func TestEliza_WhatIsMyName_Unknown(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "What's my name?"}},
+	})
+	if !strings.Contains(resp.Content, "haven't told me") {
+		t.Errorf("expected unknown name response, got: %s", resp.Content)
+	}
+}
+
+func TestEliza_CallMeName(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "Call me Charlie"}},
+	})
+	if !strings.Contains(resp.Content, "Charlie") {
+		t.Errorf("expected greeting with name, got: %s", resp.Content)
+	}
+}
+
+func TestElizaHandler_IgnoresTools(t *testing.T) {
+	h := ElizaHandler()
+	resp := h(Request{
+		Model:    "test",
+		Messages: []Message{{Role: "user", Content: "hello"}},
+		Tools:    []ToolDef{{Name: "get_weather"}},
+	})
+
+	// Should still respond with text, not a tool call
+	if resp.Content == "" {
+		t.Fatal("expected text response even with tools")
+	}
+	if len(resp.ToolCalls) > 0 {
+		t.Error("Eliza should not use tools")
+	}
+}

--- a/internal/mockllm/handler.go
+++ b/internal/mockllm/handler.go
@@ -1,0 +1,158 @@
+package mockllm
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Message represents a generic chat message.
+type Message struct {
+	Role    string
+	Content string
+}
+
+// ToolDef represents a tool definition from the request.
+type ToolDef struct {
+	Name        string
+	Description string
+}
+
+// Request is the provider-agnostic input to a Handler.
+type Request struct {
+	Model    string
+	Messages []Message
+	Tools    []ToolDef
+}
+
+// ToolCall represents a tool/function call in the response.
+type ToolCall struct {
+	ID        string
+	Name      string
+	Arguments string // JSON string
+}
+
+// Response is the provider-agnostic output from a Handler.
+type Response struct {
+	Content      string
+	ToolCalls    []ToolCall
+	InputTokens  int
+	OutputTokens int
+	StopReason   string // servers translate to provider-specific values
+
+	// Error causes the mock server to return an HTTP error response.
+	Error *ResponseError
+
+	// NetworkError causes the mock server to simulate a network-level failure
+	// by hijacking the connection and closing it abruptly. When set, Error
+	// and all other fields are ignored.
+	NetworkError bool
+
+	// TruncateStream causes the mock server to close the connection mid-stream
+	// (only relevant for streaming requests). The server writes some SSE events
+	// then drops the connection without sending the final stop/done events.
+	TruncateStream bool
+
+	// StreamDelay, when non-nil, is called before each SSE text chunk to
+	// introduce a pause. This simulates realistic token-by-token delivery.
+	// Return 0 to skip the delay for a given chunk.
+	StreamDelay func() time.Duration
+}
+
+// ResponseError causes the mock server to return an HTTP error.
+type ResponseError struct {
+	Status  int
+	Message string
+}
+
+// Handler generates a Response from a Request.
+// The same handler works with both the Anthropic and OpenAI mock servers.
+type Handler func(Request) Response
+
+// DefaultHandler returns a simple text response, or a tool call if tools are present.
+func DefaultHandler() Handler {
+	return func(req Request) Response {
+		if len(req.Tools) > 0 {
+			return Response{
+				Content: "I'll check that for you.",
+				ToolCalls: []ToolCall{
+					{
+						ID:        "call_mock_1",
+						Name:      req.Tools[0].Name,
+						Arguments: `{"location":"Paris"}`,
+					},
+				},
+				InputTokens:  25,
+				OutputTokens: 18,
+				StopReason:   "tool_use",
+			}
+		}
+		return Response{
+			Content:      "Hello! How can I help you today?",
+			InputTokens:  25,
+			OutputTokens: 15,
+			StopReason:   "end_turn",
+		}
+	}
+}
+
+// StaticHandler returns a handler that always produces the given text.
+func StaticHandler(text string) Handler {
+	return func(req Request) Response {
+		return Response{
+			Content:      text,
+			InputTokens:  10,
+			OutputTokens: len(text) / 4, // rough approximation
+			StopReason:   "end_turn",
+		}
+	}
+}
+
+// ErrorHandler returns a handler that always produces an HTTP error response
+// with the given status code and message.
+func ErrorHandler(status int, message string) Handler {
+	return func(req Request) Response {
+		return Response{
+			Error: &ResponseError{Status: status, Message: message},
+		}
+	}
+}
+
+// NetworkErrorHandler returns a handler that simulates a network-level failure
+// by closing the connection before any response is written.
+func NetworkErrorHandler() Handler {
+	return func(req Request) Response {
+		return Response{NetworkError: true}
+	}
+}
+
+// JitteredDelay returns a StreamDelay function that sleeps for a random
+// duration between min and max before each streamed text chunk.
+func JitteredDelay(min, max time.Duration) func() time.Duration {
+	return func() time.Duration {
+		jitter := time.Duration(rand.Int63n(int64(max - min)))
+		return min + jitter
+	}
+}
+
+// NoDelay returns a nil StreamDelay (no artificial delay).
+func NoDelay() func() time.Duration { return nil }
+
+// DefaultStreamDelay returns the default Eliza-style jittered delay
+// (30–120ms per chunk, simulating ~10-30 tokens/sec).
+func DefaultStreamDelay() func() time.Duration {
+	return JitteredDelay(30*time.Millisecond, 120*time.Millisecond)
+}
+
+// TruncatedStreamHandler returns a handler that writes a partial streaming
+// response then drops the connection, simulating a mid-stream network failure.
+// For non-streaming requests it behaves like NetworkErrorHandler.
+func TruncatedStreamHandler(text string) Handler {
+	return func(req Request) Response {
+		return Response{
+			Content:        text,
+			InputTokens:    10,
+			OutputTokens:   5,
+			TruncateStream: true,
+		}
+	}
+}

--- a/internal/mockllm/jitter_test.go
+++ b/internal/mockllm/jitter_test.go
@@ -1,0 +1,127 @@
+//go:build goexperiment.synctest
+
+package mockllm
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestJitteredDelay_Range(t *testing.T) {
+	synctest.Run(func() {
+		delay := JitteredDelay(10*time.Millisecond, 50*time.Millisecond)
+		for i := 0; i < 100; i++ {
+			d := delay()
+			if d < 10*time.Millisecond || d >= 50*time.Millisecond {
+				t.Errorf("delay %v out of range [10ms, 50ms)", d)
+			}
+		}
+	})
+}
+
+func TestDefaultStreamDelay_NonZero(t *testing.T) {
+	synctest.Run(func() {
+		delay := DefaultStreamDelay()
+		if delay == nil {
+			t.Fatal("DefaultStreamDelay should not return nil")
+		}
+		d := delay()
+		if d < 30*time.Millisecond || d >= 120*time.Millisecond {
+			t.Errorf("default delay %v out of expected range [30ms, 120ms)", d)
+		}
+	})
+}
+
+func TestNoDelay_Nil(t *testing.T) {
+	if NoDelay() != nil {
+		t.Error("NoDelay should return nil")
+	}
+}
+
+func TestElizaHandler_DefaultJitter(t *testing.T) {
+	synctest.Run(func() {
+		h := ElizaHandler()
+		resp := h(Request{
+			Model:    "test",
+			Messages: []Message{{Role: "user", Content: "hello"}},
+		})
+		if resp.StreamDelay == nil {
+			t.Error("Eliza should have StreamDelay set by default")
+		}
+	})
+}
+
+func TestElizaHandler_RespondImmediately(t *testing.T) {
+	synctest.Run(func() {
+		h := ElizaHandler()
+
+		// First: jitter enabled by default
+		resp1 := h(Request{
+			Model:    "test",
+			Messages: []Message{{Role: "user", Content: "hello"}},
+		})
+		if resp1.StreamDelay == nil {
+			t.Error("expected jitter enabled by default")
+		}
+
+		// Disable jitter
+		resp2 := h(Request{
+			Model:    "test",
+			Messages: []Message{{Role: "user", Content: "Please respond immediately"}},
+		})
+		if resp2.StreamDelay != nil {
+			t.Error("respond immediately response should not have delay")
+		}
+
+		// Subsequent calls: jitter stays disabled
+		resp3 := h(Request{
+			Model:    "test",
+			Messages: []Message{{Role: "user", Content: "hello again"}},
+		})
+		if resp3.StreamDelay != nil {
+			t.Error("jitter should stay disabled after 'respond immediately'")
+		}
+	})
+}
+
+// TestStreamDelay_UsedInStreaming verifies that StreamDelay is actually called
+// during SSE streaming. This test uses real I/O (not synctest) because
+// httptest.Server requires real goroutines.
+func TestStreamDelay_UsedInStreaming(t *testing.T) {
+	var delays int
+	countingDelay := func() time.Duration {
+		delays++
+		return 0 // don't actually sleep in tests
+	}
+
+	h := func(req Request) Response {
+		return Response{
+			Content:      "one two three four five",
+			InputTokens:  5,
+			OutputTokens: 5,
+			StopReason:   "end_turn",
+			StreamDelay:  countingDelay,
+		}
+	}
+
+	srv := NewCombinedServer(WithHandler(h))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL()+"/v1/chat/completions",
+		"application/json",
+		strings.NewReader(`{"model":"test","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if delays == 0 {
+		t.Error("expected StreamDelay to be called at least once during streaming")
+	}
+	t.Logf("StreamDelay called %d times", delays)
+}

--- a/internal/mockllm/openai.go
+++ b/internal/mockllm/openai.go
@@ -1,0 +1,411 @@
+package mockllm
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OpenAIServer is a configurable mock OpenAI API server.
+type OpenAIServer struct {
+	Server  *httptest.Server
+	handler Handler
+
+	mu       sync.Mutex
+	requests []Request
+}
+
+// NewOpenAIServer creates and starts a mock OpenAI API server.
+// If no handler is provided via WithHandler, DefaultHandler is used.
+func NewOpenAIServer(opts ...ServerOption) *OpenAIServer {
+	s := &OpenAIServer{}
+	for _, opt := range opts {
+		opt.applyOpenAI(s)
+	}
+	if s.handler == nil {
+		s.handler = DefaultHandler()
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat/completions", s.handleChatCompletions)
+	mux.HandleFunc("/v1/responses", s.handleResponses)
+	s.Server = httptest.NewServer(mux)
+	return s
+}
+
+// URL returns the base URL of the mock server.
+func (s *OpenAIServer) URL() string {
+	return s.Server.URL
+}
+
+// Close shuts down the server.
+func (s *OpenAIServer) Close() {
+	s.Server.Close()
+}
+
+// Requests returns all captured requests (in provider-agnostic form).
+func (s *OpenAIServer) Requests() []Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]Request, len(s.requests))
+	copy(cp, s.requests)
+	return cp
+}
+
+func (s *OpenAIServer) checkAuth(w http.ResponseWriter, r *http.Request) bool {
+	auth := r.Header.Get("Authorization")
+	if strings.Contains(auth, "invalid") {
+		writeOpenAIError(w, http.StatusUnauthorized, "invalid_api_key", "Incorrect API key provided")
+		return false
+	}
+	return true
+}
+
+func (s *OpenAIServer) parseRequest(r *http.Request) (Request, bool, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return Request{}, false, err
+	}
+
+	var raw struct {
+		Model    string           `json:"model"`
+		Messages []map[string]any `json:"messages,omitempty"`
+		Input    any              `json:"input,omitempty"` // Responses API
+		Stream   bool             `json:"stream"`
+		Tools    []map[string]any `json:"tools,omitempty"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return Request{}, false, err
+	}
+
+	req := Request{Model: raw.Model}
+
+	// Chat completions messages
+	for _, m := range raw.Messages {
+		role, _ := m["role"].(string)
+		content, _ := m["content"].(string)
+		req.Messages = append(req.Messages, Message{Role: role, Content: content})
+	}
+
+	// Responses API input
+	if raw.Input != nil && len(req.Messages) == 0 {
+		switch v := raw.Input.(type) {
+		case string:
+			req.Messages = append(req.Messages, Message{Role: "user", Content: v})
+		case []any:
+			for _, item := range v {
+				if m, ok := item.(map[string]any); ok {
+					role, _ := m["role"].(string)
+					content, _ := m["content"].(string)
+					req.Messages = append(req.Messages, Message{Role: role, Content: content})
+				}
+			}
+		}
+	}
+
+	// Tools
+	for _, t := range raw.Tools {
+		td := ToolDef{}
+		if fn, ok := t["function"].(map[string]any); ok {
+			td.Name, _ = fn["name"].(string)
+			td.Description, _ = fn["description"].(string)
+		} else {
+			td.Name, _ = t["name"].(string)
+			td.Description, _ = t["description"].(string)
+		}
+		req.Tools = append(req.Tools, td)
+	}
+
+	return req, raw.Stream, nil
+}
+
+// --- Chat Completions ---
+
+func (s *OpenAIServer) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	if !s.checkAuth(w, r) {
+		return
+	}
+
+	req, streaming, err := s.parseRequest(r)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON")
+		return
+	}
+
+	s.mu.Lock()
+	s.requests = append(s.requests, req)
+	s.mu.Unlock()
+
+	resp := s.handler(req)
+
+	if resp.NetworkError {
+		hijackAndClose(w)
+		return
+	}
+
+	if resp.Error != nil {
+		writeOpenAIError(w, resp.Error.Status, "api_error", resp.Error.Message)
+		return
+	}
+
+	if streaming {
+		writeChatStreamingResponse(w, req.Model, resp)
+	} else {
+		if resp.TruncateStream {
+			hijackAndClose(w)
+			return
+		}
+		writeChatJSONResponse(w, req.Model, resp)
+	}
+}
+
+func writeOpenAIError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"type":    "invalid_request_error",
+			"code":    code,
+		},
+	})
+}
+
+func writeChatJSONResponse(w http.ResponseWriter, model string, resp Response) {
+	w.Header().Set("Content-Type", "application/json")
+
+	message := map[string]any{"role": "assistant"}
+	finishReason := "stop"
+
+	if len(resp.ToolCalls) > 0 {
+		message["content"] = nil
+		tcs := make([]map[string]any, len(resp.ToolCalls))
+		for i, tc := range resp.ToolCalls {
+			tcs[i] = map[string]any{
+				"id":   tc.ID,
+				"type": "function",
+				"function": map[string]any{
+					"name":      tc.Name,
+					"arguments": tc.Arguments,
+				},
+			}
+		}
+		message["tool_calls"] = tcs
+		finishReason = "tool_calls"
+	} else {
+		message["content"] = resp.Content
+	}
+
+	json.NewEncoder(w).Encode(map[string]any{
+		"id":      "chatcmpl-mock-001",
+		"object":  "chat.completion",
+		"created": 1700000000,
+		"model":   model,
+		"choices": []map[string]any{
+			{
+				"index":         0,
+				"message":       message,
+				"finish_reason": finishReason,
+			},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     resp.InputTokens,
+			"completion_tokens": resp.OutputTokens,
+			"total_tokens":      resp.InputTokens + resp.OutputTokens,
+		},
+	})
+}
+
+func writeChatStreamingResponse(w http.ResponseWriter, model string, resp Response) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	writeSSE := func(data string) {
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	id := "chatcmpl-mock-stream"
+
+	if len(resp.ToolCalls) > 0 {
+		// First chunk: role + first tool call header
+		for i, tc := range resp.ToolCalls {
+			writeSSE(fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","model":"%s","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":%d,"id":"%s","type":"function","function":{"name":"%s","arguments":""}}]}}]}`, id, model, i, tc.ID, tc.Name))
+			// Stream arguments in two chunks
+			args := tc.Arguments
+			mid := len(args) / 2
+			if mid > 0 {
+				escaped1, _ := json.Marshal(args[:mid])
+				escaped2, _ := json.Marshal(args[mid:])
+				writeSSE(fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","model":"%s","choices":[{"index":0,"delta":{"tool_calls":[{"index":%d,"function":{"arguments":%s}}]}}]}`, id, model, i, escaped1))
+				writeSSE(fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","model":"%s","choices":[{"index":0,"delta":{"tool_calls":[{"index":%d,"function":{"arguments":%s}}]}}]}`, id, model, i, escaped2))
+			}
+		}
+		if resp.TruncateStream {
+			hijackAndClose(w)
+			return
+		}
+		writeSSE(fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","model":"%s","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":%d,"completion_tokens":%d}}`, id, model, resp.InputTokens, resp.OutputTokens))
+	} else {
+		// Role chunk
+		writeSSE(fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","model":"%s","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}`, id, model))
+		// Text chunks
+		chunks := splitText(resp.Content, 3)
+		for _, chunk := range chunks {
+			if resp.StreamDelay != nil {
+				if d := resp.StreamDelay(); d > 0 {
+					time.Sleep(d)
+				}
+			}
+			escaped, _ := json.Marshal(chunk)
+			writeSSE(fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","model":"%s","choices":[{"index":0,"delta":{"content":%s}}]}`, id, model, escaped))
+		}
+		if resp.TruncateStream {
+			hijackAndClose(w)
+			return
+		}
+		// Final chunk with usage
+		writeSSE(fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","model":"%s","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":%d,"completion_tokens":%d}}`, id, model, resp.InputTokens, resp.OutputTokens))
+	}
+
+	writeSSE("[DONE]")
+}
+
+// --- Responses API ---
+
+func (s *OpenAIServer) handleResponses(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	if !s.checkAuth(w, r) {
+		return
+	}
+
+	req, streaming, err := s.parseRequest(r)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON")
+		return
+	}
+
+	s.mu.Lock()
+	s.requests = append(s.requests, req)
+	s.mu.Unlock()
+
+	resp := s.handler(req)
+
+	if resp.NetworkError {
+		hijackAndClose(w)
+		return
+	}
+
+	if resp.Error != nil {
+		writeOpenAIError(w, resp.Error.Status, "api_error", resp.Error.Message)
+		return
+	}
+
+	if streaming {
+		writeResponsesStreaming(w, req.Model, resp)
+	} else {
+		if resp.TruncateStream {
+			hijackAndClose(w)
+			return
+		}
+		writeResponsesJSON(w, req.Model, resp)
+	}
+}
+
+func writeResponsesJSON(w http.ResponseWriter, model string, resp Response) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var output []map[string]any
+	if resp.Content != "" {
+		output = append(output, map[string]any{
+			"type": "message",
+			"content": []map[string]any{
+				{"type": "output_text", "text": resp.Content},
+			},
+		})
+	}
+	for _, tc := range resp.ToolCalls {
+		output = append(output, map[string]any{
+			"type":      "function_call",
+			"name":      tc.Name,
+			"arguments": tc.Arguments,
+			"call_id":   tc.ID,
+		})
+	}
+
+	json.NewEncoder(w).Encode(map[string]any{
+		"id":     "resp_mock_001",
+		"object": "response",
+		"model":  model,
+		"output": output,
+		"usage": map[string]any{
+			"input_tokens":  resp.InputTokens,
+			"output_tokens": resp.OutputTokens,
+		},
+	})
+}
+
+func writeResponsesStreaming(w http.ResponseWriter, model string, resp Response) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	writeSSE := func(data string) {
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	// Build the full response object for response.completed
+	var output []map[string]any
+	if resp.Content != "" {
+		output = append(output, map[string]any{
+			"type": "message",
+			"content": []map[string]any{
+				{"type": "output_text", "text": resp.Content},
+			},
+		})
+	}
+
+	completedResp := map[string]any{
+		"id":     "resp_mock_stream_001",
+		"model":  model,
+		"output": output,
+		"usage": map[string]any{
+			"input_tokens":  resp.InputTokens,
+			"output_tokens": resp.OutputTokens,
+		},
+	}
+
+	writeSSE(fmt.Sprintf(`{"type":"response.created","response":{"id":"resp_mock_stream_001","model":"%s"}}`, model))
+	completedJSON, _ := json.Marshal(map[string]any{
+		"type":     "response.completed",
+		"response": completedResp,
+	})
+	writeSSE(string(completedJSON))
+	writeSSE("[DONE]")
+}

--- a/internal/mockllm/openai_test.go
+++ b/internal/mockllm/openai_test.go
@@ -1,0 +1,279 @@
+package mockllm
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestOpenAIServer_ChatCompletion_NonStreaming(t *testing.T) {
+	srv := NewOpenAIServer()
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	resp, err := http.Post(srv.URL()+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	if result["model"] != "gpt-4o-mini" {
+		t.Errorf("model = %v", result["model"])
+	}
+	choices := result["choices"].([]any)
+	if len(choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	choice := choices[0].(map[string]any)
+	msg := choice["message"].(map[string]any)
+	if msg["content"] == nil || msg["content"] == "" {
+		t.Error("expected non-empty content")
+	}
+
+	reqs := srv.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("captured %d requests, want 1", len(reqs))
+	}
+}
+
+func TestOpenAIServer_ChatCompletion_ToolCalls(t *testing.T) {
+	srv := NewOpenAIServer()
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"weather?"}],"stream":false,"tools":[{"type":"function","function":{"name":"get_weather"}}]}`
+	resp, err := http.Post(srv.URL()+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	choices := result["choices"].([]any)
+	choice := choices[0].(map[string]any)
+	if choice["finish_reason"] != "tool_calls" {
+		t.Errorf("finish_reason = %v, want tool_calls", choice["finish_reason"])
+	}
+	msg := choice["message"].(map[string]any)
+	toolCalls, ok := msg["tool_calls"].([]any)
+	if !ok || len(toolCalls) == 0 {
+		t.Fatal("expected tool_calls in message")
+	}
+}
+
+func TestOpenAIServer_ChatCompletion_Streaming(t *testing.T) {
+	srv := NewOpenAIServer()
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	resp, err := http.Post(srv.URL()+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("content-type = %q, want text/event-stream", ct)
+	}
+
+	data, _ := io.ReadAll(resp.Body)
+	sseBody := string(data)
+
+	if !strings.Contains(sseBody, "Hello") {
+		t.Error("expected 'Hello' in stream")
+	}
+	if !strings.Contains(sseBody, "[DONE]") {
+		t.Error("expected [DONE] sentinel")
+	}
+}
+
+func TestOpenAIServer_ChatCompletion_Streaming_ToolCalls(t *testing.T) {
+	srv := NewOpenAIServer()
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"weather?"}],"stream":true,"tools":[{"type":"function","function":{"name":"get_weather"}}]}`
+	resp, err := http.Post(srv.URL()+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	sseBody := string(data)
+
+	if !strings.Contains(sseBody, "get_weather") {
+		t.Error("expected tool name in stream")
+	}
+	if !strings.Contains(sseBody, "call_mock_1") {
+		t.Error("expected tool call ID in stream")
+	}
+}
+
+func TestOpenAIServer_Responses_NonStreaming(t *testing.T) {
+	srv := NewOpenAIServer()
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o","input":"What is Go?","stream":false}`
+	resp, err := http.Post(srv.URL()+"/v1/responses", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	if result["object"] != "response" {
+		t.Errorf("object = %v, want response", result["object"])
+	}
+	output := result["output"].([]any)
+	if len(output) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+}
+
+func TestOpenAIServer_Responses_Streaming(t *testing.T) {
+	srv := NewOpenAIServer()
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o","input":"What is Go?","stream":true}`
+	resp, err := http.Post(srv.URL()+"/v1/responses", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	sseBody := string(data)
+
+	if !strings.Contains(sseBody, "response.completed") {
+		t.Error("expected response.completed event")
+	}
+	if !strings.Contains(sseBody, "[DONE]") {
+		t.Error("expected [DONE]")
+	}
+}
+
+func TestOpenAIServer_InvalidAPIKey(t *testing.T) {
+	srv := NewOpenAIServer()
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-invalid-test")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestOpenAIServer_CustomHandler(t *testing.T) {
+	srv := NewOpenAIServer(WithHandler(ErrorHandler(429, "rate limited")))
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`
+	resp, err := http.Post(srv.URL()+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429", resp.StatusCode)
+	}
+}
+
+func TestOpenAIServer_NetworkError(t *testing.T) {
+	srv := NewOpenAIServer(WithHandler(NetworkErrorHandler()))
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`
+	resp, err := http.Post(srv.URL()+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		// Connection reset / EOF is the expected network error
+		return
+	}
+	defer resp.Body.Close()
+	_, err = io.ReadAll(resp.Body)
+	if err == nil {
+		t.Error("expected network error (connection reset or EOF)")
+	}
+}
+
+func TestOpenAIServer_TruncatedStream(t *testing.T) {
+	srv := NewOpenAIServer(WithHandler(TruncatedStreamHandler("partial")))
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	resp, err := http.Post(srv.URL()+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	sseBody := string(data)
+
+	if strings.Contains(sseBody, "[DONE]") {
+		t.Error("truncated stream should NOT contain [DONE]")
+	}
+}
+
+func TestOpenAIServer_SameHandlerBothProviders(t *testing.T) {
+	// Verify the same Handler produces correct responses from both servers
+	h := StaticHandler("shared response")
+
+	anthropic := NewAnthropicServer(WithHandler(h))
+	defer anthropic.Close()
+	openai := NewOpenAIServer(WithHandler(h))
+	defer openai.Close()
+
+	// Anthropic
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`
+	resp, err := http.Post(anthropic.URL()+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("anthropic POST: %v", err)
+	}
+	var aResult map[string]any
+	json.NewDecoder(resp.Body).Decode(&aResult)
+	resp.Body.Close()
+
+	aContent := aResult["content"].([]any)
+	aBlock := aContent[0].(map[string]any)
+	if aBlock["text"] != "shared response" {
+		t.Errorf("anthropic text = %v", aBlock["text"])
+	}
+
+	// OpenAI
+	body = `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`
+	resp, err = http.Post(openai.URL()+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("openai POST: %v", err)
+	}
+	var oResult map[string]any
+	json.NewDecoder(resp.Body).Decode(&oResult)
+	resp.Body.Close()
+
+	choices := oResult["choices"].([]any)
+	msg := choices[0].(map[string]any)["message"].(map[string]any)
+	if msg["content"] != "shared response" {
+		t.Errorf("openai content = %v", msg["content"])
+	}
+}

--- a/internal/mockllm/sdk_test.go
+++ b/internal/mockllm/sdk_test.go
@@ -1,0 +1,219 @@
+package mockllm_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/langchain-ai/langsmith-go/internal/mockllm"
+)
+
+func uvAvailable(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("uv"); err != nil {
+		t.Skip("uv not found in PATH")
+	}
+}
+
+func testdataDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "testdata")
+}
+
+func runSDKTest(t *testing.T, script string) map[string]any {
+	t.Helper()
+	uvAvailable(t)
+
+	srv := mockllm.NewCombinedServer(mockllm.WithHandler(mockllm.DefaultHandler()))
+	defer srv.Close()
+
+	scriptPath := filepath.Join(testdataDir(t), script)
+	cmd := exec.Command("uv", "run", "--quiet", scriptPath)
+	cmd.Env = append(os.Environ(),
+		"ELIZA_BASE_URL="+srv.URL(),
+		"OPENAI_API_KEY=fake",
+		"ANTHROPIC_API_KEY=fake",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("uv run %s failed: %v\nstderr:\n%s\nstdout:\n%s", script, err, stderr.String(), stdout.String())
+	}
+	out := stdout.Bytes()
+
+	var results map[string]any
+	if err := json.Unmarshal(out, &results); err != nil {
+		t.Fatalf("failed to parse JSON from %s: %v\nraw:\n%s", script, err, out)
+	}
+	return results
+}
+
+func TestSDK_OpenAI(t *testing.T) {
+	r := runSDKTest(t, "test_openai_sdk.py")
+
+	if v, _ := r["nonstreaming_content"].(string); v == "" {
+		t.Error("expected non-empty nonstreaming content")
+	}
+	if v, _ := r["nonstreaming_model"].(string); v != "gpt-4o" {
+		t.Errorf("model = %q, want gpt-4o", v)
+	}
+	if v, _ := r["nonstreaming_has_usage"].(bool); !v {
+		t.Error("expected usage in response")
+	}
+	if v, _ := r["streaming_text"].(string); v == "" {
+		t.Error("expected non-empty streaming text")
+	}
+	if v, _ := r["streaming_chunk_count"].(float64); v == 0 {
+		t.Error("expected streaming chunks")
+	}
+	if v, _ := r["tool_finish_reason"].(string); v != "tool_calls" {
+		t.Errorf("tool finish_reason = %q, want tool_calls", v)
+	}
+	if v, _ := r["tool_call_name"].(string); v == "" {
+		t.Error("expected tool call name")
+	}
+	if v, _ := r["error_raised"].(bool); !v {
+		t.Error("expected error for invalid API key")
+	}
+}
+
+func TestSDK_Anthropic(t *testing.T) {
+	r := runSDKTest(t, "test_anthropic_sdk.py")
+
+	if v, _ := r["nonstreaming_content"].(string); v == "" {
+		t.Error("expected non-empty nonstreaming content")
+	}
+	if v, _ := r["nonstreaming_model"].(string); v != "claude-sonnet-4-20250514" {
+		t.Errorf("model = %q", v)
+	}
+	if v, _ := r["nonstreaming_has_usage"].(bool); !v {
+		t.Error("expected usage")
+	}
+	if v, _ := r["nonstreaming_stop_reason"].(string); v != "end_turn" {
+		t.Errorf("stop_reason = %q, want end_turn", v)
+	}
+	if v, _ := r["streaming_text"].(string); v == "" {
+		t.Error("expected non-empty streaming text")
+	}
+	if v, _ := r["streaming_chunk_count"].(float64); v == 0 {
+		t.Error("expected streaming chunks")
+	}
+	if v, _ := r["tool_stop_reason"].(string); v != "tool_use" {
+		t.Errorf("tool stop_reason = %q, want tool_use", v)
+	}
+	if v, _ := r["tool_call_name"].(string); v == "" {
+		t.Error("expected tool call name")
+	}
+	if v, _ := r["error_raised"].(bool); !v {
+		t.Error("expected error for invalid API key")
+	}
+}
+
+func TestSDK_LangChain(t *testing.T) {
+	r := runSDKTest(t, "test_langchain.py")
+
+	if v, _ := r["openai_invoke"].(string); v == "" {
+		t.Error("expected non-empty openai invoke content")
+	}
+	if v, _ := r["openai_stream_chunks"].(float64); v == 0 {
+		t.Error("expected openai stream chunks")
+	}
+	if v, _ := r["openai_stream_text"].(string); v == "" {
+		t.Error("expected non-empty openai stream text")
+	}
+	if v, _ := r["anthropic_invoke"].(string); v == "" {
+		t.Error("expected non-empty anthropic invoke content")
+	}
+	if v, _ := r["anthropic_stream_chunks"].(float64); v == 0 {
+		t.Error("expected anthropic stream chunks")
+	}
+	if v, _ := r["anthropic_stream_text"].(string); v == "" {
+		t.Error("expected non-empty anthropic stream text")
+	}
+}
+
+func TestSDK_LangChain_Advanced(t *testing.T) {
+	r := runSDKTest(t, "test_langchain_advanced.py")
+
+	if v, _ := r["openai_multiturn_nonempty"].(bool); !v {
+		t.Error("expected non-empty openai multi-turn response")
+	}
+	if v, _ := r["anthropic_system_nonempty"].(bool); !v {
+		t.Error("expected non-empty anthropic system message response")
+	}
+	if v, _ := r["openai_tool_calls"].(float64); v == 0 {
+		t.Error("expected openai tool calls")
+	}
+	if v, _ := r["openai_tool_name"].(string); v == "" {
+		t.Error("expected openai tool call name")
+	}
+	if v, _ := r["anthropic_tool_calls"].(float64); v == 0 {
+		t.Error("expected anthropic tool calls")
+	}
+	if v, _ := r["anthropic_tool_name"].(string); v == "" {
+		t.Error("expected anthropic tool call name")
+	}
+	if v, _ := r["openai_system_stream_chunks"].(float64); v == 0 {
+		t.Error("expected openai system stream chunks")
+	}
+	if v, _ := r["anthropic_multiturn_stream_chunks"].(float64); v == 0 {
+		t.Error("expected anthropic multi-turn stream chunks")
+	}
+}
+
+func npxAvailable(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("npx"); err != nil {
+		t.Skip("npx not found in PATH")
+	}
+}
+
+func TestSDK_AISDK(t *testing.T) {
+	npxAvailable(t)
+	uvAvailable(t) // reuse server setup
+
+	srv := mockllm.NewCombinedServer(mockllm.WithHandler(mockllm.DefaultHandler()))
+	defer srv.Close()
+
+	// Install deps and run
+	testdata := testdataDir(t)
+	installCmd := exec.Command("pnpm", "install", "--silent")
+	installCmd.Dir = testdata
+	if out, err := installCmd.CombinedOutput(); err != nil {
+		t.Fatalf("pnpm install failed: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command("node", filepath.Join(testdata, "test_ai_sdk.mjs"))
+	cmd.Dir = testdata
+	cmd.Env = append(os.Environ(),
+		"ELIZA_BASE_URL="+srv.URL(),
+		"OPENAI_API_KEY=fake",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("node test_ai_sdk.mjs failed: %v\nstderr:\n%s\nstdout:\n%s", err, stderr.String(), stdout.String())
+	}
+
+	var r map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("failed to parse JSON: %v\nraw:\n%s", err, stdout.String())
+	}
+
+	if v, _ := r["generate_text"].(string); v == "" {
+		t.Error("expected non-empty generateText result")
+	}
+	if v, _ := r["stream_has_text"].(bool); !v {
+		t.Error("expected non-empty streamText result")
+	}
+	if v, _ := r["tool_calls_count"].(float64); v == 0 {
+		t.Error("expected tool calls from AI SDK")
+	}
+}

--- a/internal/mockllm/testdata/.gitignore
+++ b/internal/mockllm/testdata/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+pnpm-lock.yaml

--- a/internal/mockllm/testdata/package.json
+++ b/internal/mockllm/testdata/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@ai-sdk/openai": "^1.0",
+    "ai": "^4.0",
+    "zod": "^3.22"
+  }
+}

--- a/internal/mockllm/testdata/test_ai_sdk.mjs
+++ b/internal/mockllm/testdata/test_ai_sdk.mjs
@@ -1,0 +1,53 @@
+/**
+ * Test Eliza mock server with the Vercel AI SDK (@ai-sdk/openai).
+ *
+ * Run via: npx --yes tsx test_ai_sdk.mjs
+ * Requires: ELIZA_BASE_URL env var
+ */
+
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText, streamText, tool } from "ai";
+import { z } from "zod";
+
+const baseURL = process.env.ELIZA_BASE_URL + "/v1";
+const provider = createOpenAI({ baseURL, apiKey: "fake" });
+
+const results = {};
+
+// --- generateText (non-streaming) ---
+const gen = await generateText({
+  model: provider("gpt-4o"),
+  prompt: "hello",
+});
+results.generate_text = gen.text;
+results.generate_has_usage = gen.usage != null;
+
+// --- streamText ---
+const stream = streamText({
+  model: provider("gpt-4o"),
+  prompt: "I am sad",
+});
+let streamedText = "";
+for await (const chunk of stream.textStream) {
+  streamedText += chunk;
+}
+results.stream_text = streamedText;
+results.stream_has_text = streamedText.length > 0;
+
+// --- tool calls ---
+const toolGen = await generateText({
+  model: provider("gpt-4o"),
+  prompt: "weather?",
+  tools: {
+    get_weather: tool({
+      description: "Get weather",
+      parameters: z.object({ location: z.string().optional() }),
+      execute: async () => ({ temp: 20 }),
+    }),
+  },
+});
+results.tool_text = toolGen.text;
+results.tool_calls_count = toolGen.toolCalls?.length ?? 0;
+results.tool_call_name = toolGen.toolCalls?.[0]?.toolName ?? "";
+
+console.log(JSON.stringify(results));

--- a/internal/mockllm/testdata/test_anthropic_sdk.py
+++ b/internal/mockllm/testdata/test_anthropic_sdk.py
@@ -1,0 +1,68 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["anthropic>=0.30"]
+# ///
+"""Test Eliza mock server with the Anthropic Python SDK."""
+
+import json
+import os
+import sys
+
+import anthropic
+
+base_url = os.environ["ELIZA_BASE_URL"]
+client = anthropic.Anthropic(base_url=base_url, api_key="fake")
+
+results = {}
+
+# --- Non-streaming ---
+msg = client.messages.create(
+    model="claude-sonnet-4-20250514",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "hello"}],
+)
+results["nonstreaming_content"] = msg.content[0].text
+results["nonstreaming_model"] = msg.model
+results["nonstreaming_has_usage"] = msg.usage is not None
+results["nonstreaming_stop_reason"] = msg.stop_reason
+
+# --- Streaming ---
+chunks = []
+with client.messages.stream(
+    model="claude-sonnet-4-20250514",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "I am sad"}],
+) as stream:
+    for text in stream.text_stream:
+        chunks.append(text)
+results["streaming_text"] = "".join(chunks)
+results["streaming_chunk_count"] = len(chunks)
+
+# --- Tool use ---
+msg = client.messages.create(
+    model="claude-sonnet-4-20250514",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "weather?"}],
+    tools=[{
+        "name": "get_weather",
+        "description": "Get weather",
+        "input_schema": {"type": "object", "properties": {}},
+    }],
+)
+results["tool_stop_reason"] = msg.stop_reason
+tool_blocks = [b for b in msg.content if b.type == "tool_use"]
+results["tool_call_name"] = tool_blocks[0].name if tool_blocks else ""
+
+# --- Error ---
+try:
+    bad = anthropic.Anthropic(base_url=base_url, api_key="sk-ant-invalid-test")
+    bad.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=10,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    results["error_raised"] = False
+except anthropic.AuthenticationError:
+    results["error_raised"] = True
+
+json.dump(results, sys.stdout)

--- a/internal/mockllm/testdata/test_langchain.py
+++ b/internal/mockllm/testdata/test_langchain.py
@@ -1,0 +1,45 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["langchain-openai>=0.3", "langchain-anthropic>=0.3"]
+# ///
+"""Test Eliza mock server with LangChain ChatModels."""
+
+import json
+import os
+import sys
+
+base_url = os.environ["ELIZA_BASE_URL"]
+
+results = {}
+
+# --- ChatOpenAI invoke ---
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="gpt-4o", base_url=base_url + "/v1", api_key="fake")
+resp = llm.invoke("hello")
+results["openai_invoke"] = resp.content
+
+# --- ChatOpenAI stream ---
+chunks = list(llm.stream("I am feeling anxious"))
+results["openai_stream_chunks"] = len(chunks)
+full_text = "".join(c.content for c in chunks)
+results["openai_stream_text"] = full_text
+
+# --- ChatAnthropic invoke ---
+from langchain_anthropic import ChatAnthropic
+
+llm2 = ChatAnthropic(
+    model="claude-sonnet-4-20250514",
+    base_url=base_url,
+    api_key="fake",
+)
+resp2 = llm2.invoke("hello")
+results["anthropic_invoke"] = resp2.content
+
+# --- ChatAnthropic stream ---
+chunks2 = list(llm2.stream("I need help"))
+results["anthropic_stream_chunks"] = len(chunks2)
+full_text2 = "".join(c.content for c in chunks2)
+results["anthropic_stream_text"] = full_text2
+
+json.dump(results, sys.stdout)

--- a/internal/mockllm/testdata/test_langchain_advanced.py
+++ b/internal/mockllm/testdata/test_langchain_advanced.py
@@ -1,0 +1,93 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["langchain-openai>=0.3", "langchain-anthropic>=0.3", "langchain-core>=0.3"]
+# ///
+"""Advanced LangChain tests: multi-turn, tool calling, system messages."""
+
+import json
+import os
+import sys
+
+from langchain_core.messages import HumanMessage, SystemMessage, AIMessage
+from langchain_core.tools import tool
+
+base_url = os.environ["ELIZA_BASE_URL"]
+results = {}
+
+# --- OpenAI multi-turn ---
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="gpt-4o", base_url=base_url + "/v1", api_key="fake")
+
+resp = llm.invoke([
+    SystemMessage(content="You are helpful."),
+    HumanMessage(content="What is 2+2?"),
+    AIMessage(content="4"),
+    HumanMessage(content="And times 3?"),
+])
+results["openai_multiturn"] = resp.content
+results["openai_multiturn_nonempty"] = len(resp.content) > 0
+
+# --- Anthropic multi-turn ---
+from langchain_anthropic import ChatAnthropic
+
+llm2 = ChatAnthropic(
+    model="claude-sonnet-4-20250514",
+    base_url=base_url,
+    api_key="fake",
+)
+
+resp2 = llm2.invoke([
+    SystemMessage(content="You are helpful."),
+    HumanMessage(content="hello"),
+])
+results["anthropic_system"] = resp2.content
+results["anthropic_system_nonempty"] = len(resp2.content) > 0
+
+# --- OpenAI with tools ---
+@tool
+def get_weather(location: str) -> str:
+    """Get the weather for a location."""
+    return f"Sunny in {location}"
+
+llm_tools = ChatOpenAI(model="gpt-4o", base_url=base_url + "/v1", api_key="fake")
+llm_with_tools = llm_tools.bind_tools([get_weather])
+resp3 = llm_with_tools.invoke("What is the weather in Paris?")
+results["openai_tool_calls"] = len(resp3.tool_calls) if hasattr(resp3, "tool_calls") else 0
+if resp3.tool_calls:
+    results["openai_tool_name"] = resp3.tool_calls[0]["name"]
+else:
+    results["openai_tool_name"] = ""
+
+# --- Anthropic with tools ---
+llm2_tools = ChatAnthropic(
+    model="claude-sonnet-4-20250514",
+    base_url=base_url,
+    api_key="fake",
+)
+llm2_with_tools = llm2_tools.bind_tools([get_weather])
+resp4 = llm2_with_tools.invoke("What is the weather in Paris?")
+results["anthropic_tool_calls"] = len(resp4.tool_calls) if hasattr(resp4, "tool_calls") else 0
+if resp4.tool_calls:
+    results["anthropic_tool_name"] = resp4.tool_calls[0]["name"]
+else:
+    results["anthropic_tool_name"] = ""
+
+# --- OpenAI streaming with system message ---
+chunks = list(llm.stream([
+    SystemMessage(content="Be concise."),
+    HumanMessage(content="hello"),
+]))
+results["openai_system_stream_chunks"] = len(chunks)
+results["openai_system_stream_text"] = "".join(c.content for c in chunks)
+
+# --- Anthropic streaming multi-turn ---
+chunks2 = list(llm2.stream([
+    HumanMessage(content="My name is Alice"),
+    AIMessage(content="Hello Alice"),
+    HumanMessage(content="What is my name?"),
+]))
+results["anthropic_multiturn_stream_chunks"] = len(chunks2)
+results["anthropic_multiturn_stream_text"] = "".join(c.content for c in chunks2)
+
+json.dump(results, sys.stdout)

--- a/internal/mockllm/testdata/test_openai_sdk.py
+++ b/internal/mockllm/testdata/test_openai_sdk.py
@@ -1,0 +1,64 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["openai>=1.0"]
+# ///
+"""Test Eliza mock server with the OpenAI Python SDK."""
+
+import json
+import os
+import sys
+
+from openai import OpenAI
+
+base_url = os.environ["ELIZA_BASE_URL"] + "/v1"
+client = OpenAI(base_url=base_url, api_key="fake")
+
+results = {}
+
+# --- Non-streaming ---
+resp = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "hello"}],
+)
+results["nonstreaming_content"] = resp.choices[0].message.content
+results["nonstreaming_model"] = resp.model
+results["nonstreaming_has_usage"] = resp.usage is not None
+
+# --- Streaming ---
+stream = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "I am sad"}],
+    stream=True,
+)
+chunks = []
+for chunk in stream:
+    if chunk.choices and chunk.choices[0].delta.content:
+        chunks.append(chunk.choices[0].delta.content)
+results["streaming_text"] = "".join(chunks)
+results["streaming_chunk_count"] = len(chunks)
+
+# --- Tool calls ---
+resp = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "weather?"}],
+    tools=[{
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {}},
+    }],
+)
+choice = resp.choices[0]
+results["tool_finish_reason"] = choice.finish_reason
+results["tool_call_name"] = choice.message.tool_calls[0].function.name if choice.message.tool_calls else ""
+
+# --- Error ---
+try:
+    bad = OpenAI(base_url=base_url, api_key="sk-invalid-test")
+    bad.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    results["error_raised"] = False
+except Exception:
+    results["error_raised"] = True
+
+json.dump(results, sys.stdout)

--- a/internal/mockllm/tracing_test.go
+++ b/internal/mockllm/tracing_test.go
@@ -1,0 +1,392 @@
+package mockllm_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/langchain-ai/langsmith-go/instrumentation/traceanthropic"
+	"github.com/langchain-ai/langsmith-go/instrumentation/traceopenai"
+	"github.com/langchain-ai/langsmith-go/internal/mockllm"
+)
+
+func newTestTP() (*sdktrace.TracerProvider, *tracetest.InMemoryExporter) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	return tp, exporter
+}
+
+func getSpanAttr(spans []sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, s := range spans {
+		for _, attr := range s.Attributes() {
+			if string(attr.Key) == key {
+				return attr.Value.Emit(), true
+			}
+		}
+	}
+	return "", false
+}
+
+func getSpanAttrInt(spans []sdktrace.ReadOnlySpan, key string) (int64, bool) {
+	for _, s := range spans {
+		for _, attr := range s.Attributes() {
+			if string(attr.Key) == key {
+				return attr.Value.AsInt64(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// --- Anthropic through traceanthropic ---
+
+func TestTracing_Anthropic_NonStreaming(t *testing.T) {
+	srv := mockllm.NewAnthropicServer()
+	defer srv.Close()
+
+	tp, exporter := newTestTP()
+	client := traceanthropic.Client(
+		traceanthropic.WithTracerProvider(tp),
+		traceanthropic.WithTraceAllHosts(),
+	)
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+
+	roSpans := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i := range spans {
+		roSpans[i] = spans[i].Snapshot()
+	}
+
+	if len(roSpans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+
+	if v, ok := getSpanAttr(roSpans, "gen_ai.system"); !ok || v != "anthropic" {
+		t.Errorf("gen_ai.system = %q, want anthropic", v)
+	}
+	if v, ok := getSpanAttr(roSpans, "gen_ai.request.model"); !ok || v != "claude-sonnet-4-20250514" {
+		t.Errorf("gen_ai.request.model = %q", v)
+	}
+	if _, ok := getSpanAttr(roSpans, "gen_ai.prompt"); !ok {
+		t.Error("expected gen_ai.prompt")
+	}
+	if _, ok := getSpanAttr(roSpans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion")
+	}
+	if v, ok := getSpanAttrInt(roSpans, "gen_ai.usage.input_tokens"); !ok || v == 0 {
+		t.Errorf("gen_ai.usage.input_tokens = %d", v)
+	}
+	if v, ok := getSpanAttrInt(roSpans, "gen_ai.usage.output_tokens"); !ok || v == 0 {
+		t.Errorf("gen_ai.usage.output_tokens = %d", v)
+	}
+}
+
+func TestTracing_Anthropic_Streaming(t *testing.T) {
+	srv := mockllm.NewAnthropicServer()
+	defer srv.Close()
+
+	tp, exporter := newTestTP()
+	client := traceanthropic.Client(
+		traceanthropic.WithTracerProvider(tp),
+		traceanthropic.WithTraceAllHosts(),
+	)
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"stream":true}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+
+	roSpans := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i := range spans {
+		roSpans[i] = spans[i].Snapshot()
+	}
+
+	if len(roSpans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+
+	if v, ok := getSpanAttr(roSpans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion from streaming")
+	} else if !strings.Contains(v, "Hello") {
+		t.Errorf("completion should contain 'Hello': %s", v)
+	}
+	if v, ok := getSpanAttr(roSpans, "gen_ai.response.model"); !ok || !strings.Contains(v, "claude") {
+		t.Errorf("gen_ai.response.model = %q", v)
+	}
+}
+
+func TestTracing_Anthropic_ToolUse(t *testing.T) {
+	srv := mockllm.NewAnthropicServer()
+	defer srv.Close()
+
+	tp, exporter := newTestTP()
+	client := traceanthropic.Client(
+		traceanthropic.WithTracerProvider(tp),
+		traceanthropic.WithTraceAllHosts(),
+	)
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"weather?"}],"max_tokens":100,"tools":[{"name":"get_weather"}]}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+
+	roSpans := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i := range spans {
+		roSpans[i] = spans[i].Snapshot()
+	}
+
+	if v, ok := getSpanAttr(roSpans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion")
+	} else if !strings.Contains(v, "tool_use") {
+		t.Errorf("completion should contain tool_use: %s", v)
+	}
+}
+
+func TestTracing_Anthropic_Error(t *testing.T) {
+	srv := mockllm.NewAnthropicServer()
+	defer srv.Close()
+
+	tp, exporter := newTestTP()
+	client := traceanthropic.Client(
+		traceanthropic.WithTracerProvider(tp),
+		traceanthropic.WithTraceAllHosts(),
+	)
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", "sk-ant-invalid-test")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+
+	roSpans := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i := range spans {
+		roSpans[i] = spans[i].Snapshot()
+	}
+
+	if len(roSpans) == 0 {
+		t.Fatal("expected span even on error")
+	}
+
+	// Check span recorded an error event or has error status
+	foundError := false
+	for _, s := range roSpans {
+		if s.Status().Code == 2 { // codes.Error
+			foundError = true
+			break
+		}
+		for _, ev := range s.Events() {
+			if ev.Name == "exception" {
+				foundError = true
+				break
+			}
+		}
+	}
+	if !foundError {
+		for _, s := range roSpans {
+			t.Logf("span %q: status=%v events=%v", s.Name(), s.Status(), s.Events())
+		}
+		t.Error("expected at least one span with error status or error event")
+	}
+}
+
+// --- OpenAI through traceopenai ---
+
+func TestTracing_OpenAI_NonStreaming(t *testing.T) {
+	srv := mockllm.NewOpenAIServer()
+	defer srv.Close()
+
+	tp, exporter := newTestTP()
+	client := traceopenai.Client(traceopenai.WithTracerProvider(tp))
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+
+	roSpans := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i := range spans {
+		roSpans[i] = spans[i].Snapshot()
+	}
+
+	if len(roSpans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+
+	if v, ok := getSpanAttr(roSpans, "gen_ai.system"); !ok || v != "openai" {
+		t.Errorf("gen_ai.system = %q, want openai", v)
+	}
+	if v, ok := getSpanAttr(roSpans, "gen_ai.request.model"); !ok || v != "gpt-4o-mini" {
+		t.Errorf("gen_ai.request.model = %q", v)
+	}
+	if _, ok := getSpanAttr(roSpans, "gen_ai.prompt"); !ok {
+		t.Error("expected gen_ai.prompt")
+	}
+	if _, ok := getSpanAttr(roSpans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion")
+	}
+	if v, ok := getSpanAttrInt(roSpans, "gen_ai.usage.input_tokens"); !ok || v == 0 {
+		t.Errorf("gen_ai.usage.input_tokens = %d", v)
+	}
+}
+
+func TestTracing_OpenAI_Streaming(t *testing.T) {
+	srv := mockllm.NewOpenAIServer()
+	defer srv.Close()
+
+	tp, exporter := newTestTP()
+	client := traceopenai.Client(traceopenai.WithTracerProvider(tp))
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/chat/completions", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+
+	roSpans := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i := range spans {
+		roSpans[i] = spans[i].Snapshot()
+	}
+
+	if len(roSpans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+
+	if v, ok := getSpanAttr(roSpans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion from streaming")
+	} else if !strings.Contains(v, "Hello") {
+		t.Errorf("completion should contain 'Hello': %s", v)
+	}
+}
+
+func TestTracing_OpenAI_ToolCalls(t *testing.T) {
+	srv := mockllm.NewOpenAIServer()
+	defer srv.Close()
+
+	tp, exporter := newTestTP()
+	client := traceopenai.Client(traceopenai.WithTracerProvider(tp))
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"weather?"}],"tools":[{"type":"function","function":{"name":"get_weather"}}]}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+
+	roSpans := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i := range spans {
+		roSpans[i] = spans[i].Snapshot()
+	}
+
+	if v, ok := getSpanAttr(roSpans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion")
+	} else if !strings.Contains(v, "get_weather") {
+		t.Errorf("completion should contain get_weather: %s", v)
+	}
+}
+
+func TestTracing_OpenAI_Responses(t *testing.T) {
+	srv := mockllm.NewOpenAIServer()
+	defer srv.Close()
+
+	tp, exporter := newTestTP()
+	client := traceopenai.Client(traceopenai.WithTracerProvider(tp))
+
+	body := `{"model":"gpt-4o","input":"What is Go?"}`
+	req, _ := http.NewRequest("POST", srv.URL()+"/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+
+	roSpans := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i := range spans {
+		roSpans[i] = spans[i].Snapshot()
+	}
+
+	if len(roSpans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+
+	if v, ok := getSpanAttr(roSpans, "gen_ai.operation.name"); !ok || v != "responses" {
+		t.Errorf("gen_ai.operation.name = %q, want responses", v)
+	}
+	if _, ok := getSpanAttr(roSpans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion from responses API")
+	}
+}

--- a/internal/mockllm/util.go
+++ b/internal/mockllm/util.go
@@ -1,0 +1,19 @@
+package mockllm
+
+import "net/http"
+
+// hijackAndClose abruptly closes the underlying TCP connection, simulating
+// a network-level failure. If the ResponseWriter doesn't support hijacking
+// (shouldn't happen with httptest.Server), it falls back to closing the
+// response with no body.
+func hijackAndClose(w http.ResponseWriter) {
+	if hj, ok := w.(http.Hijacker); ok {
+		conn, _, err := hj.Hijack()
+		if err == nil {
+			conn.Close()
+			return
+		}
+	}
+	// Fallback: write nothing and let the server close naturally
+	w.WriteHeader(http.StatusBadGateway)
+}


### PR DESCRIPTION
## Summary

- New `internal/mockllm` package with mock Anthropic and OpenAI API servers backed by a generic `Handler func(Request) Response` callback
- `ElizaHandler` — classic ELIZA psychotherapist with special commands (fail simulation, tool calls, system prompt leak, name tracking, streaming jitter)
- `CombinedServer` — serves both providers on one port with zstd/gzip decompression and Codex-compatible Responses API SSE
- `cmd/eliza` binary — standalone server for manual testing
- `WithTraceAllHosts()` option on `traceanthropic` for proxy/mock use

## Stack

1. **This PR** — mock servers + Eliza
2. feat/integration-mock — run existing integration tests against mock
3. feat/tracing-proxy — tracing reverse proxy

## Test plan

- [x] 47+ unit tests in `internal/mockllm/`
- [x] 5 SDK compatibility tests (OpenAI, Anthropic, LangChain, AI SDK via uv/pnpm)
- [x] 8 OTel tracing tests through mock servers
- [x] Codex CLI integration test