### PR TITLE
Refresh profile auth before requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
@@ -45,6 +46,17 @@ type configFile struct {
 	Profiles       map[string]configProfile `json:"profiles,omitempty"`
 }
 
+type profileState struct {
+	path        string
+	cfg         configFile
+	profileName string
+}
+
+type profileAuth struct {
+	state *profileState
+	mu    sync.Mutex
+}
+
 type oauthTokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	ExpiresIn    int    `json:"expires_in"`
@@ -72,6 +84,36 @@ func (e oauthErrorResponse) Error() string {
 //  2. current_profile key in config file
 //  3. "default" profile
 func loadProfileOptions() []option.RequestOption {
+	state := loadProfileState()
+	if state == nil {
+		return nil
+	}
+	p, ok := state.cfg.Profiles[state.profileName]
+	if !ok {
+		return nil
+	}
+
+	envAuthSet := os.Getenv("LANGSMITH_API_KEY") != ""
+	hasOAuth := p.OAuth.AccessToken != "" || p.OAuth.RefreshToken != ""
+
+	var opts []option.RequestOption
+	if p.APIURL != "" {
+		opts = append(opts, option.WithBaseURL(p.APIURL))
+	}
+	if !envAuthSet {
+		if hasOAuth {
+			opts = append(opts, withProfileAuth(&profileAuth{state: state}))
+		} else if p.APIKey != "" {
+			opts = append(opts, option.WithAPIKey(p.APIKey))
+		}
+	}
+	if p.WorkspaceID != "" {
+		opts = append(opts, option.WithTenantID(p.WorkspaceID))
+	}
+	return opts
+}
+
+func loadProfileState() *profileState {
 	path := configPath()
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -88,49 +130,100 @@ func loadProfileOptions() []option.RequestOption {
 		return nil
 	}
 
-	p, ok := cfg.Profiles[profileName]
-	if !ok {
+	if _, ok := cfg.Profiles[profileName]; !ok {
 		return nil
 	}
-
-	refreshURL := p.APIURL
-	if envURL := os.Getenv("LANGSMITH_ENDPOINT"); envURL != "" {
-		refreshURL = envURL
-	}
-	envAuthSet := os.Getenv("LANGSMITH_API_KEY") != ""
-	if shouldRefreshProfileToken(p) &&
-		!envAuthSet {
-		ctx, cancel := context.WithTimeout(context.Background(), tokenRefreshTimeout)
-		defer cancel()
-		if token, err := refreshOAuthToken(ctx, refreshURL, p.OAuth.RefreshToken); err == nil {
-			applyTokenResponse(&p, token, time.Now())
-			cfg.Profiles[profileName] = p
-			_ = saveConfig(path, cfg)
-		}
-	}
-
-	var opts []option.RequestOption
-	if p.APIURL != "" {
-		opts = append(opts, option.WithBaseURL(p.APIURL))
-	}
-	if !envAuthSet {
-		if token := p.OAuth.AccessToken; token != "" {
-			opts = append(opts, withOAuthAccessToken(token))
-		} else if p.APIKey != "" {
-			opts = append(opts, option.WithAPIKey(p.APIKey))
-		}
-	}
-	if p.WorkspaceID != "" {
-		opts = append(opts, option.WithTenantID(p.WorkspaceID))
-	}
-	return opts
+	return &profileState{path: path, cfg: cfg, profileName: profileName}
 }
 
-func withOAuthAccessToken(token string) option.RequestOption {
+func withProfileAuth(auth *profileAuth) option.RequestOption {
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
-		r.OAuthAccessToken = token
-		return r.Apply(option.WithHeader("authorization", "Bearer "+token))
+		name, value, token := auth.currentAuthHeader()
+		if token != "" {
+			r.OAuthAccessToken = token
+		}
+		if name != "" && r.APIKey == "" {
+			r.Request.Header.Set(name, value)
+		}
+		return r.Apply(option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			if req.Header.Get("X-API-Key") != "" {
+				req.Header.Del("Authorization")
+				return next(req)
+			}
+			name, value, _ := auth.authHeader(req.Context(), refreshURLFromRequest(req))
+			if name != "" {
+				if strings.EqualFold(name, "X-API-Key") {
+					req.Header.Del("Authorization")
+				}
+				req.Header.Set(name, value)
+			}
+			return next(req)
+		}))
 	})
