### PR TITLE
feat: add LangSmith tracing reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 codegen.log
 Brewfile.lock.json
 .idea/
+.env

--- a/cmd/langsmith-proxy/main.go
+++ b/cmd/langsmith-proxy/main.go
@@ -1,0 +1,74 @@
+// Command langsmith-proxy starts a reverse proxy that adds LangSmith tracing
+// to Anthropic and OpenAI API calls.
+//
+// Usage:
+//
+//	go run ./cmd/langsmith-proxy [--addr :8090] [--anthropic-upstream URL] [--openai-upstream URL]
+//
+// Environment:
+//
+//	LANGSMITH_API_KEY   — LangSmith API key (required for real tracing)
+//	LANGSMITH_PROJECT   — LangSmith project name (default: "default")
+//	LANGSMITH_ENDPOINT  — LangSmith endpoint (default: api.smith.langchain.com)
+//
+// Then point any SDK at the proxy:
+//
+//	export ANTHROPIC_BASE_URL=http://localhost:8090
+//	export OPENAI_BASE_URL=http://localhost:8090/v1
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+
+	"github.com/langchain-ai/langsmith-go/instrumentation/proxy"
+)
+
+func main() {
+	addr := flag.String("addr", ":8090", "listen address")
+	anthropicUpstream := flag.String("anthropic-upstream", "", "Anthropic upstream URL (default: https://api.anthropic.com)")
+	openaiUpstream := flag.String("openai-upstream", "", "OpenAI upstream URL (default: https://api.openai.com)")
+	flag.Parse()
+
+	p, err := proxy.New(proxy.Config{
+		AnthropicUpstream: *anthropicUpstream,
+		OpenAIUpstream:    *openaiUpstream,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create proxy: %v", err)
+	}
+
+	aUp := *anthropicUpstream
+	if aUp == "" {
+		aUp = "https://api.anthropic.com"
+	}
+	oUp := *openaiUpstream
+	if oUp == "" {
+		oUp = "https://api.openai.com"
+	}
+
+	log.Printf("LangSmith tracing proxy listening on %s", *addr)
+	log.Printf("  Anthropic: /v1/messages          -> %s", aUp)
+	log.Printf("  OpenAI:    /v1/chat/completions  -> %s", oUp)
+	log.Printf("  OpenAI:    /v1/responses         -> %s", oUp)
+	log.Printf("  Passthru:  /v1/models            -> %s", oUp)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	server := &http.Server{Addr: *addr, Handler: p}
+	go func() {
+		<-ctx.Done()
+		log.Println("Shutting down...")
+		p.Shutdown(context.Background())
+		server.Shutdown(context.Background())
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		log.Fatalf("Server error: %v", err)
+	}
+}

--- a/instrumentation/proxy/e2e_test.go
+++ b/instrumentation/proxy/e2e_test.go
@@ -1,0 +1,161 @@
+package proxy_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/langchain-ai/langsmith-go/instrumentation/proxy"
+	"github.com/langchain-ai/langsmith-go/internal/mockllm"
+)
+
+// TestE2E_ElizaUpstream tests the full proxy stack: real HTTP client →
+// proxy → Eliza mock upstream, verifying the response passes through
+// correctly for all supported endpoints.
+func TestE2E_ElizaUpstream(t *testing.T) {
+	upstream := mockllm.NewCombinedServer(mockllm.WithHandler(mockllm.ElizaHandler()))
+	defer upstream.Close()
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer tp.Shutdown(context.Background())
+
+	p, err := proxy.New(proxy.Config{
+		AnthropicUpstream: upstream.URL(),
+		OpenAIUpstream:    upstream.URL(),
+		TracerProvider:    tp,
+	})
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	proxyServer := httptest.NewServer(p)
+	defer proxyServer.Close()
+
+	t.Run("OpenAI_ChatCompletions", func(t *testing.T) {
+		resp, err := http.Post(proxyServer.URL+"/v1/chat/completions", "application/json",
+			strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}`))
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer resp.Body.Close()
+		data, _ := io.ReadAll(resp.Body)
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("status %d: %s", resp.StatusCode, data)
+		}
+
+		var result map[string]any
+		json.Unmarshal(data, &result)
+		choices, _ := result["choices"].([]any)
+		if len(choices) == 0 {
+			t.Fatal("expected choices")
+		}
+		msg := choices[0].(map[string]any)["message"].(map[string]any)
+		content, _ := msg["content"].(string)
+		if content == "" {
+			t.Error("expected non-empty Eliza response")
+		}
+		t.Logf("Eliza says: %s", content)
+	})
+
+	t.Run("Anthropic_Messages", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", proxyServer.URL+"/v1/messages",
+			strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"I am sad"}],"max_tokens":100}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", "fake")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer resp.Body.Close()
+		data, _ := io.ReadAll(resp.Body)
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("status %d: %s", resp.StatusCode, data)
+		}
+
+		var result map[string]any
+		json.Unmarshal(data, &result)
+		blocks, _ := result["content"].([]any)
+		if len(blocks) == 0 {
+			t.Fatal("expected content blocks")
+		}
+		text, _ := blocks[0].(map[string]any)["text"].(string)
+		if text == "" {
+			t.Error("expected non-empty Eliza response")
+		}
+		t.Logf("Eliza says: %s", text)
+	})
+
+	t.Run("Anthropic_Streaming", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", proxyServer.URL+"/v1/messages",
+			strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"}],"max_tokens":100,"stream":true}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", "fake")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer resp.Body.Close()
+		data, _ := io.ReadAll(resp.Body)
+
+		if !strings.Contains(string(data), "text_delta") {
+			t.Error("expected text_delta events")
+		}
+		if !strings.Contains(string(data), "message_stop") {
+			t.Error("expected message_stop event")
+		}
+	})
+
+	t.Run("OpenAI_Streaming", func(t *testing.T) {
+		resp, err := http.Post(proxyServer.URL+"/v1/chat/completions", "application/json",
+			strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"stream":true}`))
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer resp.Body.Close()
+		data, _ := io.ReadAll(resp.Body)
+
+		if !strings.Contains(string(data), "[DONE]") {
+			t.Error("expected [DONE]")
+		}
+	})
+
+	t.Run("Models_Passthrough", func(t *testing.T) {
+		resp, err := http.Get(proxyServer.URL + "/v1/models")
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer resp.Body.Close()
+		data, _ := io.ReadAll(resp.Body)
+
+		var result map[string]any
+		json.Unmarshal(data, &result)
+		if result["object"] != "list" {
+			t.Errorf("expected models list, got: %s", data)
+		}
+	})
+
+	t.Run("Eliza_SpecialCommand", func(t *testing.T) {
+		resp, err := http.Post(proxyServer.URL+"/v1/chat/completions", "application/json",
+			strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"What can you do?"}]}`))
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer resp.Body.Close()
+		data, _ := io.ReadAll(resp.Body)
+
+		if !strings.Contains(string(data), "special commands") {
+			t.Error("expected Eliza help text through proxy")
+		}
+	})
+}

--- a/instrumentation/proxy/langsmith_test.go
+++ b/instrumentation/proxy/langsmith_test.go
@@ -1,0 +1,262 @@
+//go:build integration
+
+package proxy_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/instrumentation/proxy"
+	"github.com/langchain-ai/langsmith-go/internal/mockllm"
+)
+
+// TestLangSmith_TracesLand verifies that traces sent through the proxy
+// actually appear in LangSmith by querying them back with the langsmith CLI.
+//
+// Requires:
+//   - LANGSMITH_API_KEY env var
+//   - langsmith CLI in PATH
+func TestLangSmith_TracesLand(t *testing.T) {
+	apiKey := os.Getenv("LANGSMITH_API_KEY")
+	if apiKey == "" {
+		t.Skip("LANGSMITH_API_KEY not set")
+	}
+	if _, err := exec.LookPath("langsmith"); err != nil {
+		t.Skip("langsmith CLI not found in PATH")
+	}
+
+	project := fmt.Sprintf("__test_proxy_integ_%d_%d", time.Now().UnixNano(), rand.Intn(10000))
+	t.Logf("project: %s", project)
+
+	// Start Eliza as upstream
+	upstream := mockllm.NewCombinedServer(mockllm.WithHandler(mockllm.DefaultHandler()))
+	defer upstream.Close()
+
+	// Start proxy with real LangSmith tracing
+	p, err := proxy.New(proxy.Config{
+		AnthropicUpstream: upstream.URL(),
+		OpenAIUpstream:    upstream.URL(),
+		LangSmithAPIKey:   apiKey,
+		LangSmithProject:  project,
+	})
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Shutdown(context.Background())
+
+	proxyServer := httptest.NewServer(p)
+	defer proxyServer.Close()
+
+	// --- Send requests through proxy ---
+
+	t.Log("sending OpenAI non-streaming request...")
+	sendOpenAI(t, proxyServer.URL, `{"model":"gpt-4o","messages":[{"role":"user","content":"hello from proxy test"}]}`)
+
+	t.Log("sending Anthropic non-streaming request...")
+	sendAnthropic(t, proxyServer.URL, `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"I am a proxy test"}],"max_tokens":100}`)
+
+	t.Log("sending OpenAI streaming request...")
+	sendOpenAI(t, proxyServer.URL, `{"model":"gpt-4o","messages":[{"role":"user","content":"streaming test"}],"stream":true}`)
+
+	// Flush traces
+	p.Shutdown(context.Background())
+
+	// --- Poll LangSmith CLI for runs ---
+
+	t.Log("polling LangSmith for traces...")
+	runs := pollLangSmithCLI(t, project, 3, apiKey)
+
+	if len(runs) < 3 {
+		t.Fatalf("expected at least 3 runs, got %d", len(runs))
+	}
+
+	// Verify run shapes
+	var foundOpenAI, foundAnthropic bool
+	for _, run := range runs {
+		name, _ := run["name"].(string)
+		runType, _ := run["run_type"].(string)
+
+		if runType != "llm" {
+			t.Errorf("run %q: run_type = %q, want llm", name, runType)
+		}
+
+		if strings.Contains(name, "openai") {
+			foundOpenAI = true
+		}
+		if strings.Contains(name, "anthropic") {
+			foundAnthropic = true
+		}
+	}
+
+	if !foundOpenAI {
+		t.Error("expected at least one OpenAI run")
+	}
+	if !foundAnthropic {
+		t.Error("expected at least one Anthropic run")
+	}
+
+	t.Logf("found %d runs in project %s", len(runs), project)
+}
+
+// TestLangSmith_RunContents verifies that run inputs, outputs, and token
+// usage are populated correctly in LangSmith.
+func TestLangSmith_RunContents(t *testing.T) {
+	apiKey := os.Getenv("LANGSMITH_API_KEY")
+	if apiKey == "" {
+		t.Skip("LANGSMITH_API_KEY not set")
+	}
+	if _, err := exec.LookPath("langsmith"); err != nil {
+		t.Skip("langsmith CLI not found in PATH")
+	}
+
+	project := fmt.Sprintf("__test_proxy_contents_%d_%d", time.Now().UnixNano(), rand.Intn(10000))
+
+	upstream := mockllm.NewCombinedServer(mockllm.WithHandler(mockllm.DefaultHandler()))
+	defer upstream.Close()
+
+	p, err := proxy.New(proxy.Config{
+		AnthropicUpstream: upstream.URL(),
+		OpenAIUpstream:    upstream.URL(),
+		LangSmithAPIKey:   apiKey,
+		LangSmithProject:  project,
+	})
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Shutdown(context.Background())
+
+	proxyServer := httptest.NewServer(p)
+	defer proxyServer.Close()
+
+	// Send a simple request
+	sendOpenAI(t, proxyServer.URL, `{"model":"gpt-4o","messages":[{"role":"user","content":"What is Go?"}]}`)
+
+	p.Shutdown(context.Background())
+
+	runs := pollLangSmithCLI(t, project, 1, apiKey)
+	if len(runs) == 0 {
+		t.Fatal("no runs found")
+	}
+
+	run := runs[0]
+
+	// Check inputs
+	if inputs, ok := run["inputs"].(map[string]any); ok {
+		inputsJSON, _ := json.Marshal(inputs)
+		if !strings.Contains(string(inputsJSON), "What is Go?") {
+			t.Errorf("run inputs should contain prompt text, got: %s", inputsJSON)
+		}
+	} else {
+		t.Error("run should have inputs")
+	}
+
+	// Check outputs
+	if outputs, ok := run["outputs"].(map[string]any); ok {
+		outputsJSON, _ := json.Marshal(outputs)
+		if len(outputsJSON) == 0 || string(outputsJSON) == "{}" {
+			t.Error("run outputs should be non-empty")
+		}
+	} else {
+		t.Error("run should have outputs")
+	}
+
+	// Check token usage (nested under token_usage)
+	if tokenUsage, ok := run["token_usage"].(map[string]any); ok {
+		if pt, _ := tokenUsage["prompt_tokens"].(float64); pt == 0 {
+			t.Errorf("token_usage.prompt_tokens = %v, want > 0", tokenUsage["prompt_tokens"])
+		}
+		if ct, _ := tokenUsage["completion_tokens"].(float64); ct == 0 {
+			t.Errorf("token_usage.completion_tokens = %v, want > 0", tokenUsage["completion_tokens"])
+		}
+	} else {
+		t.Errorf("expected token_usage object, got %v", run["token_usage"])
+	}
+}
+
+// --- Helpers ---
+
+func sendOpenAI(t *testing.T, proxyURL, body string) {
+	t.Helper()
+	resp, err := http.Post(proxyURL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("openai request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("openai status: %d", resp.StatusCode)
+	}
+}
+
+func sendAnthropic(t *testing.T, proxyURL, body string) {
+	t.Helper()
+	req, _ := http.NewRequest("POST", proxyURL+"/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", "fake")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("anthropic request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("anthropic status: %d", resp.StatusCode)
+	}
+}
+
+// pollLangSmithCLI uses the langsmith CLI to query runs, polling until
+// at least minRuns appear or the timeout is reached.
+func pollLangSmithCLI(t *testing.T, project string, minRuns int, apiKey string) []map[string]any {
+	t.Helper()
+
+	deadline := time.Now().Add(30 * time.Second)
+	wait := 1 * time.Second
+
+	for time.Now().Before(deadline) {
+		time.Sleep(wait)
+
+		cmd := exec.Command("langsmith", "run", "list",
+			"--project", project,
+			"--limit", "20",
+			"--full",
+			"--format", "json",
+		)
+		cmd.Env = append(os.Environ(), "LANGSMITH_API_KEY="+apiKey)
+
+		var stderr strings.Builder
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		if err != nil {
+			t.Logf("langsmith run list: %v (stderr: %s)", err, stderr.String())
+			wait = min(wait*2, 4*time.Second)
+			continue
+		}
+
+		var runs []map[string]any
+		if err := json.Unmarshal(out, &runs); err != nil {
+			t.Logf("parse runs: %v (raw: %s)", err, string(out[:min(len(out), 200)]))
+			wait = min(wait*2, 4*time.Second)
+			continue
+		}
+
+		if len(runs) >= minRuns {
+			return runs
+		}
+
+		t.Logf("found %d/%d runs, polling...", len(runs), minRuns)
+		wait = min(wait*2, 4*time.Second)
+	}
+
+	t.Errorf("expected at least %d runs in project %q, timed out", minRuns, project)
+	return nil
+}

--- a/instrumentation/proxy/proxy.go
+++ b/instrumentation/proxy/proxy.go
@@ -1,0 +1,211 @@
+// Package proxy provides a reverse proxy that transparently adds LangSmith
+// tracing to Anthropic and OpenAI API calls. It routes requests by path to
+// the correct upstream and uses the existing traceanthropic/traceopenai
+// instrumentation to create OpenTelemetry spans.
+//
+// Usage:
+//
+//	p, err := proxy.New(proxy.Config{
+//	    LangSmithAPIKey:  os.Getenv("LANGSMITH_API_KEY"),
+//	    LangSmithProject: "my-project",
+//	})
+//	defer p.Shutdown(ctx)
+//	http.ListenAndServe(":8090", p)
+//
+// Then point any SDK at the proxy:
+//
+//	export ANTHROPIC_BASE_URL=http://localhost:8090
+//	export OPENAI_BASE_URL=http://localhost:8090/v1
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/instrumentation/traceanthropic"
+	"github.com/langchain-ai/langsmith-go/instrumentation/traceopenai"
+)
+
+// Config configures a tracing proxy.
+type Config struct {
+	// Upstream URLs. Empty strings default to the real provider APIs.
+	AnthropicUpstream string // default: https://api.anthropic.com
+	OpenAIUpstream    string // default: https://api.openai.com
+
+	// LangSmith credentials. Empty strings are read from LANGSMITH_API_KEY,
+	// LANGSMITH_PROJECT, and LANGSMITH_ENDPOINT environment variables.
+	LangSmithAPIKey   string
+	LangSmithProject  string
+	LangSmithEndpoint string
+
+	// TracerProvider overrides the internally created provider. When set,
+	// the proxy does not create or shut down its own provider. Use this
+	// for testing with tracetest.InMemoryExporter.
+	TracerProvider trace.TracerProvider
+}
+
+func (c *Config) resolve() {
+	if c.AnthropicUpstream == "" {
+		c.AnthropicUpstream = "https://api.anthropic.com"
+	}
+	if c.OpenAIUpstream == "" {
+		c.OpenAIUpstream = "https://api.openai.com"
+	}
+	if c.LangSmithAPIKey == "" {
+		c.LangSmithAPIKey = os.Getenv("LANGSMITH_API_KEY")
+	}
+	if c.LangSmithProject == "" {
+		c.LangSmithProject = os.Getenv("LANGSMITH_PROJECT")
+	}
+	if c.LangSmithEndpoint == "" {
+		c.LangSmithEndpoint = os.Getenv("LANGSMITH_ENDPOINT")
+	}
+}
+
+// Proxy is an http.Handler that forwards LLM API requests to upstream
+// providers while adding LangSmith tracing.
+type Proxy struct {
+	handler http.Handler
+	tracer  *langsmith.OTelTracer // nil when an external TracerProvider was provided
+}
+
+// New creates a tracing proxy from the given configuration.
+func New(cfg Config) (*Proxy, error) {
+	cfg.resolve()
+
+	anthropicURL, err := url.Parse(cfg.AnthropicUpstream)
+	if err != nil {
+		return nil, fmt.Errorf("parsing anthropic upstream: %w", err)
+	}
+	openaiURL, err := url.Parse(cfg.OpenAIUpstream)
+	if err != nil {
+		return nil, fmt.Errorf("parsing openai upstream: %w", err)
+	}
+
+	// Obtain a TracerProvider.
+	var tp trace.TracerProvider
+	var tracer *langsmith.OTelTracer
+
+	if cfg.TracerProvider != nil {
+		tp = cfg.TracerProvider
+	} else {
+		var opts []langsmith.OTelTracerOption
+		if cfg.LangSmithAPIKey != "" {
+			opts = append(opts, langsmith.WithAPIKey(cfg.LangSmithAPIKey))
+		}
+		if cfg.LangSmithProject != "" {
+			opts = append(opts, langsmith.WithProjectName(cfg.LangSmithProject))
+		}
+		if cfg.LangSmithEndpoint != "" {
+			// WithEndpoint expects a host, but LANGSMITH_ENDPOINT is often
+			// a full URL. Strip the scheme to avoid double-wrapping.
+			ep := strings.TrimPrefix(cfg.LangSmithEndpoint, "https://")
+			ep = strings.TrimPrefix(ep, "http://")
+			opts = append(opts, langsmith.WithEndpoint(ep))
+		}
+		opts = append(opts, langsmith.WithServiceName("langsmith-proxy"))
+
+		t, tErr := langsmith.NewOTelTracer(opts...)
+		if tErr != nil {
+			return nil, fmt.Errorf("creating langsmith tracer: %w", tErr)
+		}
+		tracer = t
+		tp = t.TracerProvider()
+	}
+
+	// Build traced transports for each provider.
+	anthropicTransport := traceanthropic.WrapClient(nil,
+		traceanthropic.WithTracerProvider(tp),
+		traceanthropic.WithTraceAllHosts(),
+	).Transport
+
+	openaiTransport := traceopenai.WrapClient(nil,
+		traceopenai.WithTracerProvider(tp),
+	).Transport
+
+	plainTransport := http.DefaultTransport
+
+	rt := &routingTransport{
+		anthropic:    anthropicTransport,
+		openai:       openaiTransport,
+		passthrough:  plainTransport,
+		anthropicURL: anthropicURL,
+		openaiURL:    openaiURL,
+	}
+
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			// Route to the correct upstream based on request path.
+			if isAnthropicPath(req.URL.Path) {
+				req.URL.Scheme = anthropicURL.Scheme
+				req.URL.Host = anthropicURL.Host
+				req.Host = anthropicURL.Host
+			} else {
+				req.URL.Scheme = openaiURL.Scheme
+				req.URL.Host = openaiURL.Host
+				req.Host = openaiURL.Host
+			}
+		},
+		Transport:     rt,
+		FlushInterval: -1, // immediate flush for SSE streaming
+	}
+
+	return &Proxy{handler: rp, tracer: tracer}, nil
+}
+
+// ServeHTTP implements http.Handler.
+func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p.handler.ServeHTTP(w, r)
+}
+
+// Shutdown flushes pending spans and releases resources. If the proxy was
+// created with an external TracerProvider, Shutdown is a no-op.
+func (p *Proxy) Shutdown(ctx context.Context) error {
+	if p.tracer != nil {
+		return p.tracer.Shutdown(ctx)
+	}
+	return nil
+}
+
+// routingTransport dispatches requests to the correct traced transport
+// based on the URL path.
+type routingTransport struct {
+	anthropic   http.RoundTripper
+	openai      http.RoundTripper
+	passthrough http.RoundTripper
+
+	anthropicURL *url.URL
+	openaiURL    *url.URL
+}
+
+func (rt *routingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	path := req.URL.Path
+
+	if isAnthropicPath(path) {
+		return rt.anthropic.RoundTrip(req)
+	}
+	if isOpenAIPath(path) {
+		return rt.openai.RoundTrip(req)
+	}
+	// Passthrough for /v1/models, health checks, etc.
+	return rt.passthrough.RoundTrip(req)
+}
+
+func isAnthropicPath(path string) bool {
+	return strings.Contains(path, "/v1/messages")
+}
+
+func isOpenAIPath(path string) bool {
+	return strings.HasSuffix(path, "/chat/completions") ||
+		strings.HasSuffix(path, "/completions") ||
+		strings.HasSuffix(path, "/embeddings") ||
+		strings.HasSuffix(path, "/responses")
+}

--- a/instrumentation/proxy/proxy_test.go
+++ b/instrumentation/proxy/proxy_test.go
@@ -1,0 +1,379 @@
+package proxy_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/langchain-ai/langsmith-go/instrumentation/proxy"
+	"github.com/langchain-ai/langsmith-go/internal/mockllm"
+)
+
+type testEnv struct {
+	ProxyURL string
+	Exporter *tracetest.InMemoryExporter
+	TP       *sdktrace.TracerProvider
+	cleanup  func()
+}
+
+func (e *testEnv) Close() { e.cleanup() }
+
+func (e *testEnv) FlushAndGetSpans(t *testing.T) []sdktrace.ReadOnlySpan {
+	t.Helper()
+	e.TP.ForceFlush(context.Background())
+	spans := e.Exporter.GetSpans()
+	ro := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i := range spans {
+		ro[i] = spans[i].Snapshot()
+	}
+	return ro
+}
+
+func setup(t *testing.T) *testEnv {
+	t.Helper()
+
+	upstream := mockllm.NewCombinedServer(mockllm.WithHandler(mockllm.DefaultHandler()))
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+
+	p, err := proxy.New(proxy.Config{
+		AnthropicUpstream: upstream.URL(),
+		OpenAIUpstream:    upstream.URL(),
+		TracerProvider:    tp,
+	})
+	if err != nil {
+		upstream.Close()
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	proxyServer := httptest.NewServer(p)
+
+	return &testEnv{
+		ProxyURL: proxyServer.URL,
+		Exporter: exporter,
+		TP:       tp,
+		cleanup: func() {
+			proxyServer.Close()
+			upstream.Close()
+			tp.Shutdown(context.Background())
+		},
+	}
+}
+
+func spanAttr(spans []sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, s := range spans {
+		for _, attr := range s.Attributes() {
+			if string(attr.Key) == key {
+				return attr.Value.Emit(), true
+			}
+		}
+	}
+	return "", false
+}
+
+func spanAttrInt(spans []sdktrace.ReadOnlySpan, key string) (int64, bool) {
+	for _, s := range spans {
+		for _, attr := range s.Attributes() {
+			if string(attr.Key) == key {
+				return attr.Value.AsInt64(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// --- Anthropic ---
+
+func TestProxy_Anthropic_NonStreaming(t *testing.T) {
+	env := setup(t)
+	defer env.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"}],"max_tokens":100}`
+	resp, err := http.Post(env.ProxyURL+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	spans := env.FlushAndGetSpans(t)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+	if v, ok := spanAttr(spans, "gen_ai.system"); !ok || v != "anthropic" {
+		t.Errorf("gen_ai.system = %q, want anthropic", v)
+	}
+	if _, ok := spanAttr(spans, "gen_ai.prompt"); !ok {
+		t.Error("expected gen_ai.prompt")
+	}
+	if _, ok := spanAttr(spans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion")
+	}
+	if v, ok := spanAttrInt(spans, "gen_ai.usage.input_tokens"); !ok || v == 0 {
+		t.Errorf("gen_ai.usage.input_tokens = %d", v)
+	}
+}
+
+func TestProxy_Anthropic_Streaming(t *testing.T) {
+	env := setup(t)
+	defer env.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"}],"max_tokens":100,"stream":true}`
+	resp, err := http.Post(env.ProxyURL+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	data, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if !strings.Contains(string(data), "text_delta") {
+		t.Error("expected SSE text_delta events in response")
+	}
+
+	spans := env.FlushAndGetSpans(t)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+	if v, ok := spanAttr(spans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion")
+	} else if !strings.Contains(v, "Hello") {
+		t.Errorf("completion should contain 'Hello': %s", v)
+	}
+}
+
+// --- OpenAI ---
+
+func TestProxy_OpenAI_NonStreaming(t *testing.T) {
+	env := setup(t)
+	defer env.Close()
+
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}`
+	resp, err := http.Post(env.ProxyURL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	spans := env.FlushAndGetSpans(t)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+	if v, ok := spanAttr(spans, "gen_ai.system"); !ok || v != "openai" {
+		t.Errorf("gen_ai.system = %q, want openai", v)
+	}
+	if _, ok := spanAttr(spans, "gen_ai.prompt"); !ok {
+		t.Error("expected gen_ai.prompt")
+	}
+	if _, ok := spanAttr(spans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion")
+	}
+}
+
+func TestProxy_OpenAI_Streaming(t *testing.T) {
+	env := setup(t)
+	defer env.Close()
+
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"stream":true}`
+	resp, err := http.Post(env.ProxyURL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	data, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if !strings.Contains(string(data), "[DONE]") {
+		t.Error("expected [DONE] in SSE stream")
+	}
+
+	spans := env.FlushAndGetSpans(t)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+	if v, ok := spanAttr(spans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion")
+	} else if !strings.Contains(v, "Hello") {
+		t.Errorf("completion should contain 'Hello': %s", v)
+	}
+}
+
+func TestProxy_OpenAI_ToolCalls(t *testing.T) {
+	env := setup(t)
+	defer env.Close()
+
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"weather?"}],"tools":[{"type":"function","function":{"name":"get_weather"}}]}`
+	resp, err := http.Post(env.ProxyURL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	spans := env.FlushAndGetSpans(t)
+	if v, ok := spanAttr(spans, "gen_ai.completion"); !ok {
+		t.Error("expected gen_ai.completion")
+	} else if !strings.Contains(v, "get_weather") {
+		t.Errorf("completion should contain tool call: %s", v)
+	}
+}
+
+// --- Passthrough ---
+
+func TestProxy_Models_Passthrough(t *testing.T) {
+	env := setup(t)
+	defer env.Close()
+
+	resp, err := http.Get(env.ProxyURL + "/v1/models")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	data, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if result["object"] != "list" {
+		t.Errorf("expected models list, got %v", result["object"])
+	}
+
+	// No tracing spans for /v1/models
+	spans := env.FlushAndGetSpans(t)
+	for _, s := range spans {
+		if strings.Contains(s.Name(), "model") {
+			t.Error("unexpected tracing span for /v1/models")
+		}
+	}
+}
+
+// --- Auth headers ---
+
+func TestProxy_AuthHeaders_Forwarded(t *testing.T) {
+	// Use a custom upstream that captures headers
+	var capturedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_001", "type": "message", "role": "assistant", "model": "test",
+			"content":     []map[string]any{{"type": "text", "text": "ok"}},
+			"usage":       map[string]any{"input_tokens": 1, "output_tokens": 1},
+			"stop_reason": "end_turn",
+		})
+	}))
+	defer upstream.Close()
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer tp.Shutdown(context.Background())
+
+	p, err := proxy.New(proxy.Config{
+		AnthropicUpstream: upstream.URL,
+		OpenAIUpstream:    upstream.URL,
+		TracerProvider:    tp,
+	})
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	proxyServer := httptest.NewServer(p)
+	defer proxyServer.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":10}`
+	req, _ := http.NewRequest("POST", proxyServer.URL+"/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", "sk-ant-test-key-123")
+	req.Header.Set("Authorization", "Bearer sk-test-key-456")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if capturedHeaders.Get("X-Api-Key") != "sk-ant-test-key-123" {
+		t.Errorf("x-api-key not forwarded: %q", capturedHeaders.Get("X-Api-Key"))
+	}
+	if !strings.Contains(capturedHeaders.Get("Authorization"), "sk-test-key-456") {
+		t.Errorf("authorization not forwarded: %q", capturedHeaders.Get("Authorization"))
+	}
+}
+
+// --- Error tracing ---
+
+func TestProxy_Error_Traced(t *testing.T) {
+	// Upstream returns 401
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"type": "error",
+			"error": map[string]any{
+				"type":    "authentication_error",
+				"message": "invalid key",
+			},
+		})
+	}))
+	defer upstream.Close()
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer tp.Shutdown(context.Background())
+
+	p, _ := proxy.New(proxy.Config{
+		AnthropicUpstream: upstream.URL,
+		TracerProvider:    tp,
+	})
+	proxyServer := httptest.NewServer(p)
+	defer proxyServer.Close()
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":10}`
+	resp, err := http.Post(proxyServer.URL+"/v1/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+
+	tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+
+	foundError := false
+	for _, s := range spans {
+		snap := s.Snapshot()
+		if snap.Status().Code == 2 { // codes.Error
+			foundError = true
+			break
+		}
+		for _, ev := range snap.Events() {
+			if ev.Name == "exception" {
+				foundError = true
+				break
+			}
+		}
+	}
+	if !foundError {
+		t.Error("expected error span for 401 response")
+	}
+}


### PR DESCRIPTION
## Summary

- New `instrumentation/proxy` package — reverse proxy that transparently adds LangSmith tracing to Anthropic and OpenAI API calls
- Routes requests by path to the correct upstream, reuses existing `traceanthropic`/`traceopenai` RoundTrippers
- Supports streaming SSE passthrough, auth header forwarding, `/v1/models` passthrough
- `cmd/langsmith-proxy` binary with graceful shutdown
- End-to-end integration tests verify traces land in LangSmith via `langsmith` CLI

## Usage

```bash
# Against real APIs
LANGSMITH_API_KEY=lsv2_... go run ./cmd/langsmith-proxy

# Point clients at the proxy
export ANTHROPIC_BASE_URL=http://localhost:8090
export OPENAI_BASE_URL=http://localhost:8090/v1
```

## Stack

1. feat/mock-servers — mock servers + Eliza
2. feat/integration-mock — run existing integration tests against mock
3. **This PR** — tracing reverse proxy

## Test plan

- [x] 8 unit tests (span creation, streaming, tool calls, auth forwarding, error tracing, models passthrough)
- [x] 6 e2e subtests against Eliza through the proxy
- [x] 2 LangSmith integration tests verifying traces land (via `langsmith` CLI)