### PR TITLE
chore: sync next with main for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,20 @@
 codegen.log
 Brewfile.lock.json
 .idea/
+
+# Local secrets
+.env
+.env.*
+*.pem
+*.key
+*.crt
+credentials.json
+token.json
+
+# Local dependency and virtualenv directories
+node_modules/
+__pycache__/
+.venv/
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -41,13 +41,9 @@ The client can be configured using environment variables or by passing options d
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `LANGSMITH_API_KEY` | Optional* | Your LangSmith API key for authentication |
-| `LANGSMITH_BEARER_TOKEN` | Optional* | Bearer token for authentication (alternative to API key) |
+| `LANGSMITH_API_KEY` | Optional | Your LangSmith API key for authentication |
 | `LANGSMITH_TENANT_ID` | Optional | Your LangSmith tenant ID |
-| `LANGSMITH_ORGANIZATION_ID` | Optional | Your LangSmith organization ID |
 | `LANGSMITH_ENDPOINT` | Optional | Custom base URL for the LangSmith API (defaults to `https://api.smith.langchain.com`) |
-
-\* Either `LANGSMITH_API_KEY` or `LANGSMITH_BEARER_TOKEN` is required for authentication.
 
 ## Examples
 

--- a/annotationqueue_test.go
+++ b/annotationqueue_test.go
@@ -28,7 +28,6 @@ func TestAnnotationQueueGet(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Get(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {
@@ -53,7 +52,6 @@ func TestAnnotationQueueUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Update(
 		context.TODO(),
@@ -106,7 +104,6 @@ func TestAnnotationQueueDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Delete(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {
@@ -131,7 +128,6 @@ func TestAnnotationQueueAnnotationQueuesWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.AnnotationQueues(context.TODO(), langsmith.AnnotationQueueAnnotationQueuesParams{
 		Name:               langsmith.F("name"),
@@ -184,7 +180,6 @@ func TestAnnotationQueueNewRunStatusWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.NewRunStatus(
 		context.TODO(),
@@ -216,7 +211,6 @@ func TestAnnotationQueueExportWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Export(
 		context.TODO(),
@@ -249,7 +243,6 @@ func TestAnnotationQueuePopulate(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Populate(context.TODO(), langsmith.AnnotationQueuePopulateParams{
 		QueueID:    langsmith.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),
@@ -277,7 +270,6 @@ func TestAnnotationQueueGetAnnotationQueuesWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.GetAnnotationQueues(context.TODO(), langsmith.AnnotationQueueGetAnnotationQueuesParams{
 		AssignedToMe: langsmith.F(true),
@@ -314,7 +306,6 @@ func TestAnnotationQueueGetQueues(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.GetQueues(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {
@@ -339,7 +330,6 @@ func TestAnnotationQueueGetRunWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.GetRun(
 		context.TODO(),
@@ -371,7 +361,6 @@ func TestAnnotationQueueGetSizeWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.GetSize(
 		context.TODO(),
@@ -402,7 +391,6 @@ func TestAnnotationQueueGetTotalArchivedWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.GetTotalArchived(
 		context.TODO(),
@@ -434,7 +422,6 @@ func TestAnnotationQueueGetTotalSize(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.GetTotalSize(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {

--- a/annotationqueueinfo_test.go
+++ b/annotationqueueinfo_test.go
@@ -26,7 +26,6 @@ func TestAnnotationQueueInfoList(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Info.List(context.TODO())
 	if err != nil {

--- a/annotationqueuerun_test.go
+++ b/annotationqueuerun_test.go
@@ -27,7 +27,6 @@ func TestAnnotationQueueRunNew(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Runs.New(
 		context.TODO(),
@@ -58,7 +57,6 @@ func TestAnnotationQueueRunUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Runs.Update(
 		context.TODO(),
@@ -91,7 +89,6 @@ func TestAnnotationQueueRunListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Runs.List(
 		context.TODO(),
@@ -126,7 +123,6 @@ func TestAnnotationQueueRunDeleteAllWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Runs.DeleteAll(
 		context.TODO(),
@@ -159,7 +155,6 @@ func TestAnnotationQueueRunDeleteQueue(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.AnnotationQueues.Runs.DeleteQueue(
 		context.TODO(),

--- a/client.go
+++ b/client.go
@@ -39,10 +39,13 @@ type Client struct {
 }
 
 // DefaultClientOptions read from the environment (LANGSMITH_API_KEY,
-// LANGSMITH_TENANT_ID, LANGSMITH_BEARER_TOKEN, LANGSMITH_ORGANIZATION_ID,
-// LANGSMITH_ENDPOINT). This should be used to initialize new clients.
+// LANGSMITH_TENANT_ID, LANGSMITH_WORKSPACE_ID, LANGSMITH_ENDPOINT). This
+// should be used to initialize new clients.
 func DefaultClientOptions() []option.RequestOption {
 	defaults := []option.RequestOption{option.WithEnvironmentProduction()}
+	// Profile options are applied after the production default but before env
+	// vars, so env vars override profile values (last option wins).
+	defaults = append(defaults, loadProfileOptions()...)
 	if o, ok := os.LookupEnv("LANGSMITH_ENDPOINT"); ok {
 		defaults = append(defaults, option.WithBaseURL(o))
 	}
@@ -52,20 +55,17 @@ func DefaultClientOptions() []option.RequestOption {
 	if o, ok := os.LookupEnv("LANGSMITH_TENANT_ID"); ok {
 		defaults = append(defaults, option.WithTenantID(o))
 	}
-	if o, ok := os.LookupEnv("LANGSMITH_BEARER_TOKEN"); ok {
-		defaults = append(defaults, option.WithBearerToken(o))
-	}
-	if o, ok := os.LookupEnv("LANGSMITH_ORGANIZATION_ID"); ok {
-		defaults = append(defaults, option.WithOrganizationID(o))
+	if o, ok := os.LookupEnv("LANGSMITH_WORKSPACE_ID"); ok {
+		defaults = append(defaults, option.WithTenantID(o))
 	}
 	return defaults
 }
 
 // NewClient generates a new client with the default option read from the
-// environment (LANGSMITH_API_KEY, LANGSMITH_TENANT_ID, LANGSMITH_BEARER_TOKEN,
-// LANGSMITH_ORGANIZATION_ID, LANGSMITH_ENDPOINT). The option passed in as
-// arguments are applied after these default arguments, and all option will be
-// passed down to the services and requests that this client makes.
+// environment (LANGSMITH_API_KEY, LANGSMITH_TENANT_ID, LANGSMITH_WORKSPACE_ID,
+// LANGSMITH_ENDPOINT). The option passed in as arguments are applied after
+// these default arguments, and all option will be passed down to the services
+// and requests that this client makes.
 func NewClient(opts ...option.RequestOption) (r *Client) {
 	opts = append(DefaultClientOptions(), opts...)
 
@@ -110,8 +110,8 @@ func (r *Client) tracing() (*langsmithtracing.TracingClient, error) {
 		if cfg.APIKey != "" {
 			tracingOpts = append(tracingOpts, langsmithtracing.WithAPIKey(cfg.APIKey))
 		}
-		if cfg.BearerToken != "" {
-			tracingOpts = append(tracingOpts, langsmithtracing.WithBearerToken(cfg.BearerToken))
+		if cfg.OAuthAccessToken != "" {
+			tracingOpts = append(tracingOpts, langsmithtracing.WithOAuthAccessToken(cfg.OAuthAccessToken))
 		}
 		if cfg.BaseURL != nil {
 			tracingOpts = append(tracingOpts, langsmithtracing.WithAPIURL(cfg.BaseURL.String()))

--- a/client_test.go
+++ b/client_test.go
@@ -28,7 +28,6 @@ func TestUserAgentHeader(t *testing.T) {
 	client := langsmith.NewClient(
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 		option.WithHTTPClient(&http.Client{
 			Transport: &closureTransport{
 				fn: func(req *http.Request) (*http.Response, error) {
@@ -57,7 +56,6 @@ func TestRetryAfter(t *testing.T) {
 	client := langsmith.NewClient(
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 		option.WithHTTPClient(&http.Client{
 			Transport: &closureTransport{
 				fn: func(req *http.Request) (*http.Response, error) {
@@ -99,7 +97,6 @@ func TestDeleteRetryCountHeader(t *testing.T) {
 	client := langsmith.NewClient(
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 		option.WithHTTPClient(&http.Client{
 			Transport: &closureTransport{
 				fn: func(req *http.Request) (*http.Response, error) {
@@ -137,7 +134,6 @@ func TestOverwriteRetryCountHeader(t *testing.T) {
 	client := langsmith.NewClient(
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 		option.WithHTTPClient(&http.Client{
 			Transport: &closureTransport{
 				fn: func(req *http.Request) (*http.Response, error) {
@@ -175,7 +171,6 @@ func TestRetryAfterMs(t *testing.T) {
 	client := langsmith.NewClient(
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 		option.WithHTTPClient(&http.Client{
 			Transport: &closureTransport{
 				fn: func(req *http.Request) (*http.Response, error) {
@@ -209,7 +204,6 @@ func TestContextCancel(t *testing.T) {
 	client := langsmith.NewClient(
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 		option.WithHTTPClient(&http.Client{
 			Transport: &closureTransport{
 				fn: func(req *http.Request) (*http.Response, error) {
@@ -237,7 +231,6 @@ func TestContextCancelDelay(t *testing.T) {
 	client := langsmith.NewClient(
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 		option.WithHTTPClient(&http.Client{
 			Transport: &closureTransport{
 				fn: func(req *http.Request) (*http.Response, error) {
@@ -273,7 +266,6 @@ func TestContextDeadline(t *testing.T) {
 		client := langsmith.NewClient(
 			option.WithAPIKey("My API Key"),
 			option.WithTenantID("My Tenant ID"),
-			option.WithOrganizationID("My Organization ID"),
 			option.WithHTTPClient(&http.Client{
 				Transport: &closureTransport{
 					fn: func(req *http.Request) (*http.Response, error) {

--- a/commit_test.go
+++ b/commit_test.go
@@ -26,7 +26,6 @@ func TestCommitNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Commits.New(
 		context.TODO(),
@@ -61,7 +60,6 @@ func TestCommitGetWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Commits.Get(
 		context.TODO(),
@@ -97,7 +95,6 @@ func TestCommitListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Commits.List(
 		context.TODO(),

--- a/config.go
+++ b/config.go
@@ -1,0 +1,254 @@
+package langsmith
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+const (
+	oauthClientID       = "langsmith-cli"
+	tokenRefreshLeeway  = time.Minute
+	tokenRefreshTimeout = 10 * time.Second
+)
+
+// configProfile holds per-profile configuration from ~/.langsmith/config.json.
+// A profile uses api_key (X-API-Key header) or OAuth access_token
+// (Authorization: Bearer header) for authentication. access_token is written
+// by `langsmith login` under the profile's oauth object.
+type configProfile struct {
+	APIKey      string      `json:"api_key,omitempty"`
+	APIURL      string      `json:"api_url,omitempty"`
+	WorkspaceID string      `json:"workspace_id,omitempty"`
+	OAuth       configOAuth `json:"oauth,omitempty"`
+}
+
+type configOAuth struct {
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
+}
+
+type configFile struct {
+	CurrentProfile string                   `json:"current_profile,omitempty"`
+	Profiles       map[string]configProfile `json:"profiles,omitempty"`
+}
+
+type oauthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type oauthErrorResponse struct {
+	Code             string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func (e oauthErrorResponse) Error() string {
+	if e.ErrorDescription == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.ErrorDescription
+}
+
+// loadProfileOptions reads ~/.langsmith/config.json and returns RequestOptions
+// for the active profile. Returns nil if no config file exists or no matching
+// profile is found.
+//
+// Profile selection priority:
+//  1. LANGSMITH_PROFILE environment variable
+//  2. current_profile key in config file
+//  3. "default" profile
+func loadProfileOptions() []option.RequestOption {
+	path := configPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var cfg configFile
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+
+	profileName := resolveProfileName(cfg)
+	if profileName == "" {
+		return nil
+	}
+
+	p, ok := cfg.Profiles[profileName]
+	if !ok {
+		return nil
+	}
+
+	refreshURL := p.APIURL
+	if envURL := os.Getenv("LANGSMITH_ENDPOINT"); envURL != "" {
+		refreshURL = envURL
+	}
+	envAuthSet := os.Getenv("LANGSMITH_API_KEY") != ""
+	if shouldRefreshProfileToken(p) &&
+		!envAuthSet {
+		ctx, cancel := context.WithTimeout(context.Background(), tokenRefreshTimeout)
+		defer cancel()
+		if token, err := refreshOAuthToken(ctx, refreshURL, p.OAuth.RefreshToken); err == nil {
+			applyTokenResponse(&p, token, time.Now())
+			cfg.Profiles[profileName] = p
+			_ = saveConfig(path, cfg)
+		}
+	}
+
+	var opts []option.RequestOption
+	if p.APIURL != "" {
+		opts = append(opts, option.WithBaseURL(p.APIURL))
+	}
+	if !envAuthSet {
+		if token := p.OAuth.AccessToken; token != "" {
+			opts = append(opts, withOAuthAccessToken(token))
+		} else if p.APIKey != "" {
+			opts = append(opts, option.WithAPIKey(p.APIKey))
+		}
+	}
+	if p.WorkspaceID != "" {
+		opts = append(opts, option.WithTenantID(p.WorkspaceID))
+	}
+	return opts
+}
+
+func withOAuthAccessToken(token string) option.RequestOption {
+	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+		r.OAuthAccessToken = token
+		return r.Apply(option.WithHeader("authorization", "Bearer "+token))
+	})
+}
+
+// resolveProfileName determines which profile to use.
+func resolveProfileName(cfg configFile) string {
+	// 1. LANGSMITH_PROFILE env var
+	if name, ok := os.LookupEnv("LANGSMITH_PROFILE"); ok && name != "" {
+		return name
+	}
+	// 2. current_profile from config
+	if cfg.CurrentProfile != "" {
+		return cfg.CurrentProfile
+	}
+	// 3. "default" if it exists
+	if _, ok := cfg.Profiles["default"]; ok {
+		return "default"
+	}
+	return ""
+}
+
+// configPath returns the path to the config file.
+func configPath() string {
+	if v := os.Getenv("LANGSMITH_CONFIG_FILE"); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".langsmith", "config.json")
+}
+
+func shouldRefreshProfileToken(p configProfile) bool {
+	if p.OAuth.RefreshToken == "" {
+		return false
+	}
+	if p.OAuth.AccessToken == "" {
+		return true
+	}
+	expiresAt, err := time.Parse(time.RFC3339, p.OAuth.ExpiresAt)
+	if err != nil {
+		return false
+	}
+	return !expiresAt.After(time.Now().Add(tokenRefreshLeeway))
+}
+
+func refreshOAuthToken(ctx context.Context, apiURL, refreshToken string) (*oauthTokenResponse, error) {
+	if apiURL == "" {
+		apiURL = "https://api.smith.langchain.com"
+	}
+	values := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {oauthClientID},
+		"refresh_token": {refreshToken},
+	}
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		strings.TrimRight(normalizeConfigURL(apiURL), "/")+"/oauth/token",
+		bytes.NewBufferString(values.Encode()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var oauthErr oauthErrorResponse
+		if err := json.Unmarshal(body, &oauthErr); err == nil && oauthErr.Code != "" {
+			return nil, oauthErr
+		}
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	var token oauthTokenResponse
+	if err := json.Unmarshal(body, &token); err != nil {
+		return nil, err
+	}
+	if token.AccessToken == "" {
+		return nil, fmt.Errorf("oauth refresh response missing access_token")
+	}
+	return &token, nil
+}
+
+func applyTokenResponse(p *configProfile, token *oauthTokenResponse, now time.Time) {
+	p.OAuth.AccessToken = token.AccessToken
+	if token.RefreshToken != "" {
+		p.OAuth.RefreshToken = token.RefreshToken
+	}
+	if token.ExpiresIn > 0 {
+		p.OAuth.ExpiresAt = now.Add(time.Duration(token.ExpiresIn) * time.Second).UTC().Format(time.RFC3339)
+	}
+}
+
+func saveConfig(path string, cfg configFile) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0600)
+}
+
+func normalizeConfigURL(apiURL string) string {
+	u := strings.TrimRight(apiURL, "/")
+	return strings.TrimSuffix(u, "/api/v1")
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,405 @@
+package langsmith
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+func TestLoadProfileOptions_NoFile(t *testing.T) {
+	t.Setenv("LANGSMITH_CONFIG_FILE", "/nonexistent/path/config.json")
+	opts := loadProfileOptions()
+	if len(opts) != 0 {
+		t.Errorf("expected no options for missing file, got %d", len(opts))
+	}
+}
+
+func TestLoadProfileOptions_ValidProfile(t *testing.T) {
+	clearAuthEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "current_profile": "prod",
+  "profiles": {
+    "prod": {
+      "api_key": "lsv2_pt_prodkey",
+      "api_url": "https://prod.example.com",
+      "workspace_id": "ws-prod"
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := loadProfileOptions()
+	if len(opts) != 3 {
+		t.Fatalf("expected 3 options (base_url, api_key, tenant_id), got %d", len(opts))
+	}
+}
+
+func TestLoadProfileOptions_EnvProfileOverride(t *testing.T) {
+	clearAuthEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "current_profile": "prod",
+  "profiles": {
+    "prod": {
+      "api_key": "prod-key"
+    },
+    "staging": {
+      "api_key": "staging-key"
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "staging")
+
+	opts := loadProfileOptions()
+	if len(opts) != 1 {
+		t.Fatalf("expected 1 option (api_key only), got %d", len(opts))
+	}
+}
+
+func TestLoadProfileOptions_FallbackToDefault(t *testing.T) {
+	clearAuthEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_key": "default-key",
+      "api_url": "https://default.example.com"
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := loadProfileOptions()
+	if len(opts) != 2 {
+		t.Fatalf("expected 2 options (base_url, api_key), got %d", len(opts))
+	}
+}
+
+func TestLoadProfileOptions_NoMatchingProfile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "current_profile": "nonexistent",
+  "profiles": {
+    "prod": {
+      "api_key": "key"
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := loadProfileOptions()
+	if len(opts) != 0 {
+		t.Errorf("expected no options for missing profile, got %d", len(opts))
+	}
+}
+
+func TestLoadProfileOptions_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte("not valid json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+
+	opts := loadProfileOptions()
+	if len(opts) != 0 {
+		t.Errorf("expected no options for invalid JSON, got %d", len(opts))
+	}
+}
+
+func TestLoadProfileOptions_PartialFields(t *testing.T) {
+	clearAuthEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_key": "only-key"
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := loadProfileOptions()
+	if len(opts) != 1 {
+		t.Fatalf("expected 1 option (api_key only), got %d", len(opts))
+	}
+}
+
+func TestDefaultClientOptions_IncludesProfileOptions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_key": "profile-key"
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+	// Clear env vars so profile is the only source
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_TENANT_ID", "")
+
+	opts := DefaultClientOptions()
+	// Should have at least: WithEnvironmentProduction + profile api_key
+	if len(opts) < 2 {
+		t.Errorf("expected at least 2 options (production env + profile key), got %d", len(opts))
+	}
+	// Verify it's usable (doesn't panic)
+	_ = option.WithAPIKey("override")
+}
+
+func TestDefaultClientOptions_WorkspaceIDEnvAlias(t *testing.T) {
+	t.Setenv("LANGSMITH_CONFIG_FILE", "/nonexistent/path/config.json")
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_TENANT_ID", "tenant-env")
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "workspace-env")
+
+	cfg := applyOptions(t, DefaultClientOptions())
+	if cfg.TenantID != "workspace-env" {
+		t.Fatalf("expected LANGSMITH_WORKSPACE_ID to override tenant ID, got %q", cfg.TenantID)
+	}
+	if got := cfg.Request.Header.Get("X-Tenant-Id"); got != "workspace-env" {
+		t.Fatalf("expected X-Tenant-Id header from workspace env, got %q", got)
+	}
+}
+
+func TestLoadProfileOptions_OAuthAccessToken(t *testing.T) {
+	clearAuthEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_url": "https://api.smith.langchain.com",
+      "oauth": {
+        "access_token": "test-access-token"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := loadProfileOptions()
+	cfg := applyOptions(t, opts)
+	if cfg.OAuthAccessToken != "test-access-token" {
+		t.Fatalf("expected profile access token to become OAuth access token, got %q", cfg.OAuthAccessToken)
+	}
+	if got := cfg.Request.Header.Get("authorization"); got != "Bearer test-access-token" {
+		t.Fatalf("expected Authorization bearer header, got %q", got)
+	}
+}
+
+func TestLoadProfileOptions_RefreshesExpiredAccessToken(t *testing.T) {
+	clearAuthEnv(t)
+	tokenRequests := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		tokenRequests++
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if got := r.FormValue("grant_type"); got != "refresh_token" {
+			t.Fatalf("expected refresh_token grant, got %q", got)
+		}
+		if got := r.FormValue("client_id"); got != oauthClientID {
+			t.Fatalf("expected client_id %q, got %q", oauthClientID, got)
+		}
+		if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
+			t.Fatalf("expected old refresh token, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken:  "new-access-token",
+			ExpiresIn:    300,
+			RefreshToken: "new-refresh-token",
+		})
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_url": "` + ts.URL + `",
+      "oauth": {
+        "access_token": "old-access-token",
+        "refresh_token": "old-refresh-token",
+        "expires_at": "` + time.Now().Add(-time.Minute).UTC().Format(time.RFC3339) + `"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := loadProfileOptions()
+	cfg := applyOptions(t, opts)
+	if cfg.OAuthAccessToken != "new-access-token" {
+		t.Fatalf("expected refreshed access token, got %q", cfg.OAuthAccessToken)
+	}
+	if tokenRequests != 1 {
+		t.Fatalf("expected one token request, got %d", tokenRequests)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"access_token": "new-access-token"`) {
+		t.Fatalf("expected refreshed access token to be saved, got:\n%s", data)
+	}
+	if !strings.Contains(string(data), `"refresh_token": "new-refresh-token"`) {
+		t.Fatalf("expected refreshed refresh token to be saved, got:\n%s", data)
+	}
+	if strings.Contains(string(data), `token_type`) || strings.Contains(string(data), `bearer_token`) {
+		t.Fatalf("expected no token_type or bearer_token fields, got:\n%s", data)
+	}
+}
+
+func TestLoadProfileOptions_OAuthAccessTokenOverridesProfileAPIKey(t *testing.T) {
+	clearAuthEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_key": "some-key",
+      "oauth": {
+        "access_token": "oauth-access-token"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := loadProfileOptions()
+	cfg := applyOptions(t, opts)
+	if cfg.APIKey != "" {
+		t.Fatalf("expected profile OAuth token to take precedence over profile API key")
+	}
+	if cfg.OAuthAccessToken != "oauth-access-token" {
+		t.Fatalf("expected profile OAuth token, got %q", cfg.OAuthAccessToken)
+	}
+	if got := cfg.Request.Header.Get("X-API-Key"); got != "" {
+		t.Fatalf("expected no X-API-Key header, got %q", got)
+	}
+}
+
+func TestLoadProfileOptions_EnvAuthSuppressesProfileAuth(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_key": "profile-key",
+      "api_url": "https://profile.example.com",
+      "workspace_id": "ws-profile",
+      "oauth": {
+        "access_token": "profile-access-token"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+	t.Setenv("LANGSMITH_API_KEY", "env-api-key")
+
+	opts := loadProfileOptions()
+	cfg := applyOptions(t, opts)
+	if cfg.APIKey != "" || cfg.OAuthAccessToken != "" {
+		t.Fatalf("expected profile auth to be suppressed when env auth is set")
+	}
+	if got := cfg.Request.Header.Get("authorization"); got != "" {
+		t.Fatalf("expected no profile Authorization header, got %q", got)
+	}
+	if cfg.TenantID != "ws-profile" {
+		t.Fatalf("expected profile workspace to remain available, got %q", cfg.TenantID)
+	}
+}
+
+func applyOptions(t *testing.T, opts []option.RequestOption) requestconfig.RequestConfig {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := requestconfig.RequestConfig{Request: req, HTTPClient: http.DefaultClient}
+	if err := cfg.Apply(opts...); err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+func clearAuthEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -30,7 +30,6 @@ func TestDatasetNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.New(context.TODO(), langsmith.DatasetNewParams{
 		Name:              langsmith.F("name"),
@@ -75,7 +74,6 @@ func TestDatasetGet(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Get(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {
@@ -100,7 +98,6 @@ func TestDatasetUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Update(
 		context.TODO(),
@@ -168,7 +165,6 @@ func TestDatasetListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.List(context.TODO(), langsmith.DatasetListParams{
 		ID:                         langsmith.F([]string{"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"}),
@@ -206,7 +202,6 @@ func TestDatasetDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Delete(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {
@@ -231,7 +226,6 @@ func TestDatasetCloneWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Clone(context.TODO(), langsmith.DatasetCloneParams{
 		SourceDatasetID: langsmith.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),
@@ -262,7 +256,6 @@ func TestDatasetGetCsvWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.GetCsv(
 		context.TODO(),
@@ -293,7 +286,6 @@ func TestDatasetGetJSONLWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.GetJSONL(
 		context.TODO(),
@@ -324,7 +316,6 @@ func TestDatasetGetOpenAIWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.GetOpenAI(
 		context.TODO(),
@@ -355,7 +346,6 @@ func TestDatasetGetOpenAIFtWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.GetOpenAIFt(
 		context.TODO(),
@@ -386,7 +376,6 @@ func TestDatasetGetVersionWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.GetVersion(
 		context.TODO(),
@@ -418,7 +407,6 @@ func TestDatasetUpdateTags(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.UpdateTags(
 		context.TODO(),
@@ -450,7 +438,6 @@ func TestDatasetUploadWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Upload(context.TODO(), langsmith.DatasetUploadParams{
 		File:                    langsmith.F(io.Reader(bytes.NewBuffer([]byte("Example data")))),

--- a/datasetcomparative_test.go
+++ b/datasetcomparative_test.go
@@ -27,7 +27,6 @@ func TestDatasetComparativeNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Comparative.New(context.TODO(), langsmith.DatasetComparativeNewParams{
 		ExperimentIDs: langsmith.F([]string{"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"}),
@@ -63,7 +62,6 @@ func TestDatasetComparativeDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Comparative.Delete(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {

--- a/datasetexperiment_test.go
+++ b/datasetexperiment_test.go
@@ -27,7 +27,6 @@ func TestDatasetExperimentGroupedWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Experiments.Grouped(
 		context.TODO(),

--- a/datasetgroup_test.go
+++ b/datasetgroup_test.go
@@ -26,7 +26,6 @@ func TestDatasetGroupRunsWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Group.Runs(
 		context.TODO(),

--- a/datasetplaygroundexperiment_test.go
+++ b/datasetplaygroundexperiment_test.go
@@ -26,7 +26,6 @@ func TestDatasetPlaygroundExperimentBatchWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.PlaygroundExperiment.Batch(context.TODO(), langsmith.DatasetPlaygroundExperimentBatchParams{
 		DatasetID: langsmith.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),
@@ -90,7 +89,6 @@ func TestDatasetPlaygroundExperimentStreamWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.PlaygroundExperiment.Stream(context.TODO(), langsmith.DatasetPlaygroundExperimentStreamParams{
 		DatasetID: langsmith.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),

--- a/datasetrun_test.go
+++ b/datasetrun_test.go
@@ -26,7 +26,6 @@ func TestDatasetRunNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Runs.New(
 		context.TODO(),
@@ -71,7 +70,6 @@ func TestDatasetRunDeltaWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Runs.Delta(
 		context.TODO(),

--- a/datasetshare_test.go
+++ b/datasetshare_test.go
@@ -26,7 +26,6 @@ func TestDatasetShareNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Share.New(
 		context.TODO(),
@@ -57,7 +56,6 @@ func TestDatasetShareGet(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Share.Get(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {
@@ -82,7 +80,6 @@ func TestDatasetShareDeleteAll(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Share.DeleteAll(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {

--- a/datasetsplit_test.go
+++ b/datasetsplit_test.go
@@ -28,7 +28,6 @@ func TestDatasetSplitNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Splits.New(
 		context.TODO(),
@@ -61,7 +60,6 @@ func TestDatasetSplitGetWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Splits.Get(
 		context.TODO(),

--- a/datasetversion_test.go
+++ b/datasetversion_test.go
@@ -28,7 +28,6 @@ func TestDatasetVersionListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Versions.List(
 		context.TODO(),
@@ -62,7 +61,6 @@ func TestDatasetVersionGetDiff(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Datasets.Versions.GetDiff(
 		context.TODO(),

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -26,7 +26,6 @@ func TestEvaluatorListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Evaluators.List(context.TODO(), langsmith.EvaluatorListParams{
 		ID:                      langsmith.F([]string{"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"}),

--- a/example_test.go
+++ b/example_test.go
@@ -30,7 +30,6 @@ func TestExampleNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.New(context.TODO(), langsmith.ExampleNewParams{
 		DatasetID: langsmith.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),
@@ -73,7 +72,6 @@ func TestExampleGetWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.Get(
 		context.TODO(),
@@ -105,7 +103,6 @@ func TestExampleUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.Update(
 		context.TODO(),
@@ -153,7 +150,6 @@ func TestExampleListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.List(context.TODO(), langsmith.ExampleListParams{
 		ID:               langsmith.F([]string{"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"}),
@@ -192,7 +188,6 @@ func TestExampleDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.Delete(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {
@@ -217,7 +212,6 @@ func TestExampleDeleteAll(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.DeleteAll(context.TODO(), langsmith.ExampleDeleteAllParams{
 		ExampleIDs: langsmith.F([]string{"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"}),
@@ -244,7 +238,6 @@ func TestExampleGetCountWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.GetCount(context.TODO(), langsmith.ExampleGetCountParams{
 		ID:               langsmith.F([]string{"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"}),
@@ -277,7 +270,6 @@ func TestExampleUploadFromCsvWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.UploadFromCsv(
 		context.TODO(),

--- a/examplebulk_test.go
+++ b/examplebulk_test.go
@@ -26,7 +26,6 @@ func TestExampleBulkNew(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.Bulk.New(context.TODO(), langsmith.ExampleBulkNewParams{
 		Body: []langsmith.ExampleBulkNewParamsBody{{
@@ -71,7 +70,6 @@ func TestExampleBulkPatchAll(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.Bulk.PatchAll(context.TODO(), langsmith.ExampleBulkPatchAllParams{
 		Body: []langsmith.ExampleBulkPatchAllParamsBody{{

--- a/examplevalidate_test.go
+++ b/examplevalidate_test.go
@@ -26,7 +26,6 @@ func TestExampleValidateNew(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.Validate.New(context.TODO())
 	if err != nil {
@@ -51,7 +50,6 @@ func TestExampleValidateBulk(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Examples.Validate.Bulk(context.TODO())
 	if err != nil {

--- a/feedback_test.go
+++ b/feedback_test.go
@@ -28,7 +28,6 @@ func TestFeedbackNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Feedback.New(context.TODO(), langsmith.FeedbackNewParams{
 		FeedbackCreateSchema: langsmith.FeedbackCreateSchemaParam{
@@ -88,7 +87,6 @@ func TestFeedbackGetWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Feedback.Get(
 		context.TODO(),
@@ -119,7 +117,6 @@ func TestFeedbackUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Feedback.Update(
 		context.TODO(),
@@ -164,7 +161,6 @@ func TestFeedbackListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Feedback.List(context.TODO(), langsmith.FeedbackListParams{
 		ComparativeExperimentID: langsmith.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),
@@ -204,7 +200,6 @@ func TestFeedbackDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Feedback.Delete(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {

--- a/feedbackconfig_test.go
+++ b/feedbackconfig_test.go
@@ -26,7 +26,6 @@ func TestFeedbackConfigDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	err := client.Feedback.Configs.Delete(context.TODO(), langsmith.FeedbackConfigDeleteParams{
 		FeedbackKey: langsmith.F("feedback_key"),

--- a/feedbacktoken_test.go
+++ b/feedbacktoken_test.go
@@ -28,7 +28,6 @@ func TestFeedbackTokenNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Feedback.Tokens.New(context.TODO(), langsmith.FeedbackTokenNewParams{
 		Body: langsmith.FeedbackIngestTokenCreateSchemaParam{
@@ -73,7 +72,6 @@ func TestFeedbackTokenGetWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Feedback.Tokens.Get(
 		context.TODO(),
@@ -107,7 +105,6 @@ func TestFeedbackTokenUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Feedback.Tokens.Update(
 		context.TODO(),
@@ -146,7 +143,6 @@ func TestFeedbackTokenList(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Feedback.Tokens.List(context.TODO(), langsmith.FeedbackTokenListParams{
 		RunID: langsmith.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),

--- a/integration/profile_test.go
+++ b/integration/profile_test.go
@@ -1,0 +1,213 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/langchain-ai/langsmith-go"
+)
+
+// newClientFromProfile creates a client that resolves credentials from a
+// temporary config profile rather than environment variables.
+func newClientFromProfile(t *testing.T, profileName, configContent string) *langsmith.Client {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	if profileName != "" {
+		t.Setenv("LANGSMITH_PROFILE", profileName)
+	} else {
+		os.Unsetenv("LANGSMITH_PROFILE")
+	}
+	// Unset env vars so the profile is the only credential source.
+	// os.Unsetenv is needed because t.Setenv("X", "") makes LookupEnv
+	// return (true, ""), which the SDK interprets as an explicit empty override.
+	envVars := []string{"LANGSMITH_API_KEY", "LANGSMITH_ENDPOINT", "LANGSMITH_TENANT_ID"}
+	saved := make(map[string]string)
+	for _, k := range envVars {
+		if v, ok := os.LookupEnv(k); ok {
+			saved[k] = v
+		}
+		os.Unsetenv(k)
+	}
+	t.Cleanup(func() {
+		for k, v := range saved {
+			os.Setenv(k, v)
+		}
+	})
+	return langsmith.NewClient()
+}
+
+// TestProfileClient_ListSessions verifies that a client created entirely from
+// a config profile (no env vars) can successfully authenticate and list sessions.
+func TestProfileClient_ListSessions(t *testing.T) {
+	// We need real credentials — read them from the env BEFORE clearing.
+	apiKey := os.Getenv("LANGSMITH_API_KEY")
+	if apiKey == "" {
+		t.Skip("LANGSMITH_API_KEY not set, skipping profile integration test")
+	}
+	endpoint := os.Getenv("LANGSMITH_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.smith.langchain.com"
+	}
+
+	config := `{
+  "current_profile": "integ",
+  "profiles": {
+    "integ": {
+      "api_key": "` + apiKey + `",
+      "api_url": "` + endpoint + `"
+    }
+  }
+}
+`
+	client := newClientFromProfile(t, "integ", config)
+
+	resp, err := client.Sessions.List(context.Background(), langsmith.SessionListParams{
+		Limit: langsmith.F(int64(1)),
+	})
+	if err != nil {
+		t.Fatalf("list sessions via profile: %v", err)
+	}
+	// We just need to confirm the API accepted the request — at least 0 results is fine.
+	_ = resp.Items
+}
+
+// TestProfileClient_DatasetCRUD verifies a full CRUD cycle using profile-based auth.
+func TestProfileClient_DatasetCRUD(t *testing.T) {
+	apiKey := os.Getenv("LANGSMITH_API_KEY")
+	if apiKey == "" {
+		t.Skip("LANGSMITH_API_KEY not set, skipping profile integration test")
+	}
+	endpoint := os.Getenv("LANGSMITH_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.smith.langchain.com"
+	}
+
+	config := `{
+  "profiles": {
+    "default": {
+      "api_key": "` + apiKey + `",
+      "api_url": "` + endpoint + `"
+    }
+  }
+}
+`
+	// Uses "default" profile via fallback (no current_profile, no LANGSMITH_PROFILE).
+	client := newClientFromProfile(t, "", config)
+
+	ctx := context.Background()
+	name := uniqueName("go-integ-profile-dataset")
+
+	// Create
+	dataset, err := client.Datasets.New(ctx, langsmith.DatasetNewParams{
+		Name:        langsmith.F(name),
+		Description: langsmith.F("Profile integration test"),
+	})
+	if err != nil {
+		t.Fatalf("create dataset: %v", err)
+	}
+	defer client.Datasets.Delete(ctx, dataset.ID)
+
+	if dataset.Name != name {
+		t.Errorf("name = %q, want %q", dataset.Name, name)
+	}
+
+	// List
+	listed, err := client.Datasets.List(ctx, langsmith.DatasetListParams{
+		Name: langsmith.F(name),
+	})
+	if err != nil {
+		t.Fatalf("list datasets: %v", err)
+	}
+	if len(listed.Items) == 0 {
+		t.Error("expected at least one dataset")
+	}
+}
+
+// TestProfileClient_EnvProfileSelection verifies that LANGSMITH_PROFILE env
+// var correctly selects the named profile.
+func TestProfileClient_EnvProfileSelection(t *testing.T) {
+	apiKey := os.Getenv("LANGSMITH_API_KEY")
+	if apiKey == "" {
+		t.Skip("LANGSMITH_API_KEY not set, skipping profile integration test")
+	}
+	endpoint := os.Getenv("LANGSMITH_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.smith.langchain.com"
+	}
+
+	config := `{
+  "current_profile": "wrong",
+  "profiles": {
+    "wrong": {
+      "api_key": "invalid-key-should-not-be-used",
+      "api_url": "` + endpoint + `"
+    },
+    "correct": {
+      "api_key": "` + apiKey + `",
+      "api_url": "` + endpoint + `"
+    }
+  }
+}
+`
+	// LANGSMITH_PROFILE should override current_profile.
+	client := newClientFromProfile(t, "correct", config)
+
+	_, err := client.Sessions.List(context.Background(), langsmith.SessionListParams{
+		Limit: langsmith.F(int64(1)),
+	})
+	if err != nil {
+		t.Fatalf("expected success with 'correct' profile, got: %v", err)
+	}
+}
+
+// TestProfileClient_EnvOverridesProfile verifies that environment variables
+// take precedence over profile values. The profile has an invalid key, but
+// the env var provides the real one.
+func TestProfileClient_EnvOverridesProfile(t *testing.T) {
+	apiKey := os.Getenv("LANGSMITH_API_KEY")
+	if apiKey == "" {
+		t.Skip("LANGSMITH_API_KEY not set, skipping profile integration test")
+	}
+	endpoint := os.Getenv("LANGSMITH_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.smith.langchain.com"
+	}
+
+	// Profile has a bad key — env var should override it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	config := `{
+  "profiles": {
+    "default": {
+      "api_key": "invalid-key-from-profile",
+      "api_url": "` + endpoint + `"
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(config), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	// Set the real key via env — this should override the profile's bad key.
+	t.Setenv("LANGSMITH_API_KEY", apiKey)
+	t.Setenv("LANGSMITH_ENDPOINT", endpoint)
+	os.Unsetenv("LANGSMITH_PROFILE")
+
+	client := langsmith.NewClient()
+	_, err := client.Sessions.List(context.Background(), langsmith.SessionListParams{
+		Limit: langsmith.F(int64(1)),
+	})
+	if err != nil {
+		t.Fatalf("env var should override profile's bad key, got: %v", err)
+	}
+}

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -218,14 +218,13 @@ type RequestConfig struct {
 	BaseURL        *url.URL
 	// DefaultBaseURL will be used if BaseURL is not explicitly overridden using
 	// WithBaseURL.
-	DefaultBaseURL *url.URL
-	CustomHTTPDoer HTTPDoer
-	HTTPClient     *http.Client
-	Middlewares    []middleware
-	APIKey         string
-	TenantID       string
-	BearerToken    string
-	OrganizationID string
+	DefaultBaseURL   *url.URL
+	CustomHTTPDoer   HTTPDoer
+	HTTPClient       *http.Client
+	Middlewares      []middleware
+	APIKey           string
+	TenantID         string
+	OAuthAccessToken string
 	// If ResponseBodyInto not nil, then we will attempt to deserialize into
 	// ResponseBodyInto. If Destination is a []byte, then it will return the body as
 	// is.
@@ -592,17 +591,16 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 		return nil
 	}
 	new := &RequestConfig{
-		MaxRetries:     cfg.MaxRetries,
-		RequestTimeout: cfg.RequestTimeout,
-		Context:        ctx,
-		Request:        req,
-		BaseURL:        cfg.BaseURL,
-		HTTPClient:     cfg.HTTPClient,
-		Middlewares:    cfg.Middlewares,
-		APIKey:         cfg.APIKey,
-		TenantID:       cfg.TenantID,
-		BearerToken:    cfg.BearerToken,
-		OrganizationID: cfg.OrganizationID,
+		MaxRetries:       cfg.MaxRetries,
+		RequestTimeout:   cfg.RequestTimeout,
+		Context:          ctx,
+		Request:          req,
+		BaseURL:          cfg.BaseURL,
+		HTTPClient:       cfg.HTTPClient,
+		Middlewares:      cfg.Middlewares,
+		APIKey:           cfg.APIKey,
+		TenantID:         cfg.TenantID,
+		OAuthAccessToken: cfg.OAuthAccessToken,
 	}
 
 	return new

--- a/lib/langsmithtracing/internal/models/write_endpoint.go
+++ b/lib/langsmithtracing/internal/models/write_endpoint.go
@@ -4,17 +4,17 @@ import "net/http"
 
 // WriteEndpoint identifies a LangSmith API endpoint to send traces to.
 type WriteEndpoint struct {
-	URL          string
-	Key          string // API key (sent as X-API-Key header).
-	BearerToken  string // Bearer token (sent as Authorization header); takes precedence over Key.
-	Project      string
+	URL              string
+	Key              string // API key (sent as X-API-Key header).
+	OAuthAccessToken string // OAuth access token (sent as Authorization header); takes precedence over Key.
+	Project          string
 }
 
 // SetAuthHeader sets the appropriate authentication header on req.
-// Bearer token takes precedence over API key.
+// OAuth access token takes precedence over API key.
 func (ep WriteEndpoint) SetAuthHeader(req *http.Request) {
-	if ep.BearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+ep.BearerToken)
+	if ep.OAuthAccessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+ep.OAuthAccessToken)
 	} else if ep.Key != "" {
 		req.Header.Set("X-API-Key", ep.Key)
 	}

--- a/lib/langsmithtracing/tracing.go
+++ b/lib/langsmithtracing/tracing.go
@@ -41,11 +41,11 @@ type TracingClient struct {
 	project string
 	logger  ilog.Logger
 
-	sampleRate         *float64
-	mergeEnvMetadata   bool
-	filteredMu         sync.Mutex
-	filteredTraces     map[uuid.UUID]time.Time
-	filteredLastPrune  time.Time
+	sampleRate        *float64
+	mergeEnvMetadata  bool
+	filteredMu        sync.Mutex
+	filteredTraces    map[uuid.UUID]time.Time
+	filteredLastPrune time.Time
 }
 
 // RunCreate holds parameters for creating a new run (multipart post).
@@ -58,13 +58,13 @@ type RunCreate struct {
 	Name        string
 	RunType     string // "chain", "llm", "tool", etc.
 	Inputs      map[string]any
-	Outputs     map[string]any        // Set to create a complete run in one call.
+	Outputs     map[string]any // Set to create a complete run in one call.
 	Extra       map[string]any
-	Events      []map[string]any      // e.g. [{"name":"new_token","time":"...","kwargs":{...}}]
-	Serialized  map[string]any        // Model manifest; only retained for "llm"/"prompt" run types.
+	Events      []map[string]any // e.g. [{"name":"new_token","time":"...","kwargs":{...}}]
+	Serialized  map[string]any   // Model manifest; only retained for "llm"/"prompt" run types.
 	Tags        []string
 	StartTime   time.Time
-	EndTime     time.Time             // Set to create a complete run in one call.
+	EndTime     time.Time // Set to create a complete run in one call.
 	DottedOrder string
 	Error       string                // Set to create a failed run in one call.
 	Attachments map[string]Attachment // keyed by name; names must not contain '.'
@@ -82,14 +82,14 @@ type RunUpdate struct {
 	ID          uuid.UUID
 	TraceID     uuid.UUID
 	Outputs     map[string]any
-	Inputs      map[string]any        // override/replace inputs set at create time
-	Extra       map[string]any        // override/replace extra set at create time
-	Events      []map[string]any      // e.g. [{"name":"new_token","time":"..."}]
-	Name        string                // rename the run
-	RunType     string                // change run type ("chain", "llm", "tool", etc.)
-	Tags        []string              // add or replace tags
+	Inputs      map[string]any   // override/replace inputs set at create time
+	Extra       map[string]any   // override/replace extra set at create time
+	Events      []map[string]any // e.g. [{"name":"new_token","time":"..."}]
+	Name        string           // rename the run
+	RunType     string           // change run type ("chain", "llm", "tool", etc.)
+	Tags        []string         // add or replace tags
 	EndTime     time.Time
-	StartTime   time.Time             // adjust start time
+	StartTime   time.Time // adjust start time
 	DottedOrder string
 	Error       string
 	Attachments map[string]Attachment // keyed by name; names must not contain '.'
@@ -112,7 +112,7 @@ type Option func(*options)
 type options struct {
 	apiURL              string
 	apiKey              string
-	bearerToken         string
+	oauthAccessToken    string
 	project             string
 	drainConfig         *tracesink.DrainConfig
 	sampleRate          *float64
@@ -128,9 +128,11 @@ func WithAPIURL(url string) Option { return func(o *options) { o.apiURL = url } 
 // WithAPIKey overrides the LangSmith API key.
 func WithAPIKey(key string) Option { return func(o *options) { o.apiKey = key } }
 
-// WithBearerToken sets a bearer token for authentication.
+// WithOAuthAccessToken sets an OAuth access token for authentication.
 // When set, it takes precedence over the API key.
-func WithBearerToken(token string) Option { return func(o *options) { o.bearerToken = token } }
+func WithOAuthAccessToken(token string) Option {
+	return func(o *options) { o.oauthAccessToken = token }
+}
 
 // WithProject overrides the LangSmith project name.
 func WithProject(name string) Option { return func(o *options) { o.project = name } }
@@ -213,23 +215,23 @@ func NewTracingClient(ctx context.Context, opts ...Option) (*TracingClient, erro
 	}
 
 	endpoint := models.WriteEndpoint{
-		URL:         cfg.apiURL,
-		Key:         cfg.apiKey,
-		BearerToken: cfg.bearerToken,
-		Project:     cfg.project,
+		URL:              cfg.apiURL,
+		Key:              cfg.apiKey,
+		OAuthAccessToken: cfg.oauthAccessToken,
+		Project:          cfg.project,
 	}
 
 	exp := multipart.NewExporter(nil, multipart.DefaultRetry(), cfg.compressionDisabled, l)
 	sink := tracesink.NewTraceSink(ctx, exp, drainCfg, endpoint, cfg.runTransform, l)
 
 	return &TracingClient{
-		sink:               sink,
-		logger:             l,
-		project:            cfg.project,
-		sampleRate:         sampleRate,
-		mergeEnvMetadata:   cfg.mergeEnvMetadata,
-		filteredTraces:     make(map[uuid.UUID]time.Time),
-		filteredLastPrune:  time.Now(),
+		sink:              sink,
+		logger:            l,
+		project:           cfg.project,
+		sampleRate:        sampleRate,
+		mergeEnvMetadata:  cfg.mergeEnvMetadata,
+		filteredTraces:    make(map[uuid.UUID]time.Time),
+		filteredLastPrune: time.Now(),
 	}, nil
 }
 
@@ -423,7 +425,7 @@ func (c *TracingClient) Close() {
 
 // shouldSampleCreate decides whether a create (post) should be kept.
 // For root runs (id == traceID), a random check is made against the sample rate.
-// Child runs follow the decision of their root. 
+// Child runs follow the decision of their root.
 func (c *TracingClient) shouldSampleCreate(id, traceID uuid.UUID) bool {
 	if c.sampleRate == nil {
 		return true

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -281,19 +281,3 @@ func WithTenantID(value string) RequestOption {
 		return r.Apply(WithHeader("X-Tenant-Id", r.TenantID))
 	})
 }
-
-// WithBearerToken returns a RequestOption that sets the client setting "bearer_token".
-func WithBearerToken(value string) RequestOption {
-	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
-		r.BearerToken = value
-		return r.Apply(WithHeader("authorization", fmt.Sprintf("Bearer %s", r.BearerToken)))
-	})
-}
-
-// WithOrganizationID returns a RequestOption that sets the client setting "organization_id".
-func WithOrganizationID(value string) RequestOption {
-	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
-		r.OrganizationID = value
-		return r.Apply(WithHeader("X-Organization-Id", r.OrganizationID))
-	})
-}

--- a/paginationauto_test.go
+++ b/paginationauto_test.go
@@ -27,7 +27,6 @@ func TestAutoPagination(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	iter := client.Datasets.ListAutoPaging(context.TODO(), langsmith.DatasetListParams{
 		Limit: langsmith.F(int64(100)),

--- a/paginationmanual_test.go
+++ b/paginationmanual_test.go
@@ -27,7 +27,6 @@ func TestManualPagination(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	page, err := client.Datasets.List(context.TODO(), langsmith.DatasetListParams{
 		Limit: langsmith.F(int64(100)),

--- a/public_test.go
+++ b/public_test.go
@@ -26,7 +26,6 @@ func TestPublicGetFeedbacksWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Public.GetFeedbacks(
 		context.TODO(),

--- a/publicdataset_test.go
+++ b/publicdataset_test.go
@@ -26,7 +26,6 @@ func TestPublicDatasetListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Public.Datasets.List(
 		context.TODO(),
@@ -60,7 +59,6 @@ func TestPublicDatasetListComparativeWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Public.Datasets.ListComparative(
 		context.TODO(),
@@ -96,7 +94,6 @@ func TestPublicDatasetListFeedbackWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Public.Datasets.ListFeedback(
 		context.TODO(),
@@ -136,7 +133,6 @@ func TestPublicDatasetListSessionsWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Public.Datasets.ListSessions(
 		context.TODO(),
@@ -177,7 +173,6 @@ func TestPublicDatasetGetSessionsBulk(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Public.Datasets.GetSessionsBulk(context.TODO(), langsmith.PublicDatasetGetSessionsBulkParams{
 		ShareTokens: langsmith.F([]string{"string"}),

--- a/repo_test.go
+++ b/repo_test.go
@@ -26,7 +26,6 @@ func TestRepoNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Repos.New(context.TODO(), langsmith.RepoNewParams{
 		IsPublic:       langsmith.F(true),
@@ -59,7 +58,6 @@ func TestRepoGet(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Repos.Get(
 		context.TODO(),
@@ -88,7 +86,6 @@ func TestRepoUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Repos.Update(
 		context.TODO(),
@@ -125,7 +122,6 @@ func TestRepoListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Repos.List(context.TODO(), langsmith.RepoListParams{
 		HasCommits:         langsmith.F(true),
@@ -168,7 +164,6 @@ func TestRepoDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Repos.Delete(
 		context.TODO(),

--- a/run_test.go
+++ b/run_test.go
@@ -27,7 +27,6 @@ func TestRunNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Runs.New(context.TODO(), langsmith.RunNewParams{
 		Run: langsmith.RunParam{
@@ -90,7 +89,6 @@ func TestRunGetWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Runs.Get(
 		context.TODO(),
@@ -125,7 +123,6 @@ func TestRunUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Runs.Update(
 		context.TODO(),
@@ -192,7 +189,6 @@ func TestRunIngestBatchWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Runs.IngestBatch(context.TODO(), langsmith.RunIngestBatchParams{
 		Patch: langsmith.F([]langsmith.RunParam{{
@@ -292,7 +288,6 @@ func TestRunQueryWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Runs.Query(context.TODO(), langsmith.RunQueryParams{
 		ID:                    langsmith.F([]string{"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"}),
@@ -342,7 +337,6 @@ func TestRunStatsWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Runs.Stats(context.TODO(), langsmith.RunStatsParams{
 		RunStatsQueryParams: langsmith.RunStatsQueryParams{
@@ -396,7 +390,6 @@ func TestRunUpdate2(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Runs.Update2(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {

--- a/sandboxbox_test.go
+++ b/sandboxbox_test.go
@@ -26,7 +26,6 @@ func TestSandboxBoxNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Boxes.New(context.TODO(), langsmith.SandboxBoxNewParams{
 		FsCapacityBytes: langsmith.F(int64(0)),
@@ -93,7 +92,6 @@ func TestSandboxBoxGet(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Boxes.Get(context.TODO(), "name")
 	if err != nil {
@@ -118,7 +116,6 @@ func TestSandboxBoxUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Boxes.Update(
 		context.TODO(),
@@ -184,7 +181,6 @@ func TestSandboxBoxListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Boxes.List(context.TODO(), langsmith.SandboxBoxListParams{
 		Limit:         langsmith.F(int64(0)),
@@ -217,7 +213,6 @@ func TestSandboxBoxDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	err := client.Sandboxes.Boxes.Delete(context.TODO(), "name")
 	if err != nil {
@@ -242,7 +237,6 @@ func TestSandboxBoxNewSnapshotWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Boxes.NewSnapshot(
 		context.TODO(),
@@ -274,7 +268,6 @@ func TestSandboxBoxGenerateServiceURLWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Boxes.GenerateServiceURL(
 		context.TODO(),
@@ -306,7 +299,6 @@ func TestSandboxBoxGetStatus(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Boxes.GetStatus(context.TODO(), "name")
 	if err != nil {
@@ -331,7 +323,6 @@ func TestSandboxBoxStart(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Boxes.Start(context.TODO(), "name")
 	if err != nil {
@@ -356,7 +347,6 @@ func TestSandboxBoxStop(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	err := client.Sandboxes.Boxes.Stop(context.TODO(), "name")
 	if err != nil {

--- a/sandboxpool_test.go
+++ b/sandboxpool_test.go
@@ -26,7 +26,6 @@ func TestSandboxPoolNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Pools.New(context.TODO(), langsmith.SandboxPoolNewParams{
 		Name:         langsmith.F("name"),
@@ -57,7 +56,6 @@ func TestSandboxPoolGet(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Pools.Get(context.TODO(), "name")
 	if err != nil {
@@ -82,7 +80,6 @@ func TestSandboxPoolUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Pools.Update(
 		context.TODO(),
@@ -114,7 +111,6 @@ func TestSandboxPoolListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Pools.List(context.TODO(), langsmith.SandboxPoolListParams{
 		Limit:        langsmith.F(int64(0)),
@@ -143,7 +139,6 @@ func TestSandboxPoolDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	err := client.Sandboxes.Pools.Delete(context.TODO(), "name")
 	if err != nil {

--- a/sandboxsnapshot_test.go
+++ b/sandboxsnapshot_test.go
@@ -26,7 +26,6 @@ func TestSandboxSnapshotNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Snapshots.New(context.TODO(), langsmith.SandboxSnapshotNewParams{
 		DockerImage:     langsmith.F("docker_image"),
@@ -56,7 +55,6 @@ func TestSandboxSnapshotGet(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Snapshots.Get(context.TODO(), "snapshot_id")
 	if err != nil {
@@ -81,7 +79,6 @@ func TestSandboxSnapshotListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Snapshots.List(context.TODO(), langsmith.SandboxSnapshotListParams{
 		Limit:         langsmith.F(int64(0)),
@@ -113,7 +110,6 @@ func TestSandboxSnapshotDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	err := client.Sandboxes.Snapshots.Delete(context.TODO(), "snapshot_id")
 	if err != nil {

--- a/sandboxtemplate_test.go
+++ b/sandboxtemplate_test.go
@@ -26,7 +26,6 @@ func TestSandboxTemplateListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sandboxes.Templates.List(context.TODO(), langsmith.SandboxTemplateListParams{
 		Limit:         langsmith.F(int64(0)),

--- a/session_test.go
+++ b/session_test.go
@@ -27,7 +27,6 @@ func TestSessionNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.New(context.TODO(), langsmith.SessionNewParams{
 		Upsert:           langsmith.F(true),
@@ -65,7 +64,6 @@ func TestSessionGetWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Get(
 		context.TODO(),
@@ -98,7 +96,6 @@ func TestSessionUpdateWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Update(
 		context.TODO(),
@@ -136,7 +133,6 @@ func TestSessionListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.List(context.TODO(), langsmith.SessionListParams{
 		ID:                langsmith.F([]string{"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"}),
@@ -181,7 +177,6 @@ func TestSessionDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Delete(context.TODO(), "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
 	if err != nil {
@@ -206,7 +201,6 @@ func TestSessionDashboardWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Dashboard(
 		context.TODO(),

--- a/sessioninsight_test.go
+++ b/sessioninsight_test.go
@@ -27,7 +27,6 @@ func TestSessionInsightNewWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Insights.New(
 		context.TODO(),
@@ -82,7 +81,6 @@ func TestSessionInsightUpdate(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Insights.Update(
 		context.TODO(),
@@ -114,7 +112,6 @@ func TestSessionInsightListWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Insights.List(
 		context.TODO(),
@@ -148,7 +145,6 @@ func TestSessionInsightDelete(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Insights.Delete(
 		context.TODO(),
@@ -177,7 +173,6 @@ func TestSessionInsightGetJob(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Insights.GetJob(
 		context.TODO(),
@@ -206,7 +201,6 @@ func TestSessionInsightGetRunsWithOptionalParams(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Sessions.Insights.GetRuns(
 		context.TODO(),

--- a/setting_test.go
+++ b/setting_test.go
@@ -26,7 +26,6 @@ func TestSettingList(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	_, err := client.Settings.List(context.TODO())
 	if err != nil {

--- a/tracing.go
+++ b/tracing.go
@@ -37,11 +37,10 @@ func DefaultDrainConfig() DrainConfig { return langsmithtracing.DefaultDrainConf
 
 // Tracing option constructors.
 var (
-	WithTracingAPIURL        = langsmithtracing.WithAPIURL
-	WithTracingAPIKey        = langsmithtracing.WithAPIKey
-	WithTracingBearerToken   = langsmithtracing.WithBearerToken
-	WithTracingProject       = langsmithtracing.WithProject
-	WithTracingDrain         = langsmithtracing.WithDrainConfig
+	WithTracingAPIURL                     = langsmithtracing.WithAPIURL
+	WithTracingAPIKey                     = langsmithtracing.WithAPIKey
+	WithTracingProject                    = langsmithtracing.WithProject
+	WithTracingDrain                      = langsmithtracing.WithDrainConfig
 	WithSampleRate                        = langsmithtracing.WithSampleRate
 	WithRunTransform                      = langsmithtracing.WithRunTransform
 	WithMergeFilteredEnvIntoExtraMetadata = langsmithtracing.WithMergeFilteredEnvIntoExtraMetadata

--- a/usage_test.go
+++ b/usage_test.go
@@ -25,7 +25,6 @@ func TestUsage(t *testing.T) {
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey("My API Key"),
 		option.WithTenantID("My Tenant ID"),
-		option.WithOrganizationID("My Organization ID"),
 	)
 	customChartsSection, err := client.Sessions.Dashboard(
 		context.TODO(),


### PR DESCRIPTION
## Summary
- merge main into next so release PR #61 includes the profile auth changes from main
- keep generated default HTTP client/custom headers behavior while applying profile config before env vars
- remove stale organization option calls from generated sandbox/evaluator tests

## Testing
- go test ./...

This should prevent the release PR from being regenerated without the main-branch custom code.