### PR TITLE
feat: emit new_token span event on first content delta in streaming wrappers

### DIFF
--- a/instrumentation/traceanthropic/traceanthropic.go
+++ b/instrumentation/traceanthropic/traceanthropic.go
@@ -187,7 +187,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return resp, err
 	}
 
-	resp.Body = traceutil.NewBufferedReader(resp.Body, func(r io.Reader, readErr error) {
+	br := traceutil.NewBufferedReader(resp.Body, func(r io.Reader, readErr error) {
 		data, err := io.ReadAll(r)
 		if err != nil {
 			span.RecordError(err)
@@ -239,8 +239,21 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 		span.End()
 	})
+	// LangSmith ingest reads new_token to derive first_token_time; skip on
+	// HTTP errors so an error body doesn't inflate it.
+	if streaming && resp.StatusCode < 400 {
+		traceutil.OnFirstSSEMatch(br, isFirstContent, func() { span.AddEvent("new_token") })
+	}
+	resp.Body = br
 
 	return resp, nil
+}
+
+// Anthropic streams open with message_start and content_block_start before
+// any tokens; content_block_delta is the first real token.
+func isFirstContent(chunk map[string]any) bool {
+	t, _ := chunk["type"].(string)
+	return t == "content_block_delta"
 }
 
 // getSpanName returns an appropriate span name based on the API endpoint.

--- a/instrumentation/traceanthropic/traceanthropic_test.go
+++ b/instrumentation/traceanthropic/traceanthropic_test.go
@@ -1,8 +1,11 @@
 package traceanthropic
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -10,6 +13,158 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+// fakeTransport returns a canned response, capturing the request for inspection.
+type fakeTransport struct {
+	body []byte
+}
+
+func (t *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(t.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+// hasEvent reports whether any exported span contains an event with the given name.
+func hasEvent(spans tracetest.SpanStubs, name string) bool {
+	for _, s := range spans {
+		for _, e := range s.Events {
+			if e.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func newTracedClient(t *testing.T, body []byte) (*http.Client, *tracetest.InMemoryExporter) {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	client := WrapClient(&http.Client{Transport: &fakeTransport{body: body}}, WithTracerProvider(tp))
+	return client, exporter
+}
+
+func doStreamingMessages(t *testing.T, client *http.Client) {
+	t.Helper()
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":16,"stream":true}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.anthropic.com/v1/messages", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+}
+
+func TestRoundTrip_StreamingEmitsNewTokenOnFirstContentDelta(t *testing.T) {
+	// message_start and content_block_start arrive before any text — only the
+	// first content_block_delta should trip new_token.
+	sse := "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"usage\":{\"input_tokens\":3}}}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n" +
+		"data: {\"type\":\"message_stop\"}\n"
+	client, exporter := newTracedClient(t, []byte(sse))
+	doStreamingMessages(t, client)
+
+	if !hasEvent(exporter.GetSpans(), "new_token") {
+		t.Errorf("expected new_token event, got events=%v", exporter.GetSpans())
+	}
+}
+
+func TestRoundTrip_StreamingPreambleOnlyDoesNotEmitNewToken(t *testing.T) {
+	// Stream cancelled after content_block_start but before any content_block_delta.
+	sse := "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"usage\":{\"input_tokens\":3}}}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\"}}\n"
+	client, exporter := newTracedClient(t, []byte(sse))
+	doStreamingMessages(t, client)
+
+	if hasEvent(exporter.GetSpans(), "new_token") {
+		t.Errorf("preamble-only stream should not emit new_token, got %v", exporter.GetSpans())
+	}
+}
+
+// errStatusTransport returns an HTTP error body with no SSE frames.
+type errStatusTransport struct{ body []byte }
+
+func (e *errStatusTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       io.NopCloser(bytes.NewReader(e.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestRoundTrip_StreamingHTTPErrorDoesNotEmitNewToken(t *testing.T) {
+	// stream=true but the API returns an error JSON body — first-token time is
+	// undefined and we must not record one.
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	client := WrapClient(&http.Client{
+		Transport: &errStatusTransport{body: []byte(`{"type":"error","error":{"message":"overloaded"}}`)},
+	}, WithTracerProvider(tp))
+	doStreamingMessages(t, client)
+
+	if hasEvent(exporter.GetSpans(), "new_token") {
+		t.Errorf("streamed HTTP error should not emit new_token, got %v", exporter.GetSpans())
+	}
+}
+
+func TestIsFirstContent(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"message_start", `{"type":"message_start","message":{}}`, false},
+		{"content_block_start", `{"type":"content_block_start","index":0}`, false},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`, true},
+		{"message_delta", `{"type":"message_delta"}`, false},
+		{"message_stop", `{"type":"message_stop"}`, false},
+	}
+	for _, tt := range tests {
+		var c map[string]any
+		_ = json.Unmarshal([]byte(tt.body), &c)
+		if got := isFirstContent(c); got != tt.want {
+			t.Errorf("%s: got %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestRoundTrip_NonStreamingDoesNotEmitNewTokenEvent(t *testing.T) {
+	respBody := `{"model":"claude-sonnet-4-20250514","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":3,"output_tokens":1},"stop_reason":"end_turn"}`
+	client, exporter := newTracedClient(t, []byte(respBody))
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":16}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.anthropic.com/v1/messages", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if hasEvent(exporter.GetSpans(), "new_token") {
+		t.Errorf("non-streaming span should not record a new_token event")
+	}
+}
 
 func TestGetSpanName(t *testing.T) {
 	tests := []struct {

--- a/instrumentation/traceopenai/openaitrace.go
+++ b/instrumentation/traceopenai/openaitrace.go
@@ -148,7 +148,7 @@ func MiddlewareWithTracerProvider(req *http.Request, next MiddlewareNext, tp tra
 		return resp, err
 	}
 
-	resp.Body = traceutil.NewBufferedReader(resp.Body, func(r io.Reader, readErr error) {
+	br := traceutil.NewBufferedReader(resp.Body, func(r io.Reader, readErr error) {
 		data, err := io.ReadAll(r)
 		if err != nil {
 			span.RecordError(err)
@@ -229,8 +229,55 @@ func MiddlewareWithTracerProvider(req *http.Request, next MiddlewareNext, tp tra
 		}
 		span.End()
 	})
+	// LangSmith ingest reads new_token to derive first_token_time; skip on
+	// HTTP errors so an error body doesn't inflate it.
+	if streaming && resp.StatusCode < 400 {
+		isMatch := isFirstContentChat
+		if responsesAPI {
+			isMatch = isFirstContentResponses
+		}
+		traceutil.OnFirstSSEMatch(br, isMatch, func() { span.AddEvent("new_token") })
+	}
+	resp.Body = br
 
 	return resp, nil
+}
+
+// Chat streams open with a delta.role-only preamble; with n>1, content can
+// land first on any choice index.
+func isFirstContentChat(chunk map[string]any) bool {
+	choices, ok := chunk["choices"].([]any)
+	if !ok {
+		return false
+	}
+	for _, raw := range choices {
+		choice, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		// Legacy /v1/completions: text on the choice itself.
+		if text, ok := choice["text"].(string); ok && text != "" {
+			return true
+		}
+		delta, ok := choice["delta"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if text, ok := delta["content"].(string); ok && text != "" {
+			return true
+		}
+		if tcs, ok := delta["tool_calls"].([]any); ok && len(tcs) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Responses API uses *.delta event types for tokens; lifecycle envelopes
+// (response.created, .in_progress, .completed, …) don't.
+func isFirstContentResponses(chunk map[string]any) bool {
+	t, _ := chunk["type"].(string)
+	return strings.HasSuffix(t, ".delta")
 }
 
 // isOpenAIEndpoint returns true if the path matches a known OpenAI API endpoint.

--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -1,10 +1,265 @@
 package traceopenai
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+// fakeTransport returns a canned response, capturing the request for inspection.
+type fakeTransport struct {
+	body []byte
+}
+
+func (t *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(t.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+// hasEvent reports whether any exported span contains an event with the given name.
+func hasEvent(spans tracetest.SpanStubs, name string) bool {
+	for _, s := range spans {
+		for _, e := range s.Events {
+			if e.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func newTracedClient(t *testing.T, body []byte) (*http.Client, *tracetest.InMemoryExporter) {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	client := WrapClient(&http.Client{Transport: &fakeTransport{body: body}}, WithTracerProvider(tp))
+	return client, exporter
+}
+
+// doStreamingChat sends a chat-completions stream request through client and
+// drains the response body so the SSE chunks flow through the wrapper.
+func doStreamingChat(t *testing.T, client *http.Client) {
+	t.Helper()
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}],"stream":true}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.openai.com/v1/chat/completions", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+}
+
+func TestRoundTrip_StreamingEmitsNewTokenOnFirstContentDelta(t *testing.T) {
+	// The role chunk is preamble — it must NOT trip new_token. Only the
+	// content chunk that follows should.
+	sse := "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n" +
+		"data: [DONE]\n\n"
+	client, exporter := newTracedClient(t, []byte(sse))
+	doStreamingChat(t, client)
+
+	if !hasEvent(exporter.GetSpans(), "new_token") {
+		t.Fatalf("expected new_token event, got %v", exporter.GetSpans())
+	}
+}
+
+func TestRoundTrip_StreamingEmitsNewTokenOnToolCallDelta(t *testing.T) {
+	// A stream that only ever emits tool_calls (no text content) must still
+	// register first-token time.
+	sse := "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c\",\"function\":{\"name\":\"x\"}}]}}]}\n\n" +
+		"data: [DONE]\n\n"
+	client, exporter := newTracedClient(t, []byte(sse))
+	doStreamingChat(t, client)
+
+	if !hasEvent(exporter.GetSpans(), "new_token") {
+		t.Fatalf("expected new_token event for tool_calls delta, got %v", exporter.GetSpans())
+	}
+}
+
+func TestRoundTrip_StreamingPreambleOnlyDoesNotEmitNewToken(t *testing.T) {
+	// Stream that contains only the role preamble and then ends — there's no
+	// content, so new_token must NOT be emitted.
+	sse := "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
+		"data: [DONE]\n\n"
+	client, exporter := newTracedClient(t, []byte(sse))
+	doStreamingChat(t, client)
+
+	if hasEvent(exporter.GetSpans(), "new_token") {
+		t.Errorf("preamble-only stream should not emit new_token, got %v", exporter.GetSpans())
+	}
+}
+
+func TestRoundTrip_NonStreamingDoesNotEmitNewTokenEvent(t *testing.T) {
+	resp := `{"choices":[{"message":{"role":"assistant","content":"hi"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`
+	client, exporter := newTracedClient(t, []byte(resp))
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.openai.com/v1/chat/completions", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpResp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(httpResp.Body); err != nil {
+		t.Fatal(err)
+	}
+	httpResp.Body.Close()
+
+	if hasEvent(exporter.GetSpans(), "new_token") {
+		t.Errorf("non-streaming span should not record a new_token event")
+	}
+}
+
+// errStatusTransport returns a non-streaming JSON error body with a 429.
+type errStatusTransport struct{ body []byte }
+
+func (e *errStatusTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       io.NopCloser(bytes.NewReader(e.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestRoundTrip_StreamingHTTPErrorDoesNotEmitNewToken(t *testing.T) {
+	// stream=true but the API returns an error JSON body — first-token time is
+	// undefined and we must not record one.
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	client := WrapClient(&http.Client{
+		Transport: &errStatusTransport{body: []byte(`{"error":{"message":"rate limited"}}`)},
+	}, WithTracerProvider(tp))
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}],"stream":true}`
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.openai.com/v1/chat/completions", strings.NewReader(body))
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if hasEvent(exporter.GetSpans(), "new_token") {
+		t.Errorf("streamed HTTP error should not emit new_token, got %v", exporter.GetSpans())
+	}
+}
+
+func TestRoundTrip_ResponsesAPIStreamingFirstTextDelta(t *testing.T) {
+	// Responses API: lifecycle envelopes (response.created, output_item.added)
+	// arrive before the first text delta. Only the delta should register.
+	sse := "data: {\"type\":\"response.created\",\"response\":{}}\n\n" +
+		"data: {\"type\":\"response.in_progress\",\"response\":{}}\n\n" +
+		"data: {\"type\":\"response.output_item.added\",\"item\":{}}\n\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hi\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hi\"}]}]}}\n\n"
+	client, exporter := newTracedClient(t, []byte(sse))
+
+	body := `{"model":"gpt-4o","input":"hi","stream":true}`
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.openai.com/v1/responses", strings.NewReader(body))
+	resp, _ := client.Do(req)
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if !hasEvent(exporter.GetSpans(), "new_token") {
+		t.Errorf("expected new_token on response.output_text.delta, got %v", exporter.GetSpans())
+	}
+}
+
+func TestRoundTrip_ResponsesAPIStreamingLifecycleOnlyDoesNotEmit(t *testing.T) {
+	// Responses API stream that never produces a delta event must not emit
+	// new_token even though many bytes flow through.
+	sse := "data: {\"type\":\"response.created\",\"response\":{}}\n\n" +
+		"data: {\"type\":\"response.in_progress\",\"response\":{}}\n\n" +
+		"data: {\"type\":\"response.output_item.added\",\"item\":{}}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"output\":[]}}\n\n"
+	client, exporter := newTracedClient(t, []byte(sse))
+
+	body := `{"model":"gpt-4o","input":"hi","stream":true}`
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.openai.com/v1/responses", strings.NewReader(body))
+	resp, _ := client.Do(req)
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if hasEvent(exporter.GetSpans(), "new_token") {
+		t.Errorf("lifecycle-only Responses stream should not emit new_token")
+	}
+}
+
+func TestIsFirstContentChat(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"role preamble", `{"choices":[{"delta":{"role":"assistant"}}]}`, false},
+		{"empty content", `{"choices":[{"delta":{"content":""}}]}`, false},
+		{"content delta", `{"choices":[{"delta":{"content":"hi"}}]}`, true},
+		{"tool_calls delta", `{"choices":[{"delta":{"tool_calls":[{"id":"x"}]}}]}`, true},
+		{"legacy text", `{"choices":[{"text":"hi"}]}`, true},
+		{"no choices", `{"id":"x"}`, false},
+		{"empty choices", `{"choices":[]}`, false},
+		{"n>1 content on second choice", `{"choices":[{"index":0,"delta":{"role":"assistant"}},{"index":1,"delta":{"content":"hi"}}]}`, true},
+		{"n>1 all preamble", `{"choices":[{"index":0,"delta":{"role":"assistant"}},{"index":1,"delta":{"role":"assistant"}}]}`, false},
+	}
+	for _, tt := range tests {
+		var c map[string]any
+		_ = json.Unmarshal([]byte(tt.body), &c)
+		if got := isFirstContentChat(c); got != tt.want {
+			t.Errorf("%s: got %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestIsFirstContentResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"created lifecycle", `{"type":"response.created"}`, false},
+		{"in_progress", `{"type":"response.in_progress"}`, false},
+		{"output_item.added", `{"type":"response.output_item.added"}`, false},
+		{"output_text.delta", `{"type":"response.output_text.delta","delta":"hi"}`, true},
+		{"function_call_arguments.delta", `{"type":"response.function_call_arguments.delta"}`, true},
+		{"reasoning_summary_text.delta", `{"type":"response.reasoning_summary_text.delta"}`, true},
+		{"completed lifecycle", `{"type":"response.completed"}`, false},
+	}
+	for _, tt := range tests {
+		var c map[string]any
+		_ = json.Unmarshal([]byte(tt.body), &c)
+		if got := isFirstContentResponses(c); got != tt.want {
+			t.Errorf("%s: got %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
 
 func TestIsOpenAIEndpoint(t *testing.T) {
 	tests := []struct {

--- a/internal/traceutil/buffered_reader.go
+++ b/internal/traceutil/buffered_reader.go
@@ -11,10 +11,11 @@ import (
 // onDone receives the buffered content and the error that ended the read (nil for EOF/Close).
 // This allows response bodies to stream through while capturing content and real errors for span tagging.
 type BufferedReader struct {
-	src    io.ReadCloser
-	buf    *bytes.Buffer
-	onDone func(io.Reader, error)
-	once   sync.Once
+	src     io.ReadCloser
+	buf     *bytes.Buffer
+	onDone  func(io.Reader, error)
+	onBytes func([]byte)
+	once    sync.Once
 }
 
 // NewBufferedReader creates a BufferedReader that calls onDone with the
@@ -31,6 +32,9 @@ func NewBufferedReader(src io.ReadCloser, onDone func(io.Reader, error)) *Buffer
 func (r *BufferedReader) Read(p []byte) (int, error) {
 	n, err := r.src.Read(p)
 	if n > 0 {
+		if r.onBytes != nil {
+			r.onBytes(p[:n])
+		}
 		r.buf.Write(p[:n])
 	}
 	if err != nil {

--- a/internal/traceutil/sse_scanner.go
+++ b/internal/traceutil/sse_scanner.go
@@ -1,0 +1,61 @@
+package traceutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// SSEScanner incrementally parses Server-Sent Events. Not safe for concurrent use.
+type SSEScanner struct {
+	onChunk func(map[string]any)
+	buf     bytes.Buffer
+}
+
+func NewSSEScanner(onChunk func(map[string]any)) *SSEScanner {
+	return &SSEScanner{onChunk: onChunk}
+}
+
+func (s *SSEScanner) Feed(p []byte) {
+	s.buf.Write(p)
+	for {
+		idx := bytes.IndexByte(s.buf.Bytes(), '\n')
+		if idx < 0 {
+			return
+		}
+		line := strings.TrimRight(string(s.buf.Next(idx+1)), "\r\n")
+		s.handle(line)
+	}
+}
+
+func (s *SSEScanner) handle(line string) {
+	if !strings.HasPrefix(line, "data:") {
+		return
+	}
+	payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+	if payload == "" || payload == "[DONE]" {
+		return
+	}
+	var chunk map[string]any
+	if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+		return
+	}
+	if s.onChunk != nil {
+		s.onChunk(chunk)
+	}
+}
+
+// OnFirstSSEMatch fires once on the first SSE chunk satisfying isMatch, then
+// detaches from br. Safe only when br is read by a single goroutine.
+func OnFirstSSEMatch(br *BufferedReader, isMatch func(map[string]any) bool, fire func()) {
+	var fired bool
+	scanner := NewSSEScanner(func(chunk map[string]any) {
+		if fired || !isMatch(chunk) {
+			return
+		}
+		fired = true
+		fire()
+		br.onBytes = nil
+	})
+	br.onBytes = func(b []byte) { scanner.Feed(b) }
+}

--- a/internal/traceutil/sse_scanner_test.go
+++ b/internal/traceutil/sse_scanner_test.go
@@ -1,0 +1,95 @@
+package traceutil
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSSEScanner_ParsesAcrossWriteBoundaries(t *testing.T) {
+	var got []map[string]any
+	s := NewSSEScanner(func(c map[string]any) { got = append(got, c) })
+
+	// Split a single data line across multiple Writes — the scanner must
+	// hold partial bytes until a newline arrives.
+	s.Feed([]byte("data: {\"a\""))
+	s.Feed([]byte(":1}\n"))
+	s.Feed([]byte("data: {\"b\":2}\ndata: {\"c\":3}\n"))
+
+	want := []map[string]any{
+		{"a": float64(1)},
+		{"b": float64(2)},
+		{"c": float64(3)},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSSEScanner_SkipsPreambleAndDone(t *testing.T) {
+	var got []map[string]any
+	s := NewSSEScanner(func(c map[string]any) { got = append(got, c) })
+
+	// event:/id:/retry: lines, blank lines, and [DONE] should all be skipped.
+	s.Feed([]byte("event: foo\n"))
+	s.Feed([]byte("id: 1\n"))
+	s.Feed([]byte("\n"))
+	s.Feed([]byte("retry: 1000\n"))
+	s.Feed([]byte("data: [DONE]\n"))
+	s.Feed([]byte("data: {\"ok\":true}\n"))
+
+	want := []map[string]any{{"ok": true}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestOnFirstSSEMatch_FiresOnceAndStopsParsing(t *testing.T) {
+	src := &nopCloser{Reader: strings.NewReader(
+		"data: {\"role\":\"assistant\"}\n" + // preamble — does not match
+			"data: {\"content\":\"first\"}\n" + // matches → fires once
+			"data: {\"content\":\"second\"}\n" + // would match again, but parsing must be stopped
+			"data: {\"content\":\"third\"}\n",
+	)}
+	br := NewBufferedReader(src, nil)
+
+	matches := 0
+	fired := 0
+	OnFirstSSEMatch(br,
+		func(c map[string]any) bool {
+			matches++
+			_, ok := c["content"].(string)
+			return ok
+		},
+		func() { fired++ },
+	)
+
+	if _, err := io.ReadAll(br); err != nil {
+		t.Fatal(err)
+	}
+
+	if fired != 1 {
+		t.Errorf("expected fire called once, got %d", fired)
+	}
+	// Only the preamble + the first matching chunk should have been parsed;
+	// after the match, onBytes is detached and no further chunks are inspected.
+	if matches != 2 {
+		t.Errorf("expected scanner to stop after first match (2 isMatch calls), got %d", matches)
+	}
+}
+
+func TestSSEScanner_SkipsInvalidJSON(t *testing.T) {
+	var got []map[string]any
+	s := NewSSEScanner(func(c map[string]any) { got = append(got, c) })
+
+	// Non-JSON data lines (e.g. an error body that happens to start with
+	// "data:") must not panic or fire the callback.
+	s.Feed([]byte("data: not json\n"))
+	s.Feed([]byte("data: {\"valid\":true}\n"))
+
+	want := []map[string]any{{"valid": true}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Description

The Go SDK doesn't record time-to-first-token.

Both streaming wrappers (OpenAI and Anthropic) now record a span event the first time the provider sends a real generated token. The server-side change that turns that event into the first-token-time field lives in langchain-ai/langchainplus#23856; once both land, OTel-traced streams get TTFT automatically.

## Decisions

- We wait for actual generated content, not just the first byte off the wire. The first byte can be a role marker, a lifecycle envelope, or a message-start, and recording on it would skew TTFT.
- Streamed responses that return an HTTP error are skipped
- For chat completions with n > 1, every choice is checked, not just the first one, so content arriving first on a non-zero index still counts.

## Test plan

Added unit tests for the SSE parser and the wiring helper, plus round-trip tests covering streaming, non-streaming, preamble-only, HTTP errors, tool calls, the Responses API, and the n>1 case.