### PR TITLE
feat: run tracing integration tests against Eliza mock

### DIFF
--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (
@@ -14,9 +12,40 @@ import (
 	"time"
 
 	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/internal/mockllm"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+var (
+	sharedMockServer     *mockllm.CombinedServer
+	sharedMockServerOnce sync.Once
+)
+
+// getSharedMockServer returns a shared CombinedServer for all tests.
+// Started once, lives for the test process lifetime.
+func getSharedMockServer() *mockllm.CombinedServer {
+	sharedMockServerOnce.Do(func() {
+		sharedMockServer = mockllm.NewCombinedServer(mockllm.WithHandler(mockllm.DefaultHandler()))
+	})
+	return sharedMockServer
+}
+
+// mockBaseURL returns the mock server URL if no real API key is set for the
+// given provider. Returns ("", false) when real keys are available.
+func mockBaseURL(provider string) (string, bool) {
+	switch provider {
+	case "anthropic":
+		if os.Getenv("ANTHROPIC_API_KEY") != "" {
+			return "", false
+		}
+	case "openai":
+		if os.Getenv("OPENAI_API_KEY") != "" {
+			return "", false
+		}
+	}
+	return getSharedMockServer().URL(), true
+}
 
 var (
 	sharedIntegrationProject     string

--- a/integration/traceanthropic_test.go
+++ b/integration/traceanthropic_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (
@@ -37,13 +35,20 @@ const (
 func newAnthropicClient(t *testing.T, tp *sdktrace.TracerProvider) anthropic.Client {
 	t.Helper()
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
-		t.Skip("ANTHROPIC_API_KEY not set")
+	opts := []traceanthropic.Option{traceanthropic.WithTracerProvider(tp)}
+
+	var clientOpts []option.RequestOption
+	if mockURL, ok := mockBaseURL("anthropic"); ok {
+		apiKey = "fake"
+		clientOpts = append(clientOpts, option.WithBaseURL(mockURL))
+		opts = append(opts, traceanthropic.WithTraceAllHosts())
 	}
-	return anthropic.NewClient(
+
+	clientOpts = append(clientOpts,
 		option.WithAPIKey(apiKey),
-		option.WithHTTPClient(traceanthropic.Client(traceanthropic.WithTracerProvider(tp))),
+		option.WithHTTPClient(traceanthropic.Client(opts...)),
 	)
+	return anthropic.NewClient(clientOpts...)
 }
 
 // --- Basic Non-Streaming ---

--- a/integration/traceopenai_test.go
+++ b/integration/traceopenai_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (
@@ -34,10 +32,15 @@ const (
 func newOpenAIClient(t *testing.T, tp *sdktrace.TracerProvider) *openai.Client {
 	t.Helper()
 	apiKey := os.Getenv("OPENAI_API_KEY")
-	if apiKey == "" {
-		t.Skip("OPENAI_API_KEY not set")
+	mockURL, usingMock := mockBaseURL("openai")
+	if usingMock {
+		apiKey = "fake"
 	}
 	cfg := openai.DefaultConfig(apiKey)
+	if usingMock {
+		cfg.BaseURL = mockURL + "/v1"
+	}
+
 	cfg.HTTPClient = traceopenai.Client(traceopenai.WithTracerProvider(tp))
 	return openai.NewClientWithConfig(cfg)
 }


### PR DESCRIPTION
## Summary

- Remove `//go:build integration` tag from tracing test files
- Add automatic fallback to `mockllm.CombinedServer` when `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` are not set
- All 21 existing tracing tests now run without API keys in <1s
- Same tests still work against real APIs when keys are provided

## Stack

1. feat/mock-servers — mock servers + Eliza
2. **This PR** — run existing integration tests against mock
3. feat/tracing-proxy — tracing reverse proxy

## Test plan

- [x] 21 tracing tests pass against Eliza mock (no API keys)
- [x] Tests still pass with real API keys (verified manually)