### PR TITLE
Preserve explicit profile auth headers

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3f55087eb53259b10deee3098084f676f020121fc07d0a3ca6559d6b52f35159.yml
-openapi_spec_hash: 849550a747410f954c4c8d8b912dd8f4
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4545690c7057e69bd4c6b767de7eb22ef495ffaa9d9ebca043c8aa10ecfde052.yml
+openapi_spec_hash: d1e5595a9d634aac44989ca0a5ebf6ba
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-cca57ea9ae088d1056d8fd34f5c8b693d902e5a2fdcd7dc307b5d9a092dd8d48.yml
-openapi_spec_hash: c5c2049a41120c7aef7b795dbfba6389
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-04bcf31b5d2900d435a47de8b65f87d2db4bcc0dfe9bae5f9af8e613e289b43e.yml
+openapi_spec_hash: 1d6cebca630997b55167a34a7910291f
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-303104fd30ffc40f12cfdb47f88248559743bce075662a6417a7f2ec03571356.yml
-openapi_spec_hash: f0a27a4dce9358c1f1f3b54b696df5fb
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-681d8343b4f0f1a841307b4a687d6c8c61676a36586adb35a81046f4133082bc.yml
+openapi_spec_hash: bb813b3045047e5e48c744828c9ad940
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-126fc41f29d769233d715653c454935645254867d8856059a2c982e0f1a4e842.yml
-openapi_spec_hash: 63853b0745dcb50e94d071d79ad0ed64
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-95ccaedc37f0067bd828bc60d65dd457b8c76eed9fe6ef0e467d8b7ddc8aa8ea.yml
+openapi_spec_hash: f2a3f406142e8749b502ea05f04fd7cf
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-04bcf31b5d2900d435a47de8b65f87d2db4bcc0dfe9bae5f9af8e613e289b43e.yml
-openapi_spec_hash: 1d6cebca630997b55167a34a7910291f
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-153ff40199b6d21919c6b4c8a3f0150b35b3ef031f96f213cfad62fb18c7be71.yml
+openapi_spec_hash: ee76d4c9785b7d502cb3f6610c6f5cfd
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-29590317b7c34de07a610c163c6ae6677a76b29b85ac12f6dcf5321e6a102f72.yml
-openapi_spec_hash: 54fe692a1a67717627dcfcb8798d5a6c
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-de4f1366b105f5f33931797d377d0a810db50b2f0fd722b616aa24273c56ce06.yml
+openapi_spec_hash: 82bd47ea3c0964db0b32edb532f032a8
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-681d8343b4f0f1a841307b4a687d6c8c61676a36586adb35a81046f4133082bc.yml
-openapi_spec_hash: bb813b3045047e5e48c744828c9ad940
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-941bb01fe3ad250ab04b7ca6102222ff95800a828950f7d0bbf6ea97ff84d57c.yml
+openapi_spec_hash: 1a475d8566339e77c8b419b4c652b657
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-af0c5cd4bd9e07b9a4e6c9725904f1912fa4fe7ed88f39f2ccf84c10b5ac4116.yml
-openapi_spec_hash: 1b3fcf52b7dbe3fbacdc40ec1c3829b6
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-987c2f7a9e2ef6c096fc0af45e926a895cdeff9750d10995eed980e9c5c12956.yml
+openapi_spec_hash: 8e49a73d1a6ce66f6573569e7943f690
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-122ae364b9671b403be4fc7a7224b4e47f3a120b230fe747889e9a904da9eb01.yml
-openapi_spec_hash: 72c97731abbcf400a0257cb6b5888341
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-289f440696ca77905548cc0f1cdf412586c5964c00aff2a96d55025d761c5b10.yml
+openapi_spec_hash: a72625b342a2641ab6ff46cbdd99fde6
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-32d4c2365df1ccb3edb8388ba6c762cab5b31fa58346396a760e680347f26332.yml
-openapi_spec_hash: ba62cce07fc93ea3acc377fcfda974a1
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-cca57ea9ae088d1056d8fd34f5c8b693d902e5a2fdcd7dc307b5d9a092dd8d48.yml
+openapi_spec_hash: c5c2049a41120c7aef7b795dbfba6389
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-2887dff092a04a6bbf88d26a1da0544606d4b326b1ef2882ad1f110a4bf5d696.yml
-openapi_spec_hash: 38a359adc3701a6e479f85e0de7811c7
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-32d4c2365df1ccb3edb8388ba6c762cab5b31fa58346396a760e680347f26332.yml
+openapi_spec_hash: ba62cce07fc93ea3acc377fcfda974a1
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6b0979cc53313cc279576ffb8b1cf7bf6bb10a62b105ee5f2ef6109e1d0c1bc5.yml
-openapi_spec_hash: 78ea0fee93e4b7427b7f852a5e92a2dc
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-9a6bb39feeb144e3a93d87f9b38f641e051baf21c19f114d60b0769941eeb89f.yml
+openapi_spec_hash: 447ea591fbeff6f0522c16d9f0de184d
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4545690c7057e69bd4c6b767de7eb22ef495ffaa9d9ebca043c8aa10ecfde052.yml
-openapi_spec_hash: d1e5595a9d634aac44989ca0a5ebf6ba
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-303104fd30ffc40f12cfdb47f88248559743bce075662a6417a7f2ec03571356.yml
+openapi_spec_hash: f0a27a4dce9358c1f1f3b54b696df5fb
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-9a6bb39feeb144e3a93d87f9b38f641e051baf21c19f114d60b0769941eeb89f.yml
-openapi_spec_hash: 447ea591fbeff6f0522c16d9f0de184d
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-f1aa60c7b3f4e1633e49968956d49d1fcde96f7250082d0ef4d3f1f39d2bd56a.yml
+openapi_spec_hash: e9a6bec528cc256cdd3bff128543e00a
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-153ff40199b6d21919c6b4c8a3f0150b35b3ef031f96f213cfad62fb18c7be71.yml
-openapi_spec_hash: ee76d4c9785b7d502cb3f6610c6f5cfd
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c4d4f14ce65c86dc0604732a40257605b558fb6581d92426981a603818af1d52.yml
+openapi_spec_hash: d65b4acd00c1eb81f0a74bffd2e80047
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3ab64cdfe2a9cf004a8e226de9382ad2425000d43d00f36940c6baf3552e874a.yml
-openapi_spec_hash: 81ce40fff89eb4db224d23e664a85a09
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-95ccaedc37f0067bd828bc60d65dd457b8c76eed9fe6ef0e467d8b7ddc8aa8ea.yml
+openapi_spec_hash: f2a3f406142e8749b502ea05f04fd7cf
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-25b00b1b83d18ef35f6afe88f45a2723786be9b36fe267705334c396c2ebd0ba.yml
-openapi_spec_hash: b9b98f9e8f7484cd12136e26441029fa
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3f55087eb53259b10deee3098084f676f020121fc07d0a3ca6559d6b52f35159.yml
+openapi_spec_hash: 849550a747410f954c4c8d8b912dd8f4
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-067b803a359abef42d8222e23d7d75367b74c6f8fef5ce6529a16c021940d427.yml
-openapi_spec_hash: 8079845789f46ec56b4367c5a282346d
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-25b00b1b83d18ef35f6afe88f45a2723786be9b36fe267705334c396c2ebd0ba.yml
+openapi_spec_hash: b9b98f9e8f7484cd12136e26441029fa
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-289f440696ca77905548cc0f1cdf412586c5964c00aff2a96d55025d761c5b10.yml
-openapi_spec_hash: a72625b342a2641ab6ff46cbdd99fde6
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6b0979cc53313cc279576ffb8b1cf7bf6bb10a62b105ee5f2ef6109e1d0c1bc5.yml
+openapi_spec_hash: 78ea0fee93e4b7427b7f852a5e92a2dc
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-941bb01fe3ad250ab04b7ca6102222ff95800a828950f7d0bbf6ea97ff84d57c.yml
-openapi_spec_hash: 1a475d8566339e77c8b419b4c652b657
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-af0c5cd4bd9e07b9a4e6c9725904f1912fa4fe7ed88f39f2ccf84c10b5ac4116.yml
+openapi_spec_hash: 1b3fcf52b7dbe3fbacdc40ec1c3829b6
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-95ccaedc37f0067bd828bc60d65dd457b8c76eed9fe6ef0e467d8b7ddc8aa8ea.yml
-openapi_spec_hash: f2a3f406142e8749b502ea05f04fd7cf
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-067b803a359abef42d8222e23d7d75367b74c6f8fef5ce6529a16c021940d427.yml
+openapi_spec_hash: 8079845789f46ec56b4367c5a282346d
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-95ccaedc37f0067bd828bc60d65dd457b8c76eed9fe6ef0e467d8b7ddc8aa8ea.yml
-openapi_spec_hash: f2a3f406142e8749b502ea05f04fd7cf
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-29590317b7c34de07a610c163c6ae6677a76b29b85ac12f6dcf5321e6a102f72.yml
+openapi_spec_hash: 54fe692a1a67717627dcfcb8798d5a6c
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-de4f1366b105f5f33931797d377d0a810db50b2f0fd722b616aa24273c56ce06.yml
-openapi_spec_hash: 82bd47ea3c0964db0b32edb532f032a8
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-126fc41f29d769233d715653c454935645254867d8856059a2c982e0f1a4e842.yml
+openapi_spec_hash: 63853b0745dcb50e94d071d79ad0ed64
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-f1aa60c7b3f4e1633e49968956d49d1fcde96f7250082d0ef4d3f1f39d2bd56a.yml
-openapi_spec_hash: e9a6bec528cc256cdd3bff128543e00a
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3ab64cdfe2a9cf004a8e226de9382ad2425000d43d00f36940c6baf3552e874a.yml
+openapi_spec_hash: 81ce40fff89eb4db224d23e664a85a09
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 122
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c4d4f14ce65c86dc0604732a40257605b558fb6581d92426981a603818af1d52.yml
-openapi_spec_hash: d65b4acd00c1eb81f0a74bffd2e80047
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-122ae364b9671b403be4fc7a7224b4e47f3a120b230fe747889e9a904da9eb01.yml
+openapi_spec_hash: 72c97731abbcf400a0257cb6b5888341
 config_hash: 57e1c5d2f7d3f4c50121dda73a181670

--- a/annotationqueue.go
+++ b/annotationqueue.go
@@ -366,131 +366,133 @@ type RunSchemaWithAnnotationQueueInfo struct {
 	Name        string `json:"name" api:"required"`
 	QueueRunID  string `json:"queue_run_id" api:"required" format:"uuid"`
 	// Enum for run types.
-	RunType                RunTypeEnum                               `json:"run_type" api:"required"`
-	SessionID              string                                    `json:"session_id" api:"required" format:"uuid"`
-	Status                 string                                    `json:"status" api:"required"`
-	TraceID                string                                    `json:"trace_id" api:"required" format:"uuid"`
-	AddedAt                time.Time                                 `json:"added_at" api:"nullable" format:"date-time"`
-	ChildRunIDs            []string                                  `json:"child_run_ids" api:"nullable" format:"uuid"`
-	CompletedBy            []string                                  `json:"completed_by" format:"uuid"`
-	CompletionCost         string                                    `json:"completion_cost" api:"nullable"`
-	CompletionCostDetails  map[string]string                         `json:"completion_cost_details" api:"nullable"`
-	CompletionTokenDetails map[string]int64                          `json:"completion_token_details" api:"nullable"`
-	CompletionTokens       int64                                     `json:"completion_tokens"`
-	DirectChildRunIDs      []string                                  `json:"direct_child_run_ids" api:"nullable" format:"uuid"`
-	EffectiveAddedAt       time.Time                                 `json:"effective_added_at" api:"nullable" format:"date-time"`
-	EndTime                time.Time                                 `json:"end_time" api:"nullable" format:"date-time"`
-	Error                  string                                    `json:"error" api:"nullable"`
-	Events                 []map[string]interface{}                  `json:"events" api:"nullable"`
-	ExecutionOrder         int64                                     `json:"execution_order"`
-	Extra                  map[string]interface{}                    `json:"extra" api:"nullable"`
-	FeedbackStats          map[string]map[string]interface{}         `json:"feedback_stats" api:"nullable"`
-	FirstTokenTime         time.Time                                 `json:"first_token_time" api:"nullable" format:"date-time"`
-	InDataset              bool                                      `json:"in_dataset" api:"nullable"`
-	Inputs                 map[string]interface{}                    `json:"inputs" api:"nullable"`
-	InputsPreview          string                                    `json:"inputs_preview" api:"nullable"`
-	InputsS3URLs           map[string]interface{}                    `json:"inputs_s3_urls" api:"nullable"`
-	LastQueuedAt           time.Time                                 `json:"last_queued_at" api:"nullable" format:"date-time"`
-	LastReviewedTime       time.Time                                 `json:"last_reviewed_time" api:"nullable" format:"date-time"`
-	ManifestID             string                                    `json:"manifest_id" api:"nullable" format:"uuid"`
-	ManifestS3ID           string                                    `json:"manifest_s3_id" api:"nullable" format:"uuid"`
-	Messages               []map[string]interface{}                  `json:"messages" api:"nullable"`
-	Outputs                map[string]interface{}                    `json:"outputs" api:"nullable"`
-	OutputsPreview         string                                    `json:"outputs_preview" api:"nullable"`
-	OutputsS3URLs          map[string]interface{}                    `json:"outputs_s3_urls" api:"nullable"`
-	ParentRunID            string                                    `json:"parent_run_id" api:"nullable" format:"uuid"`
-	ParentRunIDs           []string                                  `json:"parent_run_ids" api:"nullable" format:"uuid"`
-	PriceModelID           string                                    `json:"price_model_id" api:"nullable" format:"uuid"`
-	PromptCost             string                                    `json:"prompt_cost" api:"nullable"`
-	PromptCostDetails      map[string]string                         `json:"prompt_cost_details" api:"nullable"`
-	PromptTokenDetails     map[string]int64                          `json:"prompt_token_details" api:"nullable"`
-	PromptTokens           int64                                     `json:"prompt_tokens"`
-	ReferenceDatasetID     string                                    `json:"reference_dataset_id" api:"nullable" format:"uuid"`
-	ReferenceExampleID     string                                    `json:"reference_example_id" api:"nullable" format:"uuid"`
-	ReservedBy             []string                                  `json:"reserved_by" format:"uuid"`
-	S3URLs                 map[string]interface{}                    `json:"s3_urls" api:"nullable"`
-	Serialized             map[string]interface{}                    `json:"serialized" api:"nullable"`
-	ShareToken             string                                    `json:"share_token" api:"nullable" format:"uuid"`
-	StartTime              time.Time                                 `json:"start_time" format:"date-time"`
-	Tags                   []string                                  `json:"tags" api:"nullable"`
-	ThreadID               string                                    `json:"thread_id" api:"nullable"`
-	TotalCost              string                                    `json:"total_cost" api:"nullable"`
-	TotalTokens            int64                                     `json:"total_tokens"`
-	TraceFirstReceivedAt   time.Time                                 `json:"trace_first_received_at" api:"nullable" format:"date-time"`
-	TraceMaxStartTime      time.Time                                 `json:"trace_max_start_time" api:"nullable" format:"date-time"`
-	TraceMinStartTime      time.Time                                 `json:"trace_min_start_time" api:"nullable" format:"date-time"`
-	TraceTier              RunSchemaWithAnnotationQueueInfoTraceTier `json:"trace_tier" api:"nullable"`
-	TraceUpgrade           bool                                      `json:"trace_upgrade"`
-	TtlSeconds             int64                                     `json:"ttl_seconds" api:"nullable"`
-	JSON                   runSchemaWithAnnotationQueueInfoJSON      `json:"-"`
+	RunType                 RunTypeEnum                               `json:"run_type" api:"required"`
+	SessionID               string                                    `json:"session_id" api:"required" format:"uuid"`
+	Status                  string                                    `json:"status" api:"required"`
+	TraceID                 string                                    `json:"trace_id" api:"required" format:"uuid"`
+	AddedAt                 time.Time                                 `json:"added_at" api:"nullable" format:"date-time"`
+	ChildRunIDs             []string                                  `json:"child_run_ids" api:"nullable" format:"uuid"`
+	CompletedBy             []string                                  `json:"completed_by" format:"uuid"`
+	CompletionCost          string                                    `json:"completion_cost" api:"nullable"`
+	CompletionCostDetails   map[string]string                         `json:"completion_cost_details" api:"nullable"`
+	CompletionTokenDetails  map[string]int64                          `json:"completion_token_details" api:"nullable"`
+	CompletionTokens        int64                                     `json:"completion_tokens"`
+	DirectChildRunIDs       []string                                  `json:"direct_child_run_ids" api:"nullable" format:"uuid"`
+	EffectiveAddedAt        time.Time                                 `json:"effective_added_at" api:"nullable" format:"date-time"`
+	EndTime                 time.Time                                 `json:"end_time" api:"nullable" format:"date-time"`
+	Error                   string                                    `json:"error" api:"nullable"`
+	Events                  []map[string]interface{}                  `json:"events" api:"nullable"`
+	ExecutionOrder          int64                                     `json:"execution_order"`
+	Extra                   map[string]interface{}                    `json:"extra" api:"nullable"`
+	FeedbackStats           map[string]map[string]interface{}         `json:"feedback_stats" api:"nullable"`
+	FirstTokenTime          time.Time                                 `json:"first_token_time" api:"nullable" format:"date-time"`
+	InDataset               bool                                      `json:"in_dataset" api:"nullable"`
+	Inputs                  map[string]interface{}                    `json:"inputs" api:"nullable"`
+	InputsPreview           string                                    `json:"inputs_preview" api:"nullable"`
+	InputsS3URLs            map[string]interface{}                    `json:"inputs_s3_urls" api:"nullable"`
+	LastQueuedAt            time.Time                                 `json:"last_queued_at" api:"nullable" format:"date-time"`
+	LastReviewedTime        time.Time                                 `json:"last_reviewed_time" api:"nullable" format:"date-time"`
+	ManifestID              string                                    `json:"manifest_id" api:"nullable" format:"uuid"`
+	ManifestS3ID            string                                    `json:"manifest_s3_id" api:"nullable" format:"uuid"`
+	Messages                []map[string]interface{}                  `json:"messages" api:"nullable"`
+	Outputs                 map[string]interface{}                    `json:"outputs" api:"nullable"`
+	OutputsPreview          string                                    `json:"outputs_preview" api:"nullable"`
+	OutputsS3URLs           map[string]interface{}                    `json:"outputs_s3_urls" api:"nullable"`
+	ParentRunID             string                                    `json:"parent_run_id" api:"nullable" format:"uuid"`
+	ParentRunIDs            []string                                  `json:"parent_run_ids" api:"nullable" format:"uuid"`
+	PriceModelID            string                                    `json:"price_model_id" api:"nullable" format:"uuid"`
+	PromptCost              string                                    `json:"prompt_cost" api:"nullable"`
+	PromptCostDetails       map[string]string                         `json:"prompt_cost_details" api:"nullable"`
+	PromptTokenDetails      map[string]int64                          `json:"prompt_token_details" api:"nullable"`
+	PromptTokens            int64                                     `json:"prompt_tokens"`
+	ReferenceDatasetID      string                                    `json:"reference_dataset_id" api:"nullable" format:"uuid"`
+	ReferenceExampleID      string                                    `json:"reference_example_id" api:"nullable" format:"uuid"`
+	ReservedBy              []string                                  `json:"reserved_by" format:"uuid"`
+	S3URLs                  map[string]interface{}                    `json:"s3_urls" api:"nullable"`
+	Serialized              map[string]interface{}                    `json:"serialized" api:"nullable"`
+	ShareToken              string                                    `json:"share_token" api:"nullable" format:"uuid"`
+	SourceProposedExampleID string                                    `json:"source_proposed_example_id" api:"nullable" format:"uuid"`
+	StartTime               time.Time                                 `json:"start_time" format:"date-time"`
+	Tags                    []string                                  `json:"tags" api:"nullable"`
+	ThreadID                string                                    `json:"thread_id" api:"nullable"`
+	TotalCost               string                                    `json:"total_cost" api:"nullable"`
+	TotalTokens             int64                                     `json:"total_tokens"`
+	TraceFirstReceivedAt    time.Time                                 `json:"trace_first_received_at" api:"nullable" format:"date-time"`
+	TraceMaxStartTime       time.Time                                 `json:"trace_max_start_time" api:"nullable" format:"date-time"`
+	TraceMinStartTime       time.Time                                 `json:"trace_min_start_time" api:"nullable" format:"date-time"`
+	TraceTier               RunSchemaWithAnnotationQueueInfoTraceTier `json:"trace_tier" api:"nullable"`
+	TraceUpgrade            bool                                      `json:"trace_upgrade"`
+	TtlSeconds              int64                                     `json:"ttl_seconds" api:"nullable"`
+	JSON                    runSchemaWithAnnotationQueueInfoJSON      `json:"-"`
 }
 
 // runSchemaWithAnnotationQueueInfoJSON contains the JSON metadata for the struct
 // [RunSchemaWithAnnotationQueueInfo]
 type runSchemaWithAnnotationQueueInfoJSON struct {
-	ID                     apijson.Field
-	AppPath                apijson.Field
-	DottedOrder            apijson.Field
-	Name                   apijson.Field
-	QueueRunID             apijson.Field
-	RunType                apijson.Field
-	SessionID              apijson.Field
-	Status                 apijson.Field
-	TraceID                apijson.Field
-	AddedAt                apijson.Field
-	ChildRunIDs            apijson.Field
-	CompletedBy            apijson.Field
-	CompletionCost         apijson.Field
-	CompletionCostDetails  apijson.Field
-	CompletionTokenDetails apijson.Field
-	CompletionTokens       apijson.Field
-	DirectChildRunIDs      apijson.Field
-	EffectiveAddedAt       apijson.Field
-	EndTime                apijson.Field
-	Error                  apijson.Field
-	Events                 apijson.Field
-	ExecutionOrder         apijson.Field
-	Extra                  apijson.Field
-	FeedbackStats          apijson.Field
-	FirstTokenTime         apijson.Field
-	InDataset              apijson.Field
-	Inputs                 apijson.Field
-	InputsPreview          apijson.Field
-	InputsS3URLs           apijson.Field
-	LastQueuedAt           apijson.Field
-	LastReviewedTime       apijson.Field
-	ManifestID             apijson.Field
-	ManifestS3ID           apijson.Field
-	Messages               apijson.Field
-	Outputs                apijson.Field
-	OutputsPreview         apijson.Field
-	OutputsS3URLs          apijson.Field
-	ParentRunID            apijson.Field
-	ParentRunIDs           apijson.Field
-	PriceModelID           apijson.Field
-	PromptCost             apijson.Field
-	PromptCostDetails      apijson.Field
-	PromptTokenDetails     apijson.Field
-	PromptTokens           apijson.Field
-	ReferenceDatasetID     apijson.Field
-	ReferenceExampleID     apijson.Field
-	ReservedBy             apijson.Field
-	S3URLs                 apijson.Field
-	Serialized             apijson.Field
-	ShareToken             apijson.Field
-	StartTime              apijson.Field
-	Tags                   apijson.Field
-	ThreadID               apijson.Field
-	TotalCost              apijson.Field
-	TotalTokens            apijson.Field
-	TraceFirstReceivedAt   apijson.Field
-	TraceMaxStartTime      apijson.Field
-	TraceMinStartTime      apijson.Field
-	TraceTier              apijson.Field
-	TraceUpgrade           apijson.Field
-	TtlSeconds             apijson.Field
-	raw                    string
-	ExtraFields            map[string]apijson.Field
+	ID                      apijson.Field
+	AppPath                 apijson.Field
+	DottedOrder             apijson.Field
+	Name                    apijson.Field
+	QueueRunID              apijson.Field
+	RunType                 apijson.Field
+	SessionID               apijson.Field
+	Status                  apijson.Field
+	TraceID                 apijson.Field
+	AddedAt                 apijson.Field
+	ChildRunIDs             apijson.Field
+	CompletedBy             apijson.Field
+	CompletionCost          apijson.Field
+	CompletionCostDetails   apijson.Field
+	CompletionTokenDetails  apijson.Field
+	CompletionTokens        apijson.Field
+	DirectChildRunIDs       apijson.Field
+	EffectiveAddedAt        apijson.Field
+	EndTime                 apijson.Field
+	Error                   apijson.Field
+	Events                  apijson.Field
+	ExecutionOrder          apijson.Field
+	Extra                   apijson.Field
+	FeedbackStats           apijson.Field
+	FirstTokenTime          apijson.Field
+	InDataset               apijson.Field
+	Inputs                  apijson.Field
+	InputsPreview           apijson.Field
+	InputsS3URLs            apijson.Field
+	LastQueuedAt            apijson.Field
+	LastReviewedTime        apijson.Field
+	ManifestID              apijson.Field
+	ManifestS3ID            apijson.Field
+	Messages                apijson.Field
+	Outputs                 apijson.Field
+	OutputsPreview          apijson.Field
+	OutputsS3URLs           apijson.Field
+	ParentRunID             apijson.Field
+	ParentRunIDs            apijson.Field
+	PriceModelID            apijson.Field
+	PromptCost              apijson.Field
+	PromptCostDetails       apijson.Field
+	PromptTokenDetails      apijson.Field
+	PromptTokens            apijson.Field
+	ReferenceDatasetID      apijson.Field
+	ReferenceExampleID      apijson.Field
+	ReservedBy              apijson.Field
+	S3URLs                  apijson.Field
+	Serialized              apijson.Field
+	ShareToken              apijson.Field
+	SourceProposedExampleID apijson.Field
+	StartTime               apijson.Field
+	Tags                    apijson.Field
+	ThreadID                apijson.Field
+	TotalCost               apijson.Field
+	TotalTokens             apijson.Field
+	TraceFirstReceivedAt    apijson.Field
+	TraceMaxStartTime       apijson.Field
+	TraceMinStartTime       apijson.Field
+	TraceTier               apijson.Field
+	TraceUpgrade            apijson.Field
+	TtlSeconds              apijson.Field
+	raw                     string
+	ExtraFields             map[string]apijson.Field
 }
 
 func (r *RunSchemaWithAnnotationQueueInfo) UnmarshalJSON(data []byte) (err error) {

--- a/annotationqueuerun.go
+++ b/annotationqueuerun.go
@@ -106,24 +106,26 @@ func (r *AnnotationQueueRunService) DeleteQueue(ctx context.Context, queueID str
 }
 
 type AnnotationQueueRunNewResponse struct {
-	ID               string                            `json:"id" api:"required" format:"uuid"`
-	QueueID          string                            `json:"queue_id" api:"required" format:"uuid"`
-	RunID            string                            `json:"run_id" api:"required" format:"uuid"`
-	AddedAt          time.Time                         `json:"added_at" format:"date-time"`
-	LastReviewedTime time.Time                         `json:"last_reviewed_time" api:"nullable" format:"date-time"`
-	JSON             annotationQueueRunNewResponseJSON `json:"-"`
+	ID                      string                            `json:"id" api:"required" format:"uuid"`
+	QueueID                 string                            `json:"queue_id" api:"required" format:"uuid"`
+	RunID                   string                            `json:"run_id" api:"required" format:"uuid"`
+	AddedAt                 time.Time                         `json:"added_at" format:"date-time"`
+	LastReviewedTime        time.Time                         `json:"last_reviewed_time" api:"nullable" format:"date-time"`
+	SourceProposedExampleID string                            `json:"source_proposed_example_id" api:"nullable" format:"uuid"`
+	JSON                    annotationQueueRunNewResponseJSON `json:"-"`
 }
 
 // annotationQueueRunNewResponseJSON contains the JSON metadata for the struct
 // [AnnotationQueueRunNewResponse]
 type annotationQueueRunNewResponseJSON struct {
-	ID               apijson.Field
-	QueueID          apijson.Field
-	RunID            apijson.Field
-	AddedAt          apijson.Field
-	LastReviewedTime apijson.Field
-	raw              string
-	ExtraFields      map[string]apijson.Field
+	ID                      apijson.Field
+	QueueID                 apijson.Field
+	RunID                   apijson.Field
+	AddedAt                 apijson.Field
+	LastReviewedTime        apijson.Field
+	SourceProposedExampleID apijson.Field
+	raw                     string
+	ExtraFields             map[string]apijson.Field
 }
 
 func (r *AnnotationQueueRunNewResponse) UnmarshalJSON(data []byte) (err error) {
@@ -149,7 +151,8 @@ func (r AnnotationQueueRunNewParams) MarshalJSON() (data []byte, err error) {
 }
 
 // Satisfied by [AnnotationQueueRunNewParamsBodyRunsUuidArray],
-// [AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArray].
+// [AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArray],
+// [AnnotationQueueRunNewParamsBodyArray].
 type AnnotationQueueRunNewParamsBodyUnion interface {
 	implementsAnnotationQueueRunNewParamsBodyUnion()
 }
@@ -164,8 +167,25 @@ type AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArray []Annot
 func (r AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArray) implementsAnnotationQueueRunNewParamsBodyUnion() {
 }
 
-// Deprecated: use plain UUID list or AddRunToQueueByKeyRequest instead.
+// Add a single run to AQ (CH path) with an optional back-pointer to the
+// issues-agent proposal that seeded this add. Use when bulk-adding runs that come
+// from different proposals — each row carries its own source_proposed_example_id.
+// For unrelated bulk adds, prefer plain List[UUID] on the same endpoint.
 type AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayItem struct {
+	RunID                   param.Field[string] `json:"run_id" api:"required" format:"uuid"`
+	SourceProposedExampleID param.Field[string] `json:"source_proposed_example_id" format:"uuid"`
+}
+
+func (r AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayItem) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(r)
+}
+
+type AnnotationQueueRunNewParamsBodyArray []AnnotationQueueRunNewParamsBodyArrayItem
+
+func (r AnnotationQueueRunNewParamsBodyArray) implementsAnnotationQueueRunNewParamsBodyUnion() {}
+
+// Deprecated: use plain UUID list or AddRunToQueueByKeyRequest instead.
+type AnnotationQueueRunNewParamsBodyArrayItem struct {
 	// Deprecated: deprecated
 	RunID param.Field[string] `json:"run_id" api:"required" format:"uuid"`
 	// Deprecated: deprecated
@@ -177,23 +197,23 @@ type AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayItem str
 	// Deprecated: deprecated
 	TraceID param.Field[string] `json:"trace_id" format:"uuid"`
 	// Deprecated: deprecated
-	TraceTier param.Field[AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayTraceTier] `json:"trace_tier"`
+	TraceTier param.Field[AnnotationQueueRunNewParamsBodyArrayTraceTier] `json:"trace_tier"`
 }
 
-func (r AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayItem) MarshalJSON() (data []byte, err error) {
+func (r AnnotationQueueRunNewParamsBodyArrayItem) MarshalJSON() (data []byte, err error) {
 	return apijson.MarshalRoot(r)
 }
 
-type AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayTraceTier string
+type AnnotationQueueRunNewParamsBodyArrayTraceTier string
 
 const (
-	AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayTraceTierLonglived  AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayTraceTier = "longlived"
-	AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayTraceTierShortlived AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayTraceTier = "shortlived"
+	AnnotationQueueRunNewParamsBodyArrayTraceTierLonglived  AnnotationQueueRunNewParamsBodyArrayTraceTier = "longlived"
+	AnnotationQueueRunNewParamsBodyArrayTraceTierShortlived AnnotationQueueRunNewParamsBodyArrayTraceTier = "shortlived"
 )
 
-func (r AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayTraceTier) IsKnown() bool {
+func (r AnnotationQueueRunNewParamsBodyArrayTraceTier) IsKnown() bool {
 	switch r {
-	case AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayTraceTierLonglived, AnnotationQueueRunNewParamsBodyRunsAnnotationQueueRunAddSchemaArrayTraceTierShortlived:
+	case AnnotationQueueRunNewParamsBodyArrayTraceTierLonglived, AnnotationQueueRunNewParamsBodyArrayTraceTierShortlived:
 		return true
 	}
 	return false

--- a/config.go
+++ b/config.go
@@ -53,8 +53,9 @@ type profileState struct {
 }
 
 type profileAuth struct {
-	state *profileState
-	mu    sync.Mutex
+	state                       *profileState
+	mu                          sync.Mutex
+	managedAuthorizationHeaders map[string]struct{}
 }
 
 type oauthTokenResponse struct {
@@ -102,7 +103,7 @@ func loadProfileOptions() []option.RequestOption {
 	}
 	if !envAuthSet {
 		if hasOAuth {
-			opts = append(opts, withProfileAuth(&profileAuth{state: state}))
+			opts = append(opts, withProfileAuth(newProfileAuth(state)))
 		} else if p.APIKey != "" {
 			opts = append(opts, option.WithAPIKey(p.APIKey))
 		}
@@ -111,6 +112,13 @@ func loadProfileOptions() []option.RequestOption {
 		opts = append(opts, option.WithTenantID(p.WorkspaceID))
 	}
 	return opts
+}
+
+func newProfileAuth(state *profileState) *profileAuth {
+	return &profileAuth{
+		state:                       state,
+		managedAuthorizationHeaders: make(map[string]struct{}),
+	}
 }
 
 func loadProfileState() *profileState {
@@ -150,6 +158,9 @@ func withProfileAuth(auth *profileAuth) option.RequestOption {
 				req.Header.Del("Authorization")
 				return next(req)
 			}
+			if authorization := req.Header.Get("Authorization"); authorization != "" && !auth.isProfileAuthorizationHeader(authorization) {
+				return next(req)
+			}
 			name, value, _ := auth.authHeader(req.Context())
 			if name != "" {
 				if strings.EqualFold(name, "X-API-Key") {
@@ -169,7 +180,9 @@ func (a *profileAuth) currentAuthHeader() (name string, value string, token stri
 	if !ok {
 		return "", "", ""
 	}
-	return currentAuthHeaderFromProfile(p)
+	name, value, token = currentAuthHeaderFromProfile(p)
+	a.rememberProfileAuthHeaderLocked(name, value)
+	return name, value, token
 }
 
 func (a *profileAuth) authHeader(ctx context.Context) (name string, value string, token string) {
@@ -188,7 +201,22 @@ func (a *profileAuth) authHeader(ctx context.Context) (name string, value string
 			_ = saveConfig(a.state.path, a.state.cfg)
 		}
 	}
-	return authHeaderFromProfile(p)
+	name, value, token = authHeaderFromProfile(p)
+	a.rememberProfileAuthHeaderLocked(name, value)
+	return name, value, token
+}
+
+func (a *profileAuth) isProfileAuthorizationHeader(value string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, ok := a.managedAuthorizationHeaders[value]
+	return ok
+}
+
+func (a *profileAuth) rememberProfileAuthHeaderLocked(name, value string) {
+	if strings.EqualFold(name, "Authorization") && value != "" {
+		a.managedAuthorizationHeaders[value] = struct{}{}
+	}
 }
 
 func currentAuthHeaderFromProfile(p configProfile) (name string, value string, token string) {

--- a/config_test.go
+++ b/config_test.go
@@ -491,6 +491,68 @@ func TestLoadProfileOptions_RefreshUsesProfileAPIURL(t *testing.T) {
 	}
 }
 
+func TestLoadProfileOptions_PreservesExplicitAuthorizationHeader(t *testing.T) {
+	clearAuthEnv(t)
+	tokenRequests := 0
+	apiRequests := 0
+	var apiAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			tokenRequests++
+			_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+				AccessToken:  "new-access-token",
+				ExpiresIn:    300,
+				RefreshToken: "new-refresh-token",
+			})
+		case "/info":
+			apiRequests++
+			apiAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_url": "` + ts.URL + `",
+      "oauth": {
+        "access_token": "old-access-token",
+        "refresh_token": "old-refresh-token",
+        "expires_at": "` + time.Now().Add(-time.Minute).UTC().Format(time.RFC3339) + `"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := append(loadProfileOptions(), option.WithHeader("Authorization", "Bearer explicit-token"))
+	var out map[string]string
+	if err := requestconfig.ExecuteNewRequest(context.Background(), http.MethodGet, "/info", nil, &out, opts...); err != nil {
+		t.Fatal(err)
+	}
+	if tokenRequests != 0 {
+		t.Fatalf("expected explicit Authorization to avoid profile refresh, got %d token requests", tokenRequests)
+	}
+	if apiRequests != 1 {
+		t.Fatalf("expected one API request, got %d", apiRequests)
+	}
+	if apiAuth != "Bearer explicit-token" {
+		t.Fatalf("expected explicit Authorization header, got %q", apiAuth)
+	}
+}
+
 func TestLoadProfileOptions_OAuthAccessTokenOverridesProfileAPIKey(t *testing.T) {
 	clearAuthEnv(t)
 	dir := t.TempDir()

--- a/evaluator.go
+++ b/evaluator.go
@@ -118,6 +118,7 @@ type Evaluator struct {
 	NumFewShotExamples           int64                     `json:"num_few_shot_examples" api:"nullable"`
 	SessionID                    string                    `json:"session_id" api:"nullable" format:"uuid"`
 	SessionName                  string                    `json:"session_name" api:"nullable"`
+	SpendLimit                   EvaluatorSpendLimit       `json:"spend_limit" api:"nullable"`
 	TraceFilter                  string                    `json:"trace_filter" api:"nullable"`
 	Transient                    bool                      `json:"transient"`
 	TreeFilter                   string                    `json:"tree_filter" api:"nullable"`
@@ -162,6 +163,7 @@ type evaluatorJSON struct {
 	NumFewShotExamples           apijson.Field
 	SessionID                    apijson.Field
 	SessionName                  apijson.Field
+	SpendLimit                   apijson.Field
 	TraceFilter                  apijson.Field
 	Transient                    apijson.Field
 	TreeFilter                   apijson.Field
@@ -187,6 +189,43 @@ const (
 func (r EvaluatorGroupBy) IsKnown() bool {
 	switch r {
 	case EvaluatorGroupByThreadID:
+		return true
+	}
+	return false
+}
+
+type EvaluatorSpendLimit struct {
+	LimitUsd string                    `json:"limit_usd" api:"required"`
+	Window   EvaluatorSpendLimitWindow `json:"window" api:"required"`
+	JSON     evaluatorSpendLimitJSON   `json:"-"`
+}
+
+// evaluatorSpendLimitJSON contains the JSON metadata for the struct
+// [EvaluatorSpendLimit]
+type evaluatorSpendLimitJSON struct {
+	LimitUsd    apijson.Field
+	Window      apijson.Field
+	raw         string
+	ExtraFields map[string]apijson.Field
+}
+
+func (r *EvaluatorSpendLimit) UnmarshalJSON(data []byte) (err error) {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r evaluatorSpendLimitJSON) RawJSON() string {
+	return r.raw
+}
+
+type EvaluatorSpendLimitWindow string
+
+const (
+	EvaluatorSpendLimitWindowWeekly EvaluatorSpendLimitWindow = "weekly"
+)
+
+func (r EvaluatorSpendLimitWindow) IsKnown() bool {
+	switch r {
+	case EvaluatorSpendLimitWindowWeekly:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

Preserves explicit per-request `Authorization` headers in the Go profile auth middleware.

- Tracks bearer headers that came from profile-managed OAuth auth
- Replaces stale profile-managed bearer headers after refresh
- Leaves user-provided per-request `Authorization` headers unchanged

## Verification

- `gofmt -w config.go config_test.go`
- `git diff --check`
- `go test ./...`