+}
+
+func (a *profileAuth) currentAuthHeader() (name string, value string, token string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p, ok := a.state.cfg.Profiles[a.state.profileName]
+	if !ok {
+		return "", "", ""
+	}
+	return currentAuthHeaderFromProfile(p)
+}
+
+func (a *profileAuth) authHeader(ctx context.Context, apiURL string) (name string, value string, token string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p, ok := a.state.cfg.Profiles[a.state.profileName]
+	if !ok {
+		return "", "", ""
+	}
+	if shouldRefreshProfileToken(p) {
+		refreshCtx, cancel := context.WithTimeout(ctx, tokenRefreshTimeout)
+		defer cancel()
+		if token, err := refreshOAuthToken(refreshCtx, apiURL, p.OAuth.RefreshToken); err == nil {
+			applyTokenResponse(&p, token, time.Now())
+			a.state.cfg.Profiles[a.state.profileName] = p
+			_ = saveConfig(a.state.path, a.state.cfg)
+		}
+	}
+	return authHeaderFromProfile(p)
+}
+
+func currentAuthHeaderFromProfile(p configProfile) (name string, value string, token string) {
+	if p.OAuth.AccessToken != "" {
+		return "Authorization", "Bearer " + p.OAuth.AccessToken, p.OAuth.AccessToken
+	}
+	if p.OAuth.RefreshToken != "" {
+		return "", "", ""
+	}
+	return authHeaderFromProfile(p)
+}
+
+func authHeaderFromProfile(p configProfile) (name string, value string, token string) {
+	if p.OAuth.AccessToken != "" {
+		return "Authorization", "Bearer " + p.OAuth.AccessToken, p.OAuth.AccessToken
+	}
+	if p.APIKey != "" {
+		return "X-API-Key", p.APIKey, ""
+	}
+	return "", "", ""
+}
+
+func refreshURLFromRequest(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+	u := *req.URL
+	u.RawQuery = ""
+	u.Fragment = ""
+	if idx := strings.Index(u.Path, "/api/v1"); idx >= 0 {
+		u.Path = u.Path[:idx+len("/api/v1")]
+	} else {
+		u.Path = ""
+	}
+	return u.String()
 }
 
 // resolveProfileName determines which profile to use.

--- a/config.go
+++ b/config.go
@@ -150,7 +150,7 @@ func withProfileAuth(auth *profileAuth) option.RequestOption {
 				req.Header.Del("Authorization")
 				return next(req)
 			}
-			name, value, _ := auth.authHeader(req.Context(), refreshURLFromRequest(req))
+			name, value, _ := auth.authHeader(req.Context())
 			if name != "" {
 				if strings.EqualFold(name, "X-API-Key") {
 					req.Header.Del("Authorization")
@@ -172,7 +172,7 @@ func (a *profileAuth) currentAuthHeader() (name string, value string, token stri
 	return currentAuthHeaderFromProfile(p)
 }
 
-func (a *profileAuth) authHeader(ctx context.Context, apiURL string) (name string, value string, token string) {
+func (a *profileAuth) authHeader(ctx context.Context) (name string, value string, token string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	p, ok := a.state.cfg.Profiles[a.state.profileName]
@@ -182,7 +182,7 @@ func (a *profileAuth) authHeader(ctx context.Context, apiURL string) (name strin
 	if shouldRefreshProfileToken(p) {
 		refreshCtx, cancel := context.WithTimeout(ctx, tokenRefreshTimeout)
 		defer cancel()
-		if token, err := refreshOAuthToken(refreshCtx, apiURL, p.OAuth.RefreshToken); err == nil {
+		if token, err := refreshOAuthToken(refreshCtx, p.APIURL, p.OAuth.RefreshToken); err == nil {
 			applyTokenResponse(&p, token, time.Now())
 			a.state.cfg.Profiles[a.state.profileName] = p
 			_ = saveConfig(a.state.path, a.state.cfg)
@@ -209,21 +209,6 @@ func authHeaderFromProfile(p configProfile) (name string, value string, token st
 		return "X-API-Key", p.APIKey, ""
 	}
 	return "", "", ""
-}
-
-func refreshURLFromRequest(req *http.Request) string {
-	if req == nil || req.URL == nil {
-		return ""
-	}
-	u := *req.URL
-	u.RawQuery = ""
-	u.Fragment = ""
-	if idx := strings.Index(u.Path, "/api/v1"); idx >= 0 {
-		u.Path = u.Path[:idx+len("/api/v1")]
-	} else {
-		u.Path = ""
-	}
-	return u.String()
 }
 
 // resolveProfileName determines which profile to use.

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package langsmith
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -244,8 +245,18 @@ func TestLoadProfileOptions_OAuthAccessToken(t *testing.T) {
 func TestLoadProfileOptions_RefreshesExpiredAccessToken(t *testing.T) {
 	clearAuthEnv(t)
 	tokenRequests := 0
+	apiRequests := 0
+	var apiAuth string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/oauth/token" {
+		switch r.URL.Path {
+		case "/oauth/token":
+		case "/info":
+			apiRequests++
+			apiAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+			return
+		default:
 			http.NotFound(w, r)
 			return
 		}
@@ -293,11 +304,25 @@ func TestLoadProfileOptions_RefreshesExpiredAccessToken(t *testing.T) {
 
 	opts := loadProfileOptions()
 	cfg := applyOptions(t, opts)
-	if cfg.OAuthAccessToken != "new-access-token" {
-		t.Fatalf("expected refreshed access token, got %q", cfg.OAuthAccessToken)
+	if cfg.OAuthAccessToken != "old-access-token" {
+		t.Fatalf("expected initial access token before request, got %q", cfg.OAuthAccessToken)
+	}
+	if tokenRequests != 0 {
+		t.Fatalf("expected no token request before API request, got %d", tokenRequests)
+	}
+
+	var out map[string]string
+	if err := requestconfig.ExecuteNewRequest(context.Background(), http.MethodGet, "/info", nil, &out, opts...); err != nil {
+		t.Fatal(err)
 	}
 	if tokenRequests != 1 {
-		t.Fatalf("expected one token request, got %d", tokenRequests)
+		t.Fatalf("expected one token request during API request, got %d", tokenRequests)
+	}
+	if apiRequests != 1 {
+		t.Fatalf("expected one API request, got %d", apiRequests)
+	}
+	if apiAuth != "Bearer new-access-token" {
+		t.Fatalf("expected refreshed bearer token on API request, got %q", apiAuth)
 	}
 
 	data, err := os.ReadFile(path)
@@ -312,6 +337,81 @@ func TestLoadProfileOptions_RefreshesExpiredAccessToken(t *testing.T) {
 	}
 	if strings.Contains(string(data), `token_type`) || strings.Contains(string(data), `bearer_token`) {
 		t.Fatalf("expected no token_type or bearer_token fields, got:\n%s", data)
+	}
+}
+
+func TestLoadProfileOptions_RefreshTokenOnlyBeforeProfileAPIKey(t *testing.T) {
+	clearAuthEnv(t)
+	tokenRequests := 0
+	var apiAuth string
+	var apiKey string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			tokenRequests++
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if got := r.FormValue("refresh_token"); got != "profile-refresh-token" {
+				t.Fatalf("expected profile refresh token, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+				AccessToken:  "new-access-token",
+				ExpiresIn:    300,
+				RefreshToken: "new-refresh-token",
+			})
+		case "/info":
+			apiAuth = r.Header.Get("Authorization")
+			apiKey = r.Header.Get("X-API-Key")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_key": "profile-api-key",
+      "api_url": "` + ts.URL + `",
+      "oauth": {
+        "refresh_token": "profile-refresh-token"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := loadProfileOptions()
+	cfg := applyOptions(t, opts)
+	if got := cfg.Request.Header.Get("X-API-Key"); got != "" {
+		t.Fatalf("expected no initial X-API-Key before refresh, got %q", got)
+	}
+	if tokenRequests != 0 {
+		t.Fatalf("expected no token request before API request, got %d", tokenRequests)
+	}
+
+	var out map[string]string
+	if err := requestconfig.ExecuteNewRequest(context.Background(), http.MethodGet, "/info", nil, &out, opts...); err != nil {
+		t.Fatal(err)
+	}
+	if tokenRequests != 1 {
+		t.Fatalf("expected one token request during API request, got %d", tokenRequests)
+	}
+	if apiKey != "" {
+		t.Fatalf("expected refreshed OAuth to suppress profile API key, got %q", apiKey)
+	}
+	if apiAuth != "Bearer new-access-token" {
+		t.Fatalf("expected refreshed bearer token on API request, got %q", apiAuth)
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -415,6 +415,82 @@ func TestLoadProfileOptions_RefreshTokenOnlyBeforeProfileAPIKey(t *testing.T) {
 	}
 }
 
+func TestLoadProfileOptions_RefreshUsesProfileAPIURL(t *testing.T) {
+	clearAuthEnv(t)
+	tokenRequests := 0
+	profileTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		tokenRequests++
+		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken:  "new-access-token",
+			ExpiresIn:    300,
+			RefreshToken: "new-refresh-token",
+		})
+	}))
+	defer profileTS.Close()
+
+	apiRequests := 0
+	overrideTokenRequests := 0
+	var apiAuth string
+	apiTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/info":
+			apiRequests++
+			apiAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+		case "/oauth/token":
+			overrideTokenRequests++
+			http.Error(w, "refresh should use profile api_url", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer apiTS.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_url": "` + profileTS.URL + `",
+      "oauth": {
+        "access_token": "old-access-token",
+        "refresh_token": "old-refresh-token",
+        "expires_at": "` + time.Now().Add(-time.Minute).UTC().Format(time.RFC3339) + `"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := append(loadProfileOptions(), option.WithBaseURL(apiTS.URL))
+	var out map[string]string
+	if err := requestconfig.ExecuteNewRequest(context.Background(), http.MethodGet, "/info", nil, &out, opts...); err != nil {
+		t.Fatal(err)
+	}
+	if tokenRequests != 1 {
+		t.Fatalf("expected refresh against profile api_url, got %d token requests", tokenRequests)
+	}
+	if overrideTokenRequests != 0 {
+		t.Fatalf("expected no refresh against request base URL, got %d", overrideTokenRequests)
+	}
+	if apiRequests != 1 {
+		t.Fatalf("expected one API request, got %d", apiRequests)
+	}
+	if apiAuth != "Bearer new-access-token" {
+		t.Fatalf("expected refreshed bearer token on API request, got %q", apiAuth)
+	}
+}
+
 func TestLoadProfileOptions_OAuthAccessTokenOverridesProfileAPIKey(t *testing.T) {
 	clearAuthEnv(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Adds request-time LangSmith profile OAuth refresh to the Go SDK, based on `next`.

- Loads profile config from `LANGSMITH_CONFIG_FILE` or `~/.langsmith/config.json`
- Keeps profile loading side-effect free; token refresh happens in request middleware
- Refreshes expired or missing OAuth access tokens before API requests
- Uses the selected profile's `api_url` for OAuth refresh, even when the request base URL is overridden
- Falls back to profile `api_key` only when OAuth auth is unavailable
- Persists refreshed token fields back to the profile file
- Preserves explicit per-request `Authorization` headers while replacing stale profile-managed bearer headers

## Auth precedence

Environment API-key auth suppresses profile auth. When profile auth is used, OAuth access tokens are preferred over profile `api_key`; a profile `api_key` remains a fallback if OAuth cannot provide an access token. Explicit per-request auth is preserved.

## Verification

- `gofmt -w config.go config_test.go`
- `git diff --check`
- `go test ./...`
