### PR TITLE
feat(sandbox): add Go command runtime helpers

### DIFF
--- a/sandbox_command_handle.go
+++ b/sandbox_command_handle.go
@@ -1,0 +1,373 @@
+package langsmith
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/option"
+	"golang.org/x/net/websocket"
+)
+
+// SandboxCommandHandle is a handle to a running sandbox command.
+type SandboxCommandHandle struct {
+	CommandID string
+	PID       int64
+
+	dataplaneURL string
+	opts         []option.RequestOption
+
+	ws        *websocket.Conn
+	sendMu    sync.Mutex
+	stateMu   sync.Mutex
+	chunks    chan SandboxOutputChunk
+	done      chan struct{}
+	result    *SandboxExecutionResult
+	err       error
+	killed    bool
+	closed    bool
+	callbacks SandboxCommandCallbacks
+	stdout    strings.Builder
+	stderr    strings.Builder
+	stdoutOf  int64
+	stderrOf  int64
+}
+
+func newSandboxCommandHandle(ws *websocket.Conn, dataplaneURL string, opts []option.RequestOption, commandID string, pid int64, stdoutOffset int64, stderrOffset int64) *SandboxCommandHandle {
+	return &SandboxCommandHandle{
+		CommandID:    commandID,
+		PID:          pid,
+		dataplaneURL: dataplaneURL,
+		opts:         append([]option.RequestOption{}, opts...),
+		ws:           ws,
+		chunks:       make(chan SandboxOutputChunk, 64),
+		done:         make(chan struct{}),
+		stdoutOf:     stdoutOffset,
+		stderrOf:     stderrOffset,
+	}
+}
+
+func (h *SandboxCommandHandle) start() {
+	go h.readLoop()
+}
+
+// Next returns the next stdout/stderr chunk. If ok is false, the command stream
+// has ended and Result returns the final command result.
+func (h *SandboxCommandHandle) Next(ctx context.Context) (chunk SandboxOutputChunk, ok bool, err error) {
+	select {
+	case chunk, ok = <-h.chunks:
+		if !ok {
+			return SandboxOutputChunk{}, false, h.Err()
+		}
+		return chunk, true, nil
+	case <-ctx.Done():
+		return SandboxOutputChunk{}, false, ctx.Err()
+	}
+}
+
+// Result waits for the command to exit and returns its final result. If output
+// chunks have not been consumed, Result drains them before returning.
+func (h *SandboxCommandHandle) Result(ctx context.Context) (*SandboxExecutionResult, error) {
+	for {
+		select {
+		case _, ok := <-h.chunks:
+			if !ok {
+				h.stateMu.Lock()
+				defer h.stateMu.Unlock()
+				if h.err != nil {
+					return nil, h.err
+				}
+				if h.result == nil {
+					return nil, &SandboxOperationError{Operation: "command", Message: "sandbox command stream ended without exit message"}
+				}
+				return h.result, nil
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// Err returns the terminal stream error, if any.
+func (h *SandboxCommandHandle) Err() error {
+	h.stateMu.Lock()
+	defer h.stateMu.Unlock()
+	return h.err
+}
+
+// Done is closed when the command stream exits or fails.
+func (h *SandboxCommandHandle) Done() <-chan struct{} {
+	return h.done
+}
+
+// Close closes the command stream connection. The command may continue running
+// on the sandbox unless it was started with KillOnDisconnect.
+func (h *SandboxCommandHandle) Close() error {
+	h.stateMu.Lock()
+	h.closed = true
+	h.stateMu.Unlock()
+	h.sendMu.Lock()
+	defer h.sendMu.Unlock()
+	return h.ws.Close()
+}
+
+// LastStdoutOffset returns the last known stdout byte offset.
+func (h *SandboxCommandHandle) LastStdoutOffset() int64 {
+	h.stateMu.Lock()
+	defer h.stateMu.Unlock()
+	return h.stdoutOf
+}
+
+// LastStderrOffset returns the last known stderr byte offset.
+func (h *SandboxCommandHandle) LastStderrOffset() int64 {
+	h.stateMu.Lock()
+	defer h.stateMu.Unlock()
+	return h.stderrOf
+}
+
+// SendInput writes data to the running command's stdin.
+func (h *SandboxCommandHandle) SendInput(data string) error {
+	h.sendMu.Lock()
+	defer h.sendMu.Unlock()
+	return websocket.JSON.Send(h.ws, map[string]string{"type": "input", "data": data})
+}
+
+// Kill sends a kill request for the running command.
+func (h *SandboxCommandHandle) Kill() error {
+	h.sendMu.Lock()
+	defer h.sendMu.Unlock()
+	h.stateMu.Lock()
+	h.killed = true
+	h.stateMu.Unlock()
+	return websocket.JSON.Send(h.ws, map[string]string{"type": "kill"})
+}
+
+// Reconnect opens a new stream for this command from the last known offsets.
+func (h *SandboxCommandHandle) Reconnect(ctx context.Context) (*SandboxCommandHandle, error) {
+	if h.CommandID == "" {
+		return nil, &SandboxOperationError{Operation: "reconnect", Message: "cannot reconnect: command ID is not available"}
+	}
+	ws, err := dialSandboxCommandWebSocket(ctx, h.dataplaneURL, h.opts...)
+	if err != nil {
+		return nil, err
+	}
+	payload := sandboxCommandReconnectRequest{
+		Type:         "reconnect",
+		CommandID:    h.CommandID,
+		StdoutOffset: h.LastStdoutOffset(),
+		StderrOffset: h.LastStderrOffset(),
+	}
+	if err := websocket.JSON.Send(ws, payload); err != nil {
+		_ = ws.Close()
+		return nil, &SandboxConnectionError{Message: fmt.Sprintf("langsmith: failed to send sandbox command reconnect request: %v", err)}
+	}
+	reconnected := newSandboxCommandHandle(ws, h.dataplaneURL, h.opts, h.CommandID, h.PID, payload.StdoutOffset, payload.StderrOffset)
+	reconnected.callbacks = h.callbacks
+	reconnected.start()
+	return reconnected, nil
+}
+
+func (h *SandboxCommandHandle) readLoop() {
+	defer close(h.done)
+	defer close(h.chunks)
+	defer h.closeCurrentWebSocket()
+
+	reconnectAttempts := 0
+	for {
+		msg, err := receiveSandboxWSMessage(context.Background(), h.ws)
+		if err != nil {
+			if !h.shouldReconnect(err, reconnectAttempts) {
+				h.setErr(err)
+				return
+			}
+			reconnectAttempts++
+			if !h.reconnectForReadLoop(reconnectAttempts) {
+				h.setErr(&SandboxConnectionError{Message: fmt.Sprintf("langsmith: lost sandbox command connection %d times in succession, giving up", reconnectAttempts)})
+				return
+			}
+			continue
+		}
+
+		switch msg.Type {
+		case "stdout", "stderr":
+			reconnectAttempts = 0
+			chunk := SandboxOutputChunk{Stream: msg.Type, Data: msg.Data, Offset: msg.Offset}
+			h.appendChunk(chunk)
+			h.invokeCallback(chunk)
+			h.chunks <- chunk
+		case "exit":
+			h.setResult(msg.ExitCode)
+			return
+		case "error":
+			h.setErr(sandboxErrorFromWSMessage(msg, h.CommandID))
+			return
+		case "started":
+			if h.CommandID == "" {
+				h.CommandID = msg.CommandID
+			}
+			if h.PID == 0 {
+				h.PID = msg.PID
+			}
+		default:
+			h.setErr(&SandboxOperationError{Operation: "command", Message: fmt.Sprintf("unknown sandbox command message type %q", msg.Type)})
+			return
+		}
+	}
+}
+
+func (h *SandboxCommandHandle) shouldReconnect(err error, attempts int) bool {
+	var connErr *SandboxConnectionError
+	if !errors.As(err, &connErr) {
+		return false
+	}
+	h.stateMu.Lock()
+	defer h.stateMu.Unlock()
+	if h.killed || h.closed || h.CommandID == "" {
+		return false
+	}
+	return attempts < sandboxCommandMaxAutoReconnects
+}
+
+func (h *SandboxCommandHandle) reconnectForReadLoop(attempt int) bool {
+	delay := sandboxCommandReconnectBackoffBase << max(0, attempt-1)
+	if delay > sandboxCommandReconnectBackoffMax {
+		delay = sandboxCommandReconnectBackoffMax
+	}
+	time.Sleep(delay)
+	if h.isClosedOrKilled() {
+		return false
+	}
+
+	ws, err := dialSandboxCommandWebSocket(context.Background(), h.dataplaneURL, h.opts...)
+	if err != nil {
+		return false
+	}
+	payload := sandboxCommandReconnectRequest{
+		Type:         "reconnect",
+		CommandID:    h.CommandID,
+		StdoutOffset: h.LastStdoutOffset(),
+		StderrOffset: h.LastStderrOffset(),
+	}
+	if err := websocket.JSON.Send(ws, payload); err != nil {
+		_ = ws.Close()
+		return false
+	}
+
+	h.sendMu.Lock()
+	old := h.ws
+	h.ws = ws
+	h.sendMu.Unlock()
+	_ = old.Close()
+	return true
+}
+
+func (h *SandboxCommandHandle) isClosedOrKilled() bool {
+	h.stateMu.Lock()
+	defer h.stateMu.Unlock()
+	return h.closed || h.killed
+}
+
+func (h *SandboxCommandHandle) closeCurrentWebSocket() {
+	h.sendMu.Lock()
+	defer h.sendMu.Unlock()
+	_ = h.ws.Close()
+}
+
+func (h *SandboxCommandHandle) invokeCallback(chunk SandboxOutputChunk) {
+	if chunk.Stream == "stdout" && h.callbacks.OnStdout != nil {
+		h.callbacks.OnStdout(chunk.Data)
+	}
+	if chunk.Stream == "stderr" && h.callbacks.OnStderr != nil {
+		h.callbacks.OnStderr(chunk.Data)
+	}
+}
+
+func (h *SandboxCommandHandle) appendChunk(chunk SandboxOutputChunk) {
+	h.stateMu.Lock()
+	defer h.stateMu.Unlock()
+	if chunk.Stream == "stdout" {
+		h.stdout.WriteString(chunk.Data)
+		h.stdoutOf = chunk.Offset + int64(len([]byte(chunk.Data)))
+		return
+	}
+	h.stderr.WriteString(chunk.Data)
+	h.stderrOf = chunk.Offset + int64(len([]byte(chunk.Data)))
+}
+
+func (h *SandboxCommandHandle) setResult(exitCode int64) {
+	h.stateMu.Lock()
+	defer h.stateMu.Unlock()
+	h.result = &SandboxExecutionResult{
+		Stdout:   h.stdout.String(),
+		Stderr:   h.stderr.String(),
+		ExitCode: exitCode,
+	}
+}
+
+func (h *SandboxCommandHandle) setErr(err error) {
+	h.stateMu.Lock()
+	defer h.stateMu.Unlock()
+	h.err = err
+}
+
+func receiveSandboxWSMessage(ctx context.Context, ws *websocket.Conn) (sandboxWSMessage, error) {
+	type receiveResult struct {
+		msg sandboxWSMessage
+		err error
+	}
+	ch := make(chan receiveResult, 1)
+	go func() {
+		var raw string
+		if err := websocket.Message.Receive(ws, &raw); err != nil {
+			ch <- receiveResult{err: &SandboxConnectionError{Message: fmt.Sprintf("langsmith: sandbox command WebSocket closed unexpectedly: %v", err)}}
+			return
+		}
+		var msg sandboxWSMessage
+		if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+			ch <- receiveResult{err: &SandboxOperationError{Operation: "command", Message: fmt.Sprintf("failed to parse sandbox command message: %v", err)}}
+			return
+		}
+		ch <- receiveResult{msg: msg}
+	}()
+
+	select {
+	case res := <-ch:
+		return res.msg, res.err
+	case <-ctx.Done():
+		_ = ws.Close()
+		return sandboxWSMessage{}, ctx.Err()
+	}
+}
+
+func sandboxErrorFromWSMessage(msg sandboxWSMessage, commandID string) error {
+	errorType := msg.ErrorType
+	if errorType == "" {
+		errorType = "CommandError"
+	}
+	message := msg.Error
+	if message == "" {
+		message = "unknown sandbox command error"
+	}
+	if errorType == "CommandTimeout" {
+		return &SandboxCommandTimeoutError{Message: message}
+	}
+	if errorType == "CommandNotFound" && commandID != "" {
+		message = fmt.Sprintf("command not found: %s", commandID)
+	}
+	if errorType == "SessionExpired" && commandID != "" {
+		message = fmt.Sprintf("session expired: %s", commandID)
+	}
+	operation := "command"
+	if commandID != "" {
+		operation = "reconnect"
+	}
+	return &SandboxOperationError{
+		Operation: operation,
+		ErrorType: errorType,
+		Message:   message,
+	}
+}

--- a/sandbox_command_handle_test.go
+++ b/sandbox_command_handle_test.go
@@ -1,0 +1,42 @@
+package langsmith
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSandboxCommandHandleNextContextCancellation(t *testing.T) {
+	handle := &SandboxCommandHandle{
+		chunks: make(chan SandboxOutputChunk),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	_, ok, err := handle.Next(ctx)
+	if ok {
+		t.Fatal("expected no chunk after context cancellation")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline error, got %T: %v", err, err)
+	}
+}
+
+func TestSandboxCommandHandleErrAndDone(t *testing.T) {
+	errDone := errors.New("stream failed")
+	handle := &SandboxCommandHandle{
+		done: make(chan struct{}),
+	}
+	handle.setErr(errDone)
+	close(handle.done)
+
+	if got := handle.Err(); !errors.Is(got, errDone) {
+		t.Fatalf("expected stored error, got %v", got)
+	}
+	select {
+	case <-handle.Done():
+	case <-time.After(time.Second):
+		t.Fatal("expected Done channel to be closed")
+	}
+}

--- a/sandbox_command_methods.go
+++ b/sandbox_command_methods.go
@@ -1,0 +1,44 @@
+package langsmith
+
+import (
+	"context"
+
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+// Run executes a command and waits for completion.
+func (s *Sandbox) Run(ctx context.Context, body SandboxBoxRunParams, opts ...option.RequestOption) (*SandboxExecutionResult, error) {
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return s.boxes.RunWithDataplaneURL(ctx, dataplaneURL, body, opts...)
+}
+
+// StartCommand starts a streaming command in this sandbox.
+func (s *Sandbox) StartCommand(ctx context.Context, body SandboxCommandStartParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return s.boxes.StartCommandWithDataplaneURL(ctx, dataplaneURL, body, opts...)
+}
+
+// RunWithCallbacks starts a WebSocket command, invokes callbacks for output,
+// and waits for completion.
+func (s *Sandbox) RunWithCallbacks(ctx context.Context, body SandboxCommandStartParams, callbacks SandboxCommandCallbacks, opts ...option.RequestOption) (*SandboxExecutionResult, error) {
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return s.boxes.RunWithDataplaneURLAndCallbacks(ctx, dataplaneURL, body, callbacks, opts...)
+}
+
+// ReconnectCommand reconnects to a command stream.
+func (s *Sandbox) ReconnectCommand(ctx context.Context, commandID string, body SandboxCommandReconnectParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return s.boxes.ReconnectCommandWithDataplaneURL(ctx, dataplaneURL, commandID, body, opts...)
+}

--- a/sandbox_command_methods_test.go
+++ b/sandbox_command_methods_test.go
@@ -1,0 +1,70 @@
+package langsmith
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+func TestSandboxCommandWrapperRunUsesCurrentDataplaneURL(t *testing.T) {
+	var gotPayload map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/execute" {
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"stdout":    "ok",
+			"stderr":    "",
+			"exit_code": 0,
+		})
+	}))
+	defer srv.Close()
+
+	sandbox := &Sandbox{
+		Name:         "box-a",
+		Status:       "ready",
+		DataplaneURL: srv.URL,
+		boxes: NewSandboxBoxService(
+			option.WithBaseURL("http://control-plane.test"),
+			option.WithAPIKey("test-api-key"),
+			option.WithMaxRetries(0),
+		),
+	}
+
+	result, err := sandbox.Run(context.Background(), SandboxBoxRunParams{Command: String("echo ok")})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Stdout != "ok" || !result.Success() {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if gotPayload["command"] != "echo ok" {
+		t.Fatalf("unexpected command payload: %#v", gotPayload["command"])
+	}
+}
+
+func TestSandboxCommandWrapperRejectsNotReadySandbox(t *testing.T) {
+	sandbox := &Sandbox{
+		Name:         "box-a",
+		Status:       "starting",
+		DataplaneURL: "https://sandbox.example",
+		boxes:        NewSandboxBoxService(),
+	}
+
+	_, err := sandbox.Run(context.Background(), SandboxBoxRunParams{Command: String("echo ok")})
+	var notReady *SandboxNotReadyError
+	if !errors.As(err, &notReady) {
+		t.Fatalf("expected SandboxNotReadyError, got %T: %v", err, err)
+	}
+}

--- a/sandbox_commands.go
+++ b/sandbox_commands.go
@@ -1,0 +1,338 @@
+package langsmith
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/internal/apijson"
+	"github.com/langchain-ai/langsmith-go/internal/param"
+	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
+	"github.com/langchain-ai/langsmith-go/option"
+	"golang.org/x/net/websocket"
+)
+
+const (
+	defaultSandboxCommandTimeoutSeconds = int64(60)
+	defaultSandboxCommandShell          = "/bin/bash"
+	defaultSandboxCommandIdleTimeout    = int64(300)
+	defaultSandboxCommandTTLSeconds     = int64(600)
+	sandboxCommandMaxAutoReconnects     = 5
+	sandboxCommandReconnectBackoffBase  = 500 * time.Millisecond
+	sandboxCommandReconnectBackoffMax   = 8 * time.Second
+)
+
+// SandboxExecutionResult is the result of executing a command in a sandbox.
+type SandboxExecutionResult struct {
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode int64  `json:"exit_code"`
+}
+
+// Success reports whether the command exited with code 0.
+func (r SandboxExecutionResult) Success() bool {
+	return r.ExitCode == 0
+}
+
+// SandboxBoxRunParams configures a blocking sandbox command execution.
+type SandboxBoxRunParams struct {
+	Command param.Field[string]            `json:"command" api:"required"`
+	Timeout param.Field[int64]             `json:"timeout"`
+	Env     param.Field[map[string]string] `json:"env"`
+	CWD     param.Field[string]            `json:"cwd"`
+	Shell   param.Field[string]            `json:"shell"`
+}
+
+func (r SandboxBoxRunParams) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(r)
+}
+
+// SandboxCommandStartParams configures a streaming WebSocket command execution.
+type SandboxCommandStartParams struct {
+	Command            param.Field[string]            `json:"command" api:"required"`
+	TimeoutSeconds     param.Field[int64]             `json:"timeout_seconds"`
+	Env                param.Field[map[string]string] `json:"env"`
+	CWD                param.Field[string]            `json:"cwd"`
+	Shell              param.Field[string]            `json:"shell"`
+	IdleTimeoutSeconds param.Field[int64]             `json:"idle_timeout_seconds"`
+	KillOnDisconnect   param.Field[bool]              `json:"kill_on_disconnect"`
+	TTLSeconds         param.Field[int64]             `json:"ttl_seconds"`
+	Pty                param.Field[bool]              `json:"pty"`
+}
+
+func (r SandboxCommandStartParams) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(r)
+}
+
+// SandboxCommandReconnectParams configures a command stream reconnection.
+type SandboxCommandReconnectParams struct {
+	StdoutOffset param.Field[int64] `json:"stdout_offset"`
+	StderrOffset param.Field[int64] `json:"stderr_offset"`
+}
+
+func (r SandboxCommandReconnectParams) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(r)
+}
+
+// SandboxOutputChunk is a single chunk of streaming command output.
+type SandboxOutputChunk struct {
+	Stream string `json:"stream"`
+	Data   string `json:"data"`
+	Offset int64  `json:"offset"`
+}
+
+// SandboxCommandCallbacks are invoked as streaming command output arrives.
+type SandboxCommandCallbacks struct {
+	OnStdout func(string)
+	OnStderr func(string)
+}
+
+// Run executes a command in the named sandbox and waits for completion. The
+// sandbox is fetched first so the current dataplane URL can be used.
+func (r *SandboxBoxService) Run(ctx context.Context, name string, body SandboxBoxRunParams, opts ...option.RequestOption) (res *SandboxExecutionResult, err error) {
+	box, err := r.Get(ctx, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return r.RunWithDataplaneURL(ctx, dataplaneURL, body, opts...)
+}
+
+// RunWithDataplaneURL executes a command against a sandbox dataplane URL and
+// waits for completion.
+func (r *SandboxBoxService) RunWithDataplaneURL(ctx context.Context, dataplaneURL string, body SandboxBoxRunParams, opts ...option.RequestOption) (res *SandboxExecutionResult, err error) {
+	opts = slices.Concat(r.Options, opts)
+	body, timeoutSeconds, err := normalizeSandboxRunParams(body)
+	if err != nil {
+		return nil, err
+	}
+	path, err := sandboxDataplaneURL(dataplaneURL, "execute")
+	if err != nil {
+		return nil, err
+	}
+
+	requestTimeout := time.Duration(timeoutSeconds+10) * time.Second
+	opts = slices.Concat([]option.RequestOption{option.WithRequestTimeout(requestTimeout)}, opts)
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
+	return res, err
+}
+
+// StartCommand starts a streaming command in the named sandbox. The returned
+// handle can stream output, send stdin, kill the command, and reconnect.
+func (r *SandboxBoxService) StartCommand(ctx context.Context, name string, body SandboxCommandStartParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	box, err := r.Get(ctx, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return r.StartCommandWithDataplaneURL(ctx, dataplaneURL, body, opts...)
+}
+
+// StartCommandWithDataplaneURL starts a streaming command against a sandbox
+// dataplane URL.
+func (r *SandboxBoxService) StartCommandWithDataplaneURL(ctx context.Context, dataplaneURL string, body SandboxCommandStartParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	return r.startCommandWithDataplaneURL(ctx, dataplaneURL, body, SandboxCommandCallbacks{}, opts...)
+}
+
+// RunWithCallbacks starts a command in the named sandbox over WebSocket, invokes
+// callbacks for streamed output, and waits for completion.
+func (r *SandboxBoxService) RunWithCallbacks(ctx context.Context, name string, body SandboxCommandStartParams, callbacks SandboxCommandCallbacks, opts ...option.RequestOption) (*SandboxExecutionResult, error) {
+	handle, err := r.StartCommandWithCallbacks(ctx, name, body, callbacks, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return handle.Result(ctx)
+}
+
+// RunWithDataplaneURLAndCallbacks starts a command over WebSocket against a
+// dataplane URL, invokes callbacks for streamed output, and waits for completion.
+func (r *SandboxBoxService) RunWithDataplaneURLAndCallbacks(ctx context.Context, dataplaneURL string, body SandboxCommandStartParams, callbacks SandboxCommandCallbacks, opts ...option.RequestOption) (*SandboxExecutionResult, error) {
+	handle, err := r.StartCommandWithDataplaneURLAndCallbacks(ctx, dataplaneURL, body, callbacks, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return handle.Result(ctx)
+}
+
+// StartCommandWithCallbacks starts a streaming command in the named sandbox and
+// invokes callbacks for stdout/stderr chunks as they arrive.
+func (r *SandboxBoxService) StartCommandWithCallbacks(ctx context.Context, name string, body SandboxCommandStartParams, callbacks SandboxCommandCallbacks, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	box, err := r.Get(ctx, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return r.StartCommandWithDataplaneURLAndCallbacks(ctx, dataplaneURL, body, callbacks, opts...)
+}
+
+// StartCommandWithDataplaneURLAndCallbacks starts a streaming command against a
+// dataplane URL and invokes callbacks for stdout/stderr chunks as they arrive.
+func (r *SandboxBoxService) StartCommandWithDataplaneURLAndCallbacks(ctx context.Context, dataplaneURL string, body SandboxCommandStartParams, callbacks SandboxCommandCallbacks, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	return r.startCommandWithDataplaneURL(ctx, dataplaneURL, body, callbacks, opts...)
+}
+
+func (r *SandboxBoxService) startCommandWithDataplaneURL(ctx context.Context, dataplaneURL string, body SandboxCommandStartParams, callbacks SandboxCommandCallbacks, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	opts = slices.Concat(r.Options, opts)
+	payload, err := normalizeSandboxCommandStartParams(body)
+	if err != nil {
+		return nil, err
+	}
+
+	ws, err := dialSandboxCommandWebSocket(ctx, dataplaneURL, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := websocket.JSON.Send(ws, payload); err != nil {
+		_ = ws.Close()
+		return nil, &SandboxConnectionError{Message: fmt.Sprintf("langsmith: failed to send sandbox command request: %v", err)}
+	}
+
+	started, err := receiveSandboxWSMessage(ctx, ws)
+	if err != nil {
+		_ = ws.Close()
+		return nil, err
+	}
+	if started.Type == "error" {
+		_ = ws.Close()
+		return nil, sandboxErrorFromWSMessage(started, "")
+	}
+	if started.Type != "started" {
+		_ = ws.Close()
+		return nil, &SandboxOperationError{
+			Operation: "command",
+			Message:   fmt.Sprintf("expected sandbox command started message, got %q", started.Type),
+		}
+	}
+
+	handle := newSandboxCommandHandle(ws, dataplaneURL, opts, started.CommandID, started.PID, 0, 0)
+	handle.callbacks = callbacks
+	handle.start()
+	return handle, nil
+}
+
+// ReconnectCommand reconnects to a running or recently-finished command in the
+// named sandbox.
+func (r *SandboxBoxService) ReconnectCommand(ctx context.Context, name string, commandID string, body SandboxCommandReconnectParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	if commandID == "" {
+		return nil, errors.New("missing required commandID parameter")
+	}
+	box, err := r.Get(ctx, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return r.ReconnectCommandWithDataplaneURL(ctx, dataplaneURL, commandID, body, opts...)
+}
+
+// ReconnectCommandWithDataplaneURL reconnects to a command stream against a
+// sandbox dataplane URL.
+func (r *SandboxBoxService) ReconnectCommandWithDataplaneURL(ctx context.Context, dataplaneURL string, commandID string, body SandboxCommandReconnectParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	if commandID == "" {
+		return nil, errors.New("missing required commandID parameter")
+	}
+	opts = slices.Concat(r.Options, opts)
+	stdoutOffset := sandboxFieldValue(body.StdoutOffset, int64(0))
+	stderrOffset := sandboxFieldValue(body.StderrOffset, int64(0))
+
+	ws, err := dialSandboxCommandWebSocket(ctx, dataplaneURL, opts...)
+	if err != nil {
+		return nil, err
+	}
+	payload := sandboxCommandReconnectRequest{
+		Type:         "reconnect",
+		CommandID:    commandID,
+		StdoutOffset: stdoutOffset,
+		StderrOffset: stderrOffset,
+	}
+	if err := websocket.JSON.Send(ws, payload); err != nil {
+		_ = ws.Close()
+		return nil, &SandboxConnectionError{Message: fmt.Sprintf("langsmith: failed to send sandbox command reconnect request: %v", err)}
+	}
+
+	handle := newSandboxCommandHandle(ws, dataplaneURL, opts, commandID, 0, stdoutOffset, stderrOffset)
+	handle.start()
+	return handle, nil
+}
+
+type sandboxCommandStartRequest struct {
+	Type               param.Field[string]            `json:"type" api:"required"`
+	Command            param.Field[string]            `json:"command" api:"required"`
+	TimeoutSeconds     param.Field[int64]             `json:"timeout_seconds"`
+	Env                param.Field[map[string]string] `json:"env"`
+	CWD                param.Field[string]            `json:"cwd"`
+	Shell              param.Field[string]            `json:"shell"`
+	IdleTimeoutSeconds param.Field[int64]             `json:"idle_timeout_seconds"`
+	KillOnDisconnect   param.Field[bool]              `json:"kill_on_disconnect"`
+	TTLSeconds         param.Field[int64]             `json:"ttl_seconds"`
+	Pty                param.Field[bool]              `json:"pty"`
+}
+
+func (r sandboxCommandStartRequest) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(r)
+}
+
+type sandboxCommandReconnectRequest struct {
+	Type         string `json:"type"`
+	CommandID    string `json:"command_id"`
+	StdoutOffset int64  `json:"stdout_offset"`
+	StderrOffset int64  `json:"stderr_offset"`
+}
+
+type sandboxWSMessage struct {
+	Type      string `json:"type"`
+	CommandID string `json:"command_id"`
+	PID       int64  `json:"pid"`
+	Stream    string `json:"stream"`
+	Data      string `json:"data"`
+	Offset    int64  `json:"offset"`
+	ExitCode  int64  `json:"exit_code"`
+	Error     string `json:"error"`
+	ErrorType string `json:"error_type"`
+}
+
+func normalizeSandboxRunParams(body SandboxBoxRunParams) (SandboxBoxRunParams, int64, error) {
+	command, ok := sandboxRequiredString(body.Command)
+	if !ok {
+		return SandboxBoxRunParams{}, 0, errors.New("missing required command parameter")
+	}
+	timeout := sandboxFieldValue(body.Timeout, defaultSandboxCommandTimeoutSeconds)
+	shell := sandboxFieldValue(body.Shell, defaultSandboxCommandShell)
+	body.Command = F(command)
+	body.Timeout = F(timeout)
+	body.Shell = F(shell)
+	return body, timeout, nil
+}
+
+func normalizeSandboxCommandStartParams(body SandboxCommandStartParams) (sandboxCommandStartRequest, error) {
+	command, ok := sandboxRequiredString(body.Command)
+	if !ok {
+		return sandboxCommandStartRequest{}, errors.New("missing required command parameter")
+	}
+	return sandboxCommandStartRequest{
+		Type:               F("execute"),
+		Command:            F(command),
+		TimeoutSeconds:     F(sandboxFieldValue(body.TimeoutSeconds, defaultSandboxCommandTimeoutSeconds)),
+		Env:                body.Env,
+		CWD:                body.CWD,
+		Shell:              F(sandboxFieldValue(body.Shell, defaultSandboxCommandShell)),
+		IdleTimeoutSeconds: F(sandboxFieldValue(body.IdleTimeoutSeconds, defaultSandboxCommandIdleTimeout)),
+		KillOnDisconnect:   F(sandboxFieldValue(body.KillOnDisconnect, false)),
+		TTLSeconds:         F(sandboxFieldValue(body.TTLSeconds, defaultSandboxCommandTTLSeconds)),
+		Pty:                body.Pty,
+	}, nil
+}

--- a/sandbox_commands_internal_test.go
+++ b/sandbox_commands_internal_test.go
@@ -1,0 +1,71 @@
+package langsmith
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNormalizeSandboxRunParamsDefaults(t *testing.T) {
+	params, timeout, err := normalizeSandboxRunParams(SandboxBoxRunParams{Command: String("echo ok")})
+	if err != nil {
+		t.Fatalf("normalizeSandboxRunParams returned error: %v", err)
+	}
+	if timeout != defaultSandboxCommandTimeoutSeconds {
+		t.Fatalf("unexpected timeout: %d", timeout)
+	}
+	if params.Timeout.Value != defaultSandboxCommandTimeoutSeconds {
+		t.Fatalf("expected default timeout field, got %d", params.Timeout.Value)
+	}
+	if params.Shell.Value != defaultSandboxCommandShell {
+		t.Fatalf("expected default shell, got %q", params.Shell.Value)
+	}
+}
+
+func TestNormalizeSandboxCommandStartParamsDefaultsAndMissingCommand(t *testing.T) {
+	payload, err := normalizeSandboxCommandStartParams(SandboxCommandStartParams{Command: String("echo ok")})
+	if err != nil {
+		t.Fatalf("normalizeSandboxCommandStartParams returned error: %v", err)
+	}
+	if payload.Type.Value != "execute" {
+		t.Fatalf("unexpected payload type: %q", payload.Type.Value)
+	}
+	if payload.TimeoutSeconds.Value != defaultSandboxCommandTimeoutSeconds {
+		t.Fatalf("unexpected timeout: %d", payload.TimeoutSeconds.Value)
+	}
+	if payload.Shell.Value != defaultSandboxCommandShell {
+		t.Fatalf("unexpected shell: %q", payload.Shell.Value)
+	}
+	if payload.IdleTimeoutSeconds.Value != defaultSandboxCommandIdleTimeout {
+		t.Fatalf("unexpected idle timeout: %d", payload.IdleTimeoutSeconds.Value)
+	}
+	if payload.TTLSeconds.Value != defaultSandboxCommandTTLSeconds {
+		t.Fatalf("unexpected ttl: %d", payload.TTLSeconds.Value)
+	}
+
+	if _, err := normalizeSandboxCommandStartParams(SandboxCommandStartParams{}); err == nil {
+		t.Fatal("expected missing command error")
+	}
+	if _, _, err := normalizeSandboxRunParams(SandboxBoxRunParams{}); err == nil {
+		t.Fatal("expected missing run command error")
+	}
+}
+
+func TestSandboxErrorFromWSMessage(t *testing.T) {
+	timeoutErr := sandboxErrorFromWSMessage(sandboxWSMessage{
+		Type:      "error",
+		ErrorType: "CommandTimeout",
+		Error:     "deadline exceeded",
+	}, "cmd-1")
+	var commandTimeout *SandboxCommandTimeoutError
+	if !errors.As(timeoutErr, &commandTimeout) {
+		t.Fatalf("expected SandboxCommandTimeoutError, got %T: %v", timeoutErr, timeoutErr)
+	}
+
+	notFoundErr := sandboxErrorFromWSMessage(sandboxWSMessage{
+		Type:      "error",
+		ErrorType: "CommandNotFound",
+	}, "cmd-1")
+	if notFoundErr.Error() != "command not found: cmd-1 [CommandNotFound]" {
+		t.Fatalf("unexpected command not found error: %v", notFoundErr)
+	}
+}

--- a/sandbox_commands_test.go
+++ b/sandbox_commands_test.go
@@ -1,0 +1,431 @@
+package langsmith_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/option"
+	"golang.org/x/net/websocket"
+)
+
+func TestSandboxBoxRunWithDataplaneURL(t *testing.T) {
+	var gotPayload map[string]any
+	var gotAPIKey string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/execute" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotAPIKey = r.Header.Get("X-API-Key")
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"stdout":    "hello\n",
+			"stderr":    "",
+			"exit_code": 0,
+		})
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	res, err := client.Sandboxes.Boxes.RunWithDataplaneURL(context.Background(), srv.URL, langsmith.SandboxBoxRunParams{
+		Command: langsmith.String("echo hello"),
+		Timeout: langsmith.Int(12),
+		Env: langsmith.F(map[string]string{
+			"NAME": "value",
+		}),
+		CWD:   langsmith.String("/tmp"),
+		Shell: langsmith.String("/bin/sh"),
+	})
+	if err != nil {
+		t.Fatalf("RunWithDataplaneURL returned error: %v", err)
+	}
+	if res.Stdout != "hello\n" || res.Stderr != "" || res.ExitCode != 0 {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+	if !res.Success() {
+		t.Fatal("expected result to be successful")
+	}
+	if gotAPIKey != "test-api-key" {
+		t.Fatalf("expected API key header, got %q", gotAPIKey)
+	}
+	if gotPayload["command"] != "echo hello" {
+		t.Fatalf("expected command payload, got %#v", gotPayload["command"])
+	}
+	if gotPayload["timeout"] != float64(12) {
+		t.Fatalf("expected timeout payload, got %#v", gotPayload["timeout"])
+	}
+	if gotPayload["shell"] != "/bin/sh" {
+		t.Fatalf("expected shell payload, got %#v", gotPayload["shell"])
+	}
+	if gotPayload["cwd"] != "/tmp" {
+		t.Fatalf("expected cwd payload, got %#v", gotPayload["cwd"])
+	}
+	env, ok := gotPayload["env"].(map[string]any)
+	if !ok || env["NAME"] != "value" {
+		t.Fatalf("expected env payload, got %#v", gotPayload["env"])
+	}
+}
+
+func TestSandboxBoxRunFetchesDataplaneURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/test-box":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":          "test-box",
+				"status":        "ready",
+				"dataplane_url": srvURL(r),
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/execute":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"stdout":    "ok",
+				"stderr":    "",
+				"exit_code": 0,
+			})
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	res, err := client.Sandboxes.Boxes.Run(context.Background(), "test-box", langsmith.SandboxBoxRunParams{
+		Command: langsmith.String("true"),
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if res.Stdout != "ok" {
+		t.Fatalf("expected stdout ok, got %q", res.Stdout)
+	}
+}
+
+func TestSandboxCommandHandleWebSocketLifecycle(t *testing.T) {
+	executePayload := make(chan map[string]any, 1)
+	inputPayload := make(chan map[string]any, 1)
+	killPayload := make(chan map[string]any, 1)
+
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		var msg map[string]any
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive execute: %v", err)
+			return
+		}
+		executePayload <- msg
+		if err := websocket.Message.Send(ws, `{"type":"started","command_id":"cmd-123","pid":42}`); err != nil {
+			t.Errorf("send started: %v", err)
+			return
+		}
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive input: %v", err)
+			return
+		}
+		inputPayload <- msg
+		if err := websocket.Message.Send(ws, `{"type":"stdout","data":"ready\n","offset":0}`); err != nil {
+			t.Errorf("send stdout: %v", err)
+			return
+		}
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive kill: %v", err)
+			return
+		}
+		killPayload <- msg
+		if err := websocket.Message.Send(ws, `{"type":"exit","exit_code":137}`); err != nil {
+			t.Errorf("send exit: %v", err)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	handle, err := client.Sandboxes.Boxes.StartCommandWithDataplaneURL(context.Background(), srv.URL, langsmith.SandboxCommandStartParams{
+		Command:            langsmith.String("python3 -u -i"),
+		TimeoutSeconds:     langsmith.Int(90),
+		Shell:              langsmith.String("/bin/sh"),
+		IdleTimeoutSeconds: langsmith.Int(-1),
+		TTLSeconds:         langsmith.Int(120),
+		Pty:                langsmith.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("StartCommandWithDataplaneURL returned error: %v", err)
+	}
+	if handle.CommandID != "cmd-123" {
+		t.Fatalf("expected command id, got %q", handle.CommandID)
+	}
+	if handle.PID != 42 {
+		t.Fatalf("expected pid 42, got %d", handle.PID)
+	}
+
+	execute := <-executePayload
+	if execute["type"] != "execute" || execute["command"] != "python3 -u -i" {
+		t.Fatalf("unexpected execute payload: %#v", execute)
+	}
+	if execute["timeout_seconds"] != float64(90) {
+		t.Fatalf("unexpected timeout_seconds: %#v", execute["timeout_seconds"])
+	}
+	if execute["shell"] != "/bin/sh" {
+		t.Fatalf("unexpected shell: %#v", execute["shell"])
+	}
+	if execute["idle_timeout_seconds"] != float64(-1) {
+		t.Fatalf("unexpected idle_timeout_seconds: %#v", execute["idle_timeout_seconds"])
+	}
+	if execute["ttl_seconds"] != float64(120) {
+		t.Fatalf("unexpected ttl_seconds: %#v", execute["ttl_seconds"])
+	}
+	if execute["pty"] != true {
+		t.Fatalf("unexpected pty: %#v", execute["pty"])
+	}
+
+	if err := handle.SendInput("print('hi')\n"); err != nil {
+		t.Fatalf("SendInput returned error: %v", err)
+	}
+	input := <-inputPayload
+	if input["type"] != "input" || input["data"] != "print('hi')\n" {
+		t.Fatalf("unexpected input payload: %#v", input)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	chunk, ok, err := handle.Next(ctx)
+	if err != nil {
+		t.Fatalf("Next returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected output chunk")
+	}
+	if chunk.Stream != "stdout" || chunk.Data != "ready\n" || chunk.Offset != 0 {
+		t.Fatalf("unexpected chunk: %#v", chunk)
+	}
+	if handle.LastStdoutOffset() != int64(len("ready\n")) {
+		t.Fatalf("unexpected stdout offset: %d", handle.LastStdoutOffset())
+	}
+
+	if err := handle.Kill(); err != nil {
+		t.Fatalf("Kill returned error: %v", err)
+	}
+	kill := <-killPayload
+	if kill["type"] != "kill" {
+		t.Fatalf("unexpected kill payload: %#v", kill)
+	}
+
+	result, err := handle.Result(ctx)
+	if err != nil {
+		t.Fatalf("Result returned error: %v", err)
+	}
+	if result.Stdout != "ready\n" || result.ExitCode != 137 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestSandboxReconnectCommandWithDataplaneURL(t *testing.T) {
+	reconnectPayload := make(chan map[string]any, 1)
+
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		var msg map[string]any
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive reconnect: %v", err)
+			return
+		}
+		reconnectPayload <- msg
+		if err := websocket.Message.Send(ws, `{"type":"stderr","data":"warn\n","offset":3}`); err != nil {
+			t.Errorf("send stderr: %v", err)
+			return
+		}
+		if err := websocket.Message.Send(ws, `{"type":"exit","exit_code":0}`); err != nil {
+			t.Errorf("send exit: %v", err)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	handle, err := client.Sandboxes.Boxes.ReconnectCommandWithDataplaneURL(context.Background(), srv.URL, "cmd-123", langsmith.SandboxCommandReconnectParams{
+		StdoutOffset: langsmith.Int(7),
+		StderrOffset: langsmith.Int(3),
+	})
+	if err != nil {
+		t.Fatalf("ReconnectCommandWithDataplaneURL returned error: %v", err)
+	}
+	if handle.CommandID != "cmd-123" {
+		t.Fatalf("expected command id, got %q", handle.CommandID)
+	}
+
+	reconnect := <-reconnectPayload
+	if reconnect["type"] != "reconnect" || reconnect["command_id"] != "cmd-123" {
+		t.Fatalf("unexpected reconnect payload: %#v", reconnect)
+	}
+	if reconnect["stdout_offset"] != float64(7) {
+		t.Fatalf("unexpected stdout offset: %#v", reconnect["stdout_offset"])
+	}
+	if reconnect["stderr_offset"] != float64(3) {
+		t.Fatalf("unexpected stderr offset: %#v", reconnect["stderr_offset"])
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	chunk, ok, err := handle.Next(ctx)
+	if err != nil {
+		t.Fatalf("Next returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected output chunk")
+	}
+	if chunk.Stream != "stderr" || chunk.Data != "warn\n" || chunk.Offset != 3 {
+		t.Fatalf("unexpected chunk: %#v", chunk)
+	}
+	if handle.LastStderrOffset() != int64(8) {
+		t.Fatalf("unexpected stderr offset: %d", handle.LastStderrOffset())
+	}
+
+	result, err := handle.Result(ctx)
+	if err != nil {
+		t.Fatalf("Result returned error: %v", err)
+	}
+	if result.Stderr != "warn\n" || result.ExitCode != 0 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestSandboxRunWithCallbacks(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		var msg map[string]any
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive execute: %v", err)
+			return
+		}
+		if err := websocket.Message.Send(ws, `{"type":"started","command_id":"cmd-123","pid":42}`); err != nil {
+			t.Errorf("send started: %v", err)
+			return
+		}
+		if err := websocket.Message.Send(ws, `{"type":"stdout","data":"out","offset":0}`); err != nil {
+			t.Errorf("send stdout: %v", err)
+			return
+		}
+		if err := websocket.Message.Send(ws, `{"type":"stderr","data":"err","offset":0}`); err != nil {
+			t.Errorf("send stderr: %v", err)
+			return
+		}
+		if err := websocket.Message.Send(ws, `{"type":"exit","exit_code":0}`); err != nil {
+			t.Errorf("send exit: %v", err)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	result, err := client.Sandboxes.Boxes.RunWithDataplaneURLAndCallbacks(context.Background(), srv.URL, langsmith.SandboxCommandStartParams{
+		Command: langsmith.String("make test"),
+	}, langsmith.SandboxCommandCallbacks{
+		OnStdout: func(data string) { stdout.WriteString(data) },
+		OnStderr: func(data string) { stderr.WriteString(data) },
+	})
+	if err != nil {
+		t.Fatalf("RunWithDataplaneURLAndCallbacks returned error: %v", err)
+	}
+	if result.Stdout != "out" || result.Stderr != "err" || result.ExitCode != 0 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if stdout.String() != "out" || stderr.String() != "err" {
+		t.Fatalf("unexpected callbacks: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestSandboxCommandHandleAutoReconnect(t *testing.T) {
+	reconnectPayload := make(chan map[string]any, 1)
+	var connections atomic.Int64
+
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		conn := connections.Add(1)
+		var msg map[string]any
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive message: %v", err)
+			return
+		}
+		if conn == 1 {
+			if err := websocket.Message.Send(ws, `{"type":"started","command_id":"cmd-123","pid":42}`); err != nil {
+				t.Errorf("send started: %v", err)
+				return
+			}
+			if err := websocket.Message.Send(ws, `{"type":"stdout","data":"one","offset":0}`); err != nil {
+				t.Errorf("send stdout: %v", err)
+				return
+			}
+			_ = ws.Close()
+			return
+		}
+		reconnectPayload <- msg
+		if err := websocket.Message.Send(ws, `{"type":"stdout","data":"two","offset":3}`); err != nil {
+			t.Errorf("send reconnected stdout: %v", err)
+			return
+		}
+		if err := websocket.Message.Send(ws, `{"type":"exit","exit_code":0}`); err != nil {
+			t.Errorf("send exit: %v", err)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	handle, err := client.Sandboxes.Boxes.StartCommandWithDataplaneURL(context.Background(), srv.URL, langsmith.SandboxCommandStartParams{
+		Command: langsmith.String("printf onetwo"),
+	})
+	if err != nil {
+		t.Fatalf("StartCommandWithDataplaneURL returned error: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	result, err := handle.Result(ctx)
+	if err != nil {
+		t.Fatalf("Result returned error: %v", err)
+	}
+	if result.Stdout != "onetwo" || result.ExitCode != 0 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	reconnect := <-reconnectPayload
+	if reconnect["type"] != "reconnect" || reconnect["command_id"] != "cmd-123" {
+		t.Fatalf("unexpected reconnect payload: %#v", reconnect)
+	}
+	if reconnect["stdout_offset"] != float64(3) || reconnect["stderr_offset"] != float64(0) {
+		t.Fatalf("unexpected reconnect offsets: %#v", reconnect)
+	}
+	if connections.Load() != 2 {
+		t.Fatalf("expected 2 websocket connections, got %d", connections.Load())
+	}
+}

--- a/sandbox_errors.go
+++ b/sandbox_errors.go
@@ -1,0 +1,99 @@
+package langsmith
+
+import (
+	"fmt"
+	"time"
+)
+
+// SandboxDataplaneNotConfiguredError is returned when runtime operations are
+// requested before the sandbox has a dataplane URL.
+type SandboxDataplaneNotConfiguredError struct {
+	SandboxName string
+}
+
+func (e *SandboxDataplaneNotConfiguredError) Error() string {
+	if e.SandboxName == "" {
+		return "langsmith: sandbox does not have a dataplane_url configured"
+	}
+	return fmt.Sprintf("langsmith: sandbox %q does not have a dataplane_url configured", e.SandboxName)
+}
+
+// SandboxNotReadyError is returned when runtime operations are requested for a
+// sandbox that is not ready.
+type SandboxNotReadyError struct {
+	SandboxName string
+	Status      string
+}
+
+func (e *SandboxNotReadyError) Error() string {
+	if e.SandboxName == "" {
+		return fmt.Sprintf("langsmith: sandbox is not ready (status: %s)", e.Status)
+	}
+	return fmt.Sprintf("langsmith: sandbox %q is not ready (status: %s)", e.SandboxName, e.Status)
+}
+
+// SandboxConnectionError is returned when a sandbox WebSocket command stream
+// cannot be established or is interrupted unexpectedly.
+type SandboxConnectionError struct {
+	Message string
+}
+
+func (e *SandboxConnectionError) Error() string {
+	return e.Message
+}
+
+// SandboxOperationError is returned when the sandbox dataplane reports a
+// command operation error.
+type SandboxOperationError struct {
+	Operation string
+	ErrorType string
+	Message   string
+}
+
+func (e *SandboxOperationError) Error() string {
+	if e.ErrorType != "" {
+		return fmt.Sprintf("%s [%s]", e.Message, e.ErrorType)
+	}
+	return e.Message
+}
+
+// SandboxCommandTimeoutError is returned when the sandbox reports a command
+// timeout.
+type SandboxCommandTimeoutError struct {
+	Message string
+}
+
+func (e *SandboxCommandTimeoutError) Error() string {
+	return e.Message
+}
+
+// SandboxResourceTimeoutError is returned when waiting for a sandbox resource
+// exceeds the configured timeout.
+type SandboxResourceTimeoutError struct {
+	ResourceType string
+	ResourceID   string
+	LastStatus   string
+	Timeout      time.Duration
+}
+
+func (e *SandboxResourceTimeoutError) Error() string {
+	if e.LastStatus != "" {
+		return fmt.Sprintf("langsmith: %s %q not ready after %s (last_status: %s)", e.ResourceType, e.ResourceID, e.Timeout, e.LastStatus)
+	}
+	return fmt.Sprintf("langsmith: %s %q not ready after %s", e.ResourceType, e.ResourceID, e.Timeout)
+}
+
+// SandboxResourceCreationError is returned when a sandbox resource reaches a
+// failed provisioning state.
+type SandboxResourceCreationError struct {
+	ResourceType string
+	ResourceID   string
+	Message      string
+}
+
+func (e *SandboxResourceCreationError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("langsmith: %s %q failed: %s", e.ResourceType, e.ResourceID, e.Message)
+	}
+	return fmt.Sprintf("langsmith: %s %q failed", e.ResourceType, e.ResourceID)
+}

--- a/sandbox_errors_test.go
+++ b/sandbox_errors_test.go
@@ -1,0 +1,58 @@
+package langsmith
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSandboxErrorMessages(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "dataplane not configured with sandbox name",
+			err:  &SandboxDataplaneNotConfiguredError{SandboxName: "box-a"},
+			want: `langsmith: sandbox "box-a" does not have a dataplane_url configured`,
+		},
+		{
+			name: "sandbox not ready",
+			err:  &SandboxNotReadyError{SandboxName: "box-a", Status: "starting"},
+			want: `langsmith: sandbox "box-a" is not ready (status: starting)`,
+		},
+		{
+			name: "connection error",
+			err:  &SandboxConnectionError{Message: "dial failed"},
+			want: "dial failed",
+		},
+		{
+			name: "operation error includes type",
+			err:  &SandboxOperationError{ErrorType: "CommandError", Message: "bad command"},
+			want: "bad command [CommandError]",
+		},
+		{
+			name: "command timeout",
+			err:  &SandboxCommandTimeoutError{Message: "timed out"},
+			want: "timed out",
+		},
+		{
+			name: "resource timeout includes last status",
+			err:  &SandboxResourceTimeoutError{ResourceType: "sandbox", ResourceID: "box-a", LastStatus: "starting", Timeout: 2 * time.Second},
+			want: `langsmith: sandbox "box-a" not ready after 2s (last_status: starting)`,
+		},
+		{
+			name: "resource creation includes message",
+			err:  &SandboxResourceCreationError{ResourceType: "snapshot", ResourceID: "snap-a", Message: "builder failed"},
+			want: `langsmith: snapshot "snap-a" failed: builder failed`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/sandbox_files.go
+++ b/sandbox_files.go
@@ -1,0 +1,111 @@
+package langsmith
+
+import (
+	"bytes"
+	"context"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"slices"
+
+	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+// ReadFile reads a file from a named sandbox.
+func (r *SandboxBoxService) ReadFile(ctx context.Context, name string, path string, opts ...option.RequestOption) ([]byte, error) {
+	box, err := r.Get(ctx, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return r.ReadFileWithDataplaneURL(ctx, dataplaneURL, path, opts...)
+}
+
+// ReadFileWithDataplaneURL reads a file directly from a sandbox dataplane URL.
+func (r *SandboxBoxService) ReadFileWithDataplaneURL(ctx context.Context, dataplaneURL string, path string, opts ...option.RequestOption) ([]byte, error) {
+	opts = slices.Concat(r.Options, opts)
+	requestURL, err := sandboxDataplaneURL(dataplaneURL, "download")
+	if err != nil {
+		return nil, err
+	}
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("path", path)
+	u.RawQuery = q.Encode()
+
+	var out []byte
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, u.String(), nil, &out, opts...)
+	return out, err
+}
+
+// WriteFile writes bytes to a file in a named sandbox.
+func (r *SandboxBoxService) WriteFile(ctx context.Context, name string, path string, content []byte, opts ...option.RequestOption) error {
+	box, err := r.Get(ctx, name, opts...)
+	if err != nil {
+		return err
+	}
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	if err != nil {
+		return err
+	}
+	return r.WriteFileWithDataplaneURL(ctx, dataplaneURL, path, content, opts...)
+}
+
+// WriteFileWithDataplaneURL writes bytes directly to a sandbox dataplane URL.
+func (r *SandboxBoxService) WriteFileWithDataplaneURL(ctx context.Context, dataplaneURL string, path string, content []byte, opts ...option.RequestOption) error {
+	opts = slices.Concat(r.Options, opts)
+	requestURL, err := sandboxDataplaneURL(dataplaneURL, "upload")
+	if err != nil {
+		return err
+	}
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return err
+	}
+	q := u.Query()
+	q.Set("path", path)
+	u.RawQuery = q.Encode()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", "file")
+	if err != nil {
+		return err
+	}
+	if _, err := part.Write(content); err != nil {
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+
+	opts = slices.Concat([]option.RequestOption{
+		option.WithRequestBody(writer.FormDataContentType(), &buf),
+	}, opts)
+	return requestconfig.ExecuteNewRequest(ctx, http.MethodPost, u.String(), nil, nil, opts...)
+}
+
+// ReadFile reads a file from this sandbox.
+func (s *Sandbox) ReadFile(ctx context.Context, path string, opts ...option.RequestOption) ([]byte, error) {
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return s.boxes.ReadFileWithDataplaneURL(ctx, dataplaneURL, path, opts...)
+}
+
+// WriteFile writes bytes to a file in this sandbox.
+func (s *Sandbox) WriteFile(ctx context.Context, path string, content []byte, opts ...option.RequestOption) error {
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	if err != nil {
+		return err
+	}
+	return s.boxes.WriteFileWithDataplaneURL(ctx, dataplaneURL, path, content, opts...)
+}

--- a/sandbox_files_test.go
+++ b/sandbox_files_test.go
@@ -1,0 +1,76 @@
+package langsmith_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+func TestSandboxFileMethodsResolveNamedSandbox(t *testing.T) {
+	var uploaded bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/box-a":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":          "box-a",
+				"status":        "ready",
+				"dataplane_url": srvURL(r),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/download":
+			if got := r.URL.Query().Get("path"); got != "/tmp/read.txt" {
+				t.Fatalf("unexpected download path: %q", got)
+			}
+			_, _ = w.Write([]byte("downloaded"))
+		case r.Method == http.MethodPost && r.URL.Path == "/upload":
+			if got := r.URL.Query().Get("path"); got != "/tmp/write.txt" {
+				t.Fatalf("unexpected upload path: %q", got)
+			}
+			file, _, err := r.FormFile("file")
+			if err != nil {
+				t.Fatalf("read upload file: %v", err)
+			}
+			defer file.Close()
+			content, err := io.ReadAll(file)
+			if err != nil {
+				t.Fatalf("read upload content: %v", err)
+			}
+			if string(content) != "uploaded" {
+				t.Fatalf("unexpected upload content: %q", string(content))
+			}
+			uploaded = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+
+	content, err := client.Sandboxes.Boxes.ReadFile(context.Background(), "box-a", "/tmp/read.txt")
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if string(content) != "downloaded" {
+		t.Fatalf("unexpected read content: %q", string(content))
+	}
+
+	if err := client.Sandboxes.Boxes.WriteFile(context.Background(), "box-a", "/tmp/write.txt", []byte("uploaded")); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if !uploaded {
+		t.Fatal("expected upload request")
+	}
+}

--- a/sandbox_internal.go
+++ b/sandbox_internal.go
@@ -1,0 +1,155 @@
+package langsmith
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/internal/param"
+	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
+	"github.com/langchain-ai/langsmith-go/option"
+	"golang.org/x/net/websocket"
+)
+
+func sandboxRequiredString(field param.Field[string]) (string, bool) {
+	if !field.Present || field.Null {
+		return "", false
+	}
+	if field.Value != "" {
+		return field.Value, true
+	}
+	if raw, ok := field.Raw.(string); ok && raw != "" {
+		return raw, true
+	}
+	return "", false
+}
+
+func sandboxFieldValue[T any](field param.Field[T], fallback T) T {
+	if field.Present && !field.Null {
+		return field.Value
+	}
+	return fallback
+}
+
+func requireSandboxDataplaneURL(name string, status string, dataplaneURL string) (string, error) {
+	if status != "" && status != "ready" {
+		return "", &SandboxNotReadyError{SandboxName: name, Status: status}
+	}
+	if dataplaneURL == "" {
+		return "", &SandboxDataplaneNotConfiguredError{SandboxName: name}
+	}
+	return dataplaneURL, nil
+}
+
+func sandboxDataplaneURL(dataplaneURL string, path string) (string, error) {
+	u, err := url.Parse(dataplaneURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid sandbox dataplane URL %q", dataplaneURL)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/" + strings.TrimLeft(path, "/")
+	return u.String(), nil
+}
+
+func sandboxWebSocketURL(dataplaneURL string) (string, error) {
+	u, err := url.Parse(dataplaneURL)
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "ws", "wss":
+	default:
+		return "", fmt.Errorf("unsupported sandbox dataplane URL scheme %q", u.Scheme)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/execute/ws"
+	u.RawQuery = ""
+	return u.String(), nil
+}
+
+func dialSandboxCommandWebSocket(ctx context.Context, dataplaneURL string, opts ...option.RequestOption) (*websocket.Conn, error) {
+	wsURL, err := sandboxWebSocketURL(dataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return dialSandboxWebSocketURL(ctx, wsURL, opts...)
+}
+
+func dialSandboxWebSocketURL(ctx context.Context, wsURL string, opts ...option.RequestOption) (*websocket.Conn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	headers, err := sandboxHeaders(ctx, wsURL, opts...)
+	if err != nil {
+		return nil, err
+	}
+	origin, err := sandboxWebSocketOrigin(wsURL)
+	if err != nil {
+		return nil, err
+	}
+	config, err := websocket.NewConfig(wsURL, origin)
+	if err != nil {
+		return nil, err
+	}
+	config.Header = headers
+
+	type dialResult struct {
+		ws  *websocket.Conn
+		err error
+	}
+	ch := make(chan dialResult, 1)
+	go func() {
+		ws, err := websocket.DialConfig(config)
+		ch <- dialResult{ws: ws, err: err}
+	}()
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			return nil, &SandboxConnectionError{Message: fmt.Sprintf("langsmith: failed to connect to sandbox command WebSocket: %v", res.err)}
+		}
+		return res.ws, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func sandboxWebSocketOrigin(wsURL string) (string, error) {
+	u, err := url.Parse(wsURL)
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "ws":
+		u.Scheme = "http"
+	case "wss":
+		u.Scheme = "https"
+	}
+	u.Path = "/"
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+func sandboxHeaders(ctx context.Context, requestURL string, opts ...option.RequestOption) (http.Header, error) {
+	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, requestURL, nil, nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Request.Header.Clone(), nil
+}
+
+func minDuration(a time.Duration, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/sandbox_internal_test.go
+++ b/sandbox_internal_test.go
@@ -1,0 +1,94 @@
+package langsmith
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+func TestSandboxInternalFieldHelpers(t *testing.T) {
+	if got, ok := sandboxRequiredString(String("echo ok")); !ok || got != "echo ok" {
+		t.Fatalf("expected required string from value, got %q ok=%v", got, ok)
+	}
+	if got, ok := sandboxRequiredString(Raw[string]("raw command")); !ok || got != "raw command" {
+		t.Fatalf("expected required string from raw value, got %q ok=%v", got, ok)
+	}
+	if got, ok := sandboxRequiredString(Null[string]()); ok || got != "" {
+		t.Fatalf("expected null string to be missing, got %q ok=%v", got, ok)
+	}
+	if got := sandboxFieldValue(Int(7), int64(3)); got != 7 {
+		t.Fatalf("expected explicit field value, got %d", got)
+	}
+	if got := sandboxFieldValue(Null[int64](), int64(3)); got != 3 {
+		t.Fatalf("expected fallback value, got %d", got)
+	}
+}
+
+func TestSandboxInternalURLHelpers(t *testing.T) {
+	dataplaneURL, err := sandboxDataplaneURL("https://sandbox.example/base/", "/execute")
+	if err != nil {
+		t.Fatalf("sandboxDataplaneURL returned error: %v", err)
+	}
+	if dataplaneURL != "https://sandbox.example/base/execute" {
+		t.Fatalf("unexpected dataplane URL: %q", dataplaneURL)
+	}
+
+	wsURL, err := sandboxWebSocketURL("https://sandbox.example/base/")
+	if err != nil {
+		t.Fatalf("sandboxWebSocketURL returned error: %v", err)
+	}
+	if wsURL != "wss://sandbox.example/base/execute/ws" {
+		t.Fatalf("unexpected websocket URL: %q", wsURL)
+	}
+
+	origin, err := sandboxWebSocketOrigin("wss://sandbox.example/base/execute/ws")
+	if err != nil {
+		t.Fatalf("sandboxWebSocketOrigin returned error: %v", err)
+	}
+	if origin != "https://sandbox.example/" {
+		t.Fatalf("unexpected websocket origin: %q", origin)
+	}
+
+	if _, err := sandboxDataplaneURL("sandbox.example", "execute"); err == nil {
+		t.Fatal("expected invalid dataplane URL error")
+	}
+	if _, err := sandboxWebSocketURL("ftp://sandbox.example"); err == nil {
+		t.Fatal("expected unsupported websocket scheme error")
+	}
+}
+
+func TestRequireSandboxDataplaneURL(t *testing.T) {
+	got, err := requireSandboxDataplaneURL("box-a", "ready", "https://sandbox.example")
+	if err != nil {
+		t.Fatalf("requireSandboxDataplaneURL returned error: %v", err)
+	}
+	if got != "https://sandbox.example" {
+		t.Fatalf("unexpected dataplane URL: %q", got)
+	}
+
+	var notReady *SandboxNotReadyError
+	if _, err := requireSandboxDataplaneURL("box-a", "starting", "https://sandbox.example"); !errors.As(err, &notReady) {
+		t.Fatalf("expected SandboxNotReadyError, got %T: %v", err, err)
+	}
+
+	var notConfigured *SandboxDataplaneNotConfiguredError
+	if _, err := requireSandboxDataplaneURL("box-a", "ready", ""); !errors.As(err, &notConfigured) {
+		t.Fatalf("expected SandboxDataplaneNotConfiguredError, got %T: %v", err, err)
+	}
+}
+
+func TestSandboxHeadersAndMinDuration(t *testing.T) {
+	headers, err := sandboxHeaders(context.Background(), "https://sandbox.example/execute", option.WithAPIKey("test-api-key"))
+	if err != nil {
+		t.Fatalf("sandboxHeaders returned error: %v", err)
+	}
+	if got := headers.Get("X-API-Key"); got != "test-api-key" {
+		t.Fatalf("expected API key header, got %q", got)
+	}
+	if got := minDuration(10*time.Millisecond, time.Second); got != 10*time.Millisecond {
+		t.Fatalf("unexpected min duration: %s", got)
+	}
+}

--- a/sandbox_resource.go
+++ b/sandbox_resource.go
@@ -1,0 +1,192 @@
+package langsmith
+
+import (
+	"context"
+
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+// Sandbox is a convenience wrapper around generated sandbox box responses.
+type Sandbox struct {
+	ID              string
+	Name            string
+	DataplaneURL    string
+	Status          string
+	StatusMessage   string
+	CreatedAt       string
+	UpdatedAt       string
+	TTLSeconds      int64
+	IdleTTLSeconds  int64
+	ExpiresAt       string
+	SnapshotID      string
+	Vcpus           int64
+	MemBytes        int64
+	FsCapacityBytes int64
+
+	boxes *SandboxBoxService
+}
+
+// NewSandbox creates a sandbox and returns the convenience wrapper.
+func (r *SandboxBoxService) NewSandbox(ctx context.Context, body SandboxBoxNewParams, opts ...option.RequestOption) (*Sandbox, error) {
+	res, err := r.New(ctx, body, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return sandboxFromNewResponse(res, r), nil
+}
+
+// GetSandbox retrieves a sandbox and returns the convenience wrapper.
+func (r *SandboxBoxService) GetSandbox(ctx context.Context, name string, opts ...option.RequestOption) (*Sandbox, error) {
+	res, err := r.Get(ctx, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return sandboxFromGetResponse(res, r), nil
+}
+
+// ListSandboxes lists sandboxes and returns convenience wrappers.
+func (r *SandboxBoxService) ListSandboxes(ctx context.Context, query SandboxBoxListParams, opts ...option.RequestOption) ([]*Sandbox, error) {
+	res, err := r.List(ctx, query, opts...)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*Sandbox, 0, len(res.Sandboxes))
+	for i := range res.Sandboxes {
+		out = append(out, sandboxFromListResponse(&res.Sandboxes[i], r))
+	}
+	return out, nil
+}
+
+// Refresh fetches latest sandbox state and updates this object.
+func (s *Sandbox) Refresh(ctx context.Context, opts ...option.RequestOption) error {
+	box, err := s.boxes.Get(ctx, s.Name, opts...)
+	if err != nil {
+		return err
+	}
+	s.applyGetResponse(box)
+	return nil
+}
+
+// Update updates this sandbox and refreshes this object's fields.
+func (s *Sandbox) Update(ctx context.Context, body SandboxBoxUpdateParams, opts ...option.RequestOption) error {
+	box, err := s.boxes.Update(ctx, s.Name, body, opts...)
+	if err != nil {
+		return err
+	}
+	s.applyUpdateResponse(box)
+	return nil
+}
+
+// Start starts this sandbox and waits until it is ready.
+func (s *Sandbox) Start(ctx context.Context, params SandboxWaitParams, opts ...option.RequestOption) error {
+	box, err := s.boxes.StartAndWait(ctx, s.Name, params, opts...)
+	if err != nil {
+		return err
+	}
+	s.applyGetResponse(box)
+	return nil
+}
+
+// Stop stops this sandbox.
+func (s *Sandbox) Stop(ctx context.Context, opts ...option.RequestOption) error {
+	if err := s.boxes.Stop(ctx, s.Name, opts...); err != nil {
+		return err
+	}
+	s.Status = "stopped"
+	s.DataplaneURL = ""
+	return nil
+}
+
+// Delete deletes this sandbox.
+func (s *Sandbox) Delete(ctx context.Context, opts ...option.RequestOption) error {
+	return s.boxes.Delete(ctx, s.Name, opts...)
+}
+
+func sandboxFromNewResponse(res *SandboxBoxNewResponse, boxes *SandboxBoxService) *Sandbox {
+	if res == nil {
+		return nil
+	}
+	return &Sandbox{
+		ID:              res.ID,
+		Name:            res.Name,
+		DataplaneURL:    res.DataplaneURL,
+		Status:          res.Status,
+		StatusMessage:   res.StatusMessage,
+		CreatedAt:       res.CreatedAt,
+		UpdatedAt:       res.UpdatedAt,
+		TTLSeconds:      res.TtlSeconds,
+		IdleTTLSeconds:  res.IdleTtlSeconds,
+		ExpiresAt:       res.ExpiresAt,
+		SnapshotID:      res.SnapshotID,
+		Vcpus:           res.Vcpus,
+		MemBytes:        res.MemBytes,
+		FsCapacityBytes: res.FsCapacityBytes,
+		boxes:           boxes,
+	}
+}
+
+func sandboxFromGetResponse(res *SandboxBoxGetResponse, boxes *SandboxBoxService) *Sandbox {
+	if res == nil {
+		return nil
+	}
+	sb := &Sandbox{boxes: boxes}
+	sb.applyGetResponse(res)
+	return sb
+}
+
+func sandboxFromListResponse(res *SandboxBoxListResponseSandbox, boxes *SandboxBoxService) *Sandbox {
+	if res == nil {
+		return nil
+	}
+	return &Sandbox{
+		ID:              res.ID,
+		Name:            res.Name,
+		DataplaneURL:    res.DataplaneURL,
+		Status:          res.Status,
+		StatusMessage:   res.StatusMessage,
+		CreatedAt:       res.CreatedAt,
+		UpdatedAt:       res.UpdatedAt,
+		TTLSeconds:      res.TtlSeconds,
+		IdleTTLSeconds:  res.IdleTtlSeconds,
+		ExpiresAt:       res.ExpiresAt,
+		SnapshotID:      res.SnapshotID,
+		Vcpus:           res.Vcpus,
+		MemBytes:        res.MemBytes,
+		FsCapacityBytes: res.FsCapacityBytes,
+		boxes:           boxes,
+	}
+}
+
+func (s *Sandbox) applyGetResponse(res *SandboxBoxGetResponse) {
+	s.ID = res.ID
+	s.Name = res.Name
+	s.DataplaneURL = res.DataplaneURL
+	s.Status = res.Status
+	s.StatusMessage = res.StatusMessage
+	s.CreatedAt = res.CreatedAt
+	s.UpdatedAt = res.UpdatedAt
+	s.TTLSeconds = res.TtlSeconds
+	s.IdleTTLSeconds = res.IdleTtlSeconds
+	s.ExpiresAt = res.ExpiresAt
+	s.SnapshotID = res.SnapshotID
+	s.Vcpus = res.Vcpus
+	s.MemBytes = res.MemBytes
+	s.FsCapacityBytes = res.FsCapacityBytes
+}
+
+func (s *Sandbox) applyUpdateResponse(res *SandboxBoxUpdateResponse) {
+	s.ID = res.ID
+	s.Name = res.Name
+	s.DataplaneURL = res.DataplaneURL
+	s.Status = res.Status
+	s.StatusMessage = res.StatusMessage
+	s.CreatedAt = res.CreatedAt
+	s.UpdatedAt = res.UpdatedAt
+	s.TTLSeconds = res.TtlSeconds
+	s.IdleTTLSeconds = res.IdleTtlSeconds
+	s.ExpiresAt = res.ExpiresAt
+	s.SnapshotID = res.SnapshotID
+	s.Vcpus = res.Vcpus
+	s.MemBytes = res.MemBytes
+	s.FsCapacityBytes = res.FsCapacityBytes
+}

--- a/sandbox_resource_test.go
+++ b/sandbox_resource_test.go
@@ -1,0 +1,143 @@
+package langsmith_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+func TestSandboxResourceWrappers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes/boxes":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":                "new-id",
+				"name":              "new-box",
+				"status":            "starting",
+				"dataplane_url":     "https://sandbox.example/new",
+				"ttl_seconds":       600,
+				"fs_capacity_bytes": 1024,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/new-box":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":                "get-id",
+				"name":              "new-box",
+				"status":            "ready",
+				"dataplane_url":     "https://sandbox.example/get",
+				"ttl_seconds":       700,
+				"fs_capacity_bytes": 2048,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"offset": 0,
+				"sandboxes": []map[string]any{
+					{
+						"id":                "list-id",
+						"name":              "listed-box",
+						"status":            "ready",
+						"dataplane_url":     "https://sandbox.example/list",
+						"ttl_seconds":       800,
+						"fs_capacity_bytes": 4096,
+					},
+				},
+			})
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+
+	created, err := client.Sandboxes.Boxes.NewSandbox(context.Background(), langsmith.SandboxBoxNewParams{
+		SnapshotID: langsmith.String("snapshot-id"),
+		Name:       langsmith.String("new-box"),
+	})
+	if err != nil {
+		t.Fatalf("NewSandbox returned error: %v", err)
+	}
+	if created.Name != "new-box" || created.DataplaneURL != "https://sandbox.example/new" || created.TTLSeconds != 600 {
+		t.Fatalf("unexpected created sandbox: %#v", created)
+	}
+
+	got, err := client.Sandboxes.Boxes.GetSandbox(context.Background(), "new-box")
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got.Name != "new-box" || got.Status != "ready" || got.FsCapacityBytes != 2048 {
+		t.Fatalf("unexpected fetched sandbox: %#v", got)
+	}
+
+	listed, err := client.Sandboxes.Boxes.ListSandboxes(context.Background(), langsmith.SandboxBoxListParams{})
+	if err != nil {
+		t.Fatalf("ListSandboxes returned error: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Name != "listed-box" || listed[0].DataplaneURL != "https://sandbox.example/list" {
+		t.Fatalf("unexpected listed sandboxes: %#v", listed)
+	}
+}
+
+func TestSandboxRefreshUpdateAndStop(t *testing.T) {
+	var stopped bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/box-a":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":            "box-id",
+				"name":          "box-a",
+				"status":        "ready",
+				"dataplane_url": "https://sandbox.example/refreshed",
+			})
+		case r.Method == http.MethodPatch && r.URL.Path == "/v2/sandboxes/boxes/box-a":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":            "box-id",
+				"name":          "box-renamed",
+				"status":        "ready",
+				"dataplane_url": "https://sandbox.example/updated",
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes/boxes/box-renamed/stop":
+			stopped = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	sandbox, err := client.Sandboxes.Boxes.GetSandbox(context.Background(), "box-a")
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if sandbox.DataplaneURL != "https://sandbox.example/refreshed" {
+		t.Fatalf("unexpected refreshed dataplane URL: %q", sandbox.DataplaneURL)
+	}
+	if err := sandbox.Update(context.Background(), langsmith.SandboxBoxUpdateParams{Name: langsmith.String("box-renamed")}); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+	if sandbox.Name != "box-renamed" || sandbox.DataplaneURL != "https://sandbox.example/updated" {
+		t.Fatalf("unexpected updated sandbox: %#v", sandbox)
+	}
+	if err := sandbox.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+	if !stopped || sandbox.Status != "stopped" || sandbox.DataplaneURL != "" {
+		t.Fatalf("unexpected stopped state: stopped=%v sandbox=%#v", stopped, sandbox)
+	}
+}

--- a/sandbox_service_url.go
+++ b/sandbox_service_url.go
@@ -1,0 +1,201 @@
+package langsmith
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+const (
+	sandboxServiceAuthHeader           = "X-Langsmith-Sandbox-Service-Token"
+	defaultSandboxServiceURLTTLSeconds = int64(600)
+	maxSandboxServiceURLTTLSeconds     = int64(86400)
+)
+
+// Service returns an auto-refreshing authenticated service URL helper.
+func (r *SandboxBoxService) Service(ctx context.Context, name string, body SandboxBoxGenerateServiceURLParams, opts ...option.RequestOption) (*SandboxServiceURL, error) {
+	body, err := normalizeSandboxServiceURLParams(body)
+	if err != nil {
+		return nil, err
+	}
+	res, err := r.GenerateServiceURL(ctx, name, body, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return newSandboxServiceURL(res, func(ctx context.Context) (*SandboxServiceURL, error) {
+		return r.Service(ctx, name, body, opts...)
+	}), nil
+}
+
+// SandboxServiceURL is an authenticated URL for an HTTP service inside a sandbox.
+type SandboxServiceURL struct {
+	mu        sync.Mutex
+	browser   string
+	service   string
+	token     string
+	expiresAt string
+	refresher func(context.Context) (*SandboxServiceURL, error)
+}
+
+func newSandboxServiceURL(res *SandboxBoxGenerateServiceURLResponse, refresher func(context.Context) (*SandboxServiceURL, error)) *SandboxServiceURL {
+	return &SandboxServiceURL{
+		browser:   res.BrowserURL,
+		service:   res.ServiceURL,
+		token:     res.Token,
+		expiresAt: res.ExpiresAt,
+		refresher: refresher,
+	}
+}
+
+// BrowserURL returns a URL suitable for browser use, refreshing the token if it
+// is near expiry.
+func (s *SandboxServiceURL) BrowserURL(ctx context.Context) (string, error) {
+	if err := s.refreshIfNeeded(ctx); err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.browser, nil
+}
+
+// ServiceURL returns the base service URL, refreshing the token if it is near
+// expiry.
+func (s *SandboxServiceURL) ServiceURL(ctx context.Context) (string, error) {
+	if err := s.refreshIfNeeded(ctx); err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.service, nil
+}
+
+// Token returns the raw service token, refreshing it if it is near expiry.
+func (s *SandboxServiceURL) Token(ctx context.Context) (string, error) {
+	if err := s.refreshIfNeeded(ctx); err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.token, nil
+}
+
+// ExpiresAt returns the token expiration timestamp, refreshing it if it is near
+// expiry.
+func (s *SandboxServiceURL) ExpiresAt(ctx context.Context) (string, error) {
+	if err := s.refreshIfNeeded(ctx); err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.expiresAt, nil
+}
+
+// Request sends an HTTP request to the sandbox service and injects the service
+// auth token.
+func (s *SandboxServiceURL) Request(ctx context.Context, method string, path string, body io.Reader, headers http.Header) (*http.Response, error) {
+	if err := s.refreshIfNeeded(ctx); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	base := s.service
+	token := s.token
+	s.mu.Unlock()
+
+	requestURL := strings.TrimRight(base, "/") + "/" + strings.TrimLeft(path, "/")
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
+	if err != nil {
+		return nil, err
+	}
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	req.Header.Set(sandboxServiceAuthHeader, token)
+	return http.DefaultClient.Do(req)
+}
+
+// Get sends a GET request to the sandbox service.
+func (s *SandboxServiceURL) Get(ctx context.Context, path string, headers http.Header) (*http.Response, error) {
+	return s.Request(ctx, http.MethodGet, path, nil, headers)
+}
+
+// Post sends a POST request to the sandbox service.
+func (s *SandboxServiceURL) Post(ctx context.Context, path string, body io.Reader, headers http.Header) (*http.Response, error) {
+	return s.Request(ctx, http.MethodPost, path, body, headers)
+}
+
+// Put sends a PUT request to the sandbox service.
+func (s *SandboxServiceURL) Put(ctx context.Context, path string, body io.Reader, headers http.Header) (*http.Response, error) {
+	return s.Request(ctx, http.MethodPut, path, body, headers)
+}
+
+// Patch sends a PATCH request to the sandbox service.
+func (s *SandboxServiceURL) Patch(ctx context.Context, path string, body io.Reader, headers http.Header) (*http.Response, error) {
+	return s.Request(ctx, http.MethodPatch, path, body, headers)
+}
+
+// Delete sends a DELETE request to the sandbox service.
+func (s *SandboxServiceURL) Delete(ctx context.Context, path string, headers http.Header) (*http.Response, error) {
+	return s.Request(ctx, http.MethodDelete, path, nil, headers)
+}
+
+func (s *SandboxServiceURL) refreshIfNeeded(ctx context.Context) error {
+	s.mu.Lock()
+	if !s.shouldRefreshLocked() || s.refresher == nil {
+		s.mu.Unlock()
+		return nil
+	}
+	refresher := s.refresher
+	s.mu.Unlock()
+
+	fresh, err := refresher(ctx)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.browser = fresh.browser
+	s.service = fresh.service
+	s.token = fresh.token
+	s.expiresAt = fresh.expiresAt
+	s.refresher = fresh.refresher
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *SandboxServiceURL) shouldRefreshLocked() bool {
+	if s.expiresAt == "" {
+		return false
+	}
+	expires, err := time.Parse(time.RFC3339, strings.Replace(s.expiresAt, "Z", "+00:00", 1))
+	if err != nil {
+		return false
+	}
+	return time.Until(expires) <= 30*time.Second
+}
+
+// Service returns an auto-refreshing service URL helper for this sandbox.
+func (s *Sandbox) Service(ctx context.Context, body SandboxBoxGenerateServiceURLParams, opts ...option.RequestOption) (*SandboxServiceURL, error) {
+	return s.boxes.Service(ctx, s.Name, body, opts...)
+}
+
+func normalizeSandboxServiceURLParams(body SandboxBoxGenerateServiceURLParams) (SandboxBoxGenerateServiceURLParams, error) {
+	port := sandboxFieldValue(body.Port, int64(0))
+	if port < 1 || port > 65535 {
+		return SandboxBoxGenerateServiceURLParams{}, fmt.Errorf("port must be between 1 and 65535, got %d", port)
+	}
+	expiresInSeconds := sandboxFieldValue(body.ExpiresInSeconds, defaultSandboxServiceURLTTLSeconds)
+	if expiresInSeconds < 1 || expiresInSeconds > maxSandboxServiceURLTTLSeconds {
+		return SandboxBoxGenerateServiceURLParams{}, fmt.Errorf("expires_in_seconds must be between 1 and %d, got %d", maxSandboxServiceURLTTLSeconds, expiresInSeconds)
+	}
+	body.Port = F(port)
+	body.ExpiresInSeconds = F(expiresInSeconds)
+	return body, nil
+}

--- a/sandbox_service_url_test.go
+++ b/sandbox_service_url_test.go
@@ -1,0 +1,70 @@
+package langsmith
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNormalizeSandboxServiceURLParams(t *testing.T) {
+	params, err := normalizeSandboxServiceURLParams(SandboxBoxGenerateServiceURLParams{
+		Port: Int(8080),
+	})
+	if err != nil {
+		t.Fatalf("normalizeSandboxServiceURLParams returned error: %v", err)
+	}
+	if params.Port.Value != 8080 {
+		t.Fatalf("unexpected port: %d", params.Port.Value)
+	}
+	if params.ExpiresInSeconds.Value != defaultSandboxServiceURLTTLSeconds {
+		t.Fatalf("expected default ttl, got %d", params.ExpiresInSeconds.Value)
+	}
+
+	if _, err := normalizeSandboxServiceURLParams(SandboxBoxGenerateServiceURLParams{Port: Int(0)}); err == nil {
+		t.Fatal("expected invalid port error")
+	}
+	if _, err := normalizeSandboxServiceURLParams(SandboxBoxGenerateServiceURLParams{
+		Port:             Int(8080),
+		ExpiresInSeconds: Int(maxSandboxServiceURLTTLSeconds + 1),
+	}); err == nil {
+		t.Fatal("expected invalid ttl error")
+	}
+}
+
+func TestSandboxServiceURLAccessorsWithoutRefresh(t *testing.T) {
+	service := newSandboxServiceURL(&SandboxBoxGenerateServiceURLResponse{
+		BrowserURL: "https://browser.example",
+		ServiceURL: "https://service.example",
+		Token:      "token-a",
+		ExpiresAt:  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+	}, nil)
+
+	browserURL, err := service.BrowserURL(context.Background())
+	if err != nil {
+		t.Fatalf("BrowserURL returned error: %v", err)
+	}
+	if browserURL != "https://browser.example" {
+		t.Fatalf("unexpected browser URL: %q", browserURL)
+	}
+	serviceURL, err := service.ServiceURL(context.Background())
+	if err != nil {
+		t.Fatalf("ServiceURL returned error: %v", err)
+	}
+	if serviceURL != "https://service.example" {
+		t.Fatalf("unexpected service URL: %q", serviceURL)
+	}
+	token, err := service.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token returned error: %v", err)
+	}
+	if token != "token-a" {
+		t.Fatalf("unexpected token: %q", token)
+	}
+	expiresAt, err := service.ExpiresAt(context.Background())
+	if err != nil {
+		t.Fatalf("ExpiresAt returned error: %v", err)
+	}
+	if expiresAt == "" {
+		t.Fatal("expected expiration timestamp")
+	}
+}

--- a/sandbox_snapshots.go
+++ b/sandbox_snapshots.go
@@ -1,0 +1,91 @@
+package langsmith
+
+import (
+	"context"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+// SnapshotWaitParams configures polling for snapshot readiness.
+type SnapshotWaitParams struct {
+	Timeout      time.Duration
+	PollInterval time.Duration
+}
+
+// Wait polls until a snapshot reaches ready or failed status.
+func (r *SandboxSnapshotService) Wait(ctx context.Context, snapshotID string, params SnapshotWaitParams, opts ...option.RequestOption) (*SandboxSnapshotGetResponse, error) {
+	timeout := params.Timeout
+	if timeout == 0 {
+		timeout = 300 * time.Second
+	}
+	pollInterval := params.PollInterval
+	if pollInterval == 0 {
+		pollInterval = 2 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	lastStatus := ""
+
+	for {
+		snapshot, err := r.Get(ctx, snapshotID, opts...)
+		if err != nil {
+			return nil, err
+		}
+		lastStatus = snapshot.Status
+		switch snapshot.Status {
+		case "ready":
+			return snapshot, nil
+		case "failed":
+			return nil, &SandboxResourceCreationError{
+				ResourceType: "snapshot",
+				ResourceID:   snapshotID,
+				Message:      snapshot.StatusMessage,
+			}
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, &SandboxResourceTimeoutError{
+				ResourceType: "snapshot",
+				ResourceID:   snapshotID,
+				LastStatus:   lastStatus,
+				Timeout:      timeout,
+			}
+		}
+		delay := minDuration(pollInterval, remaining)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+// NewAndWait creates a snapshot and waits until it is ready or failed.
+func (r *SandboxSnapshotService) NewAndWait(ctx context.Context, body SandboxSnapshotNewParams, params SnapshotWaitParams, opts ...option.RequestOption) (*SandboxSnapshotGetResponse, error) {
+	snapshot, err := r.New(ctx, body, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return r.Wait(ctx, snapshot.ID, params, opts...)
+}
+
+// CaptureSnapshotAndWait captures a snapshot from a sandbox and waits until it
+// is ready or failed.
+func (r *SandboxBoxService) CaptureSnapshotAndWait(ctx context.Context, name string, body SandboxBoxNewSnapshotParams, params SnapshotWaitParams, opts ...option.RequestOption) (*SandboxSnapshotGetResponse, error) {
+	snapshot, err := r.NewSnapshot(ctx, name, body, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return NewSandboxSnapshotService(r.Options...).Wait(ctx, snapshot.ID, params, opts...)
+}
+
+// CaptureSnapshot captures a snapshot from this sandbox.
+func (s *Sandbox) CaptureSnapshot(ctx context.Context, body SandboxBoxNewSnapshotParams, opts ...option.RequestOption) (*SandboxBoxNewSnapshotResponse, error) {
+	return s.boxes.NewSnapshot(ctx, s.Name, body, opts...)
+}
+
+// CaptureSnapshotAndWait captures a snapshot and waits until it is ready.
+func (s *Sandbox) CaptureSnapshotAndWait(ctx context.Context, body SandboxBoxNewSnapshotParams, params SnapshotWaitParams, opts ...option.RequestOption) (*SandboxSnapshotGetResponse, error) {
+	return s.boxes.CaptureSnapshotAndWait(ctx, s.Name, body, params, opts...)
+}

--- a/sandbox_snapshots_test.go
+++ b/sandbox_snapshots_test.go
@@ -1,0 +1,66 @@
+package langsmith_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+func TestSandboxCaptureSnapshotAndWait(t *testing.T) {
+	var snapshotGets atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes/boxes/box-a/snapshot":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":                "snap-1",
+				"name":              "snap",
+				"status":            "building",
+				"fs_capacity_bytes": 1024,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/snapshots/snap-1":
+			status := "building"
+			if snapshotGets.Add(1) > 1 {
+				status = "ready"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":                "snap-1",
+				"name":              "snap",
+				"status":            status,
+				"fs_capacity_bytes": 1024,
+			})
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	snapshot, err := client.Sandboxes.Boxes.CaptureSnapshotAndWait(context.Background(), "box-a", langsmith.SandboxBoxNewSnapshotParams{
+		Name: langsmith.String("snap"),
+	}, langsmith.SnapshotWaitParams{
+		Timeout:      time.Second,
+		PollInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("CaptureSnapshotAndWait returned error: %v", err)
+	}
+	if snapshot.ID != "snap-1" || snapshot.Status != "ready" {
+		t.Fatalf("unexpected snapshot: %#v", snapshot)
+	}
+	if snapshotGets.Load() != 2 {
+		t.Fatalf("expected 2 snapshot get calls, got %d", snapshotGets.Load())
+	}
+}

--- a/sandbox_test_helpers_test.go
+++ b/sandbox_test_helpers_test.go
@@ -1,0 +1,13 @@
+package langsmith_test
+
+import (
+	"net/http"
+)
+
+func srvURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
+}

--- a/sandbox_tunnel.go
+++ b/sandbox_tunnel.go
@@ -1,0 +1,237 @@
+package langsmith
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"sync"
+
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+const (
+	// SandboxTunnelProtocolVersion is the per-stream connect header protocol
+	// version layered on top of yamux streams.
+	SandboxTunnelProtocolVersion = byte(0x01)
+)
+
+// SandboxTunnelStatus is the daemon's one-byte response to a tunnel stream
+// connect request.
+type SandboxTunnelStatus byte
+
+const (
+	SandboxTunnelStatusOK                 SandboxTunnelStatus = 0x00
+	SandboxTunnelStatusPortNotAllowed     SandboxTunnelStatus = 0x01
+	SandboxTunnelStatusDialFailed         SandboxTunnelStatus = 0x02
+	SandboxTunnelStatusUnsupportedVersion SandboxTunnelStatus = 0x03
+
+	yamuxVersion           = byte(0)
+	yamuxTypeData          = byte(0)
+	yamuxTypeWindowUpdate  = byte(1)
+	yamuxTypePing          = byte(2)
+	yamuxTypeGoAway        = byte(3)
+	yamuxFlagSYN           = uint16(0x0001)
+	yamuxFlagACK           = uint16(0x0002)
+	yamuxFlagFIN           = uint16(0x0004)
+	yamuxFlagRST           = uint16(0x0008)
+	yamuxHeaderSize        = 12
+	yamuxInitialWindowSize = uint32(256 * 1024)
+)
+
+// Reason returns a stable human-readable status reason.
+func (s SandboxTunnelStatus) Reason() string {
+	switch s {
+	case SandboxTunnelStatusOK:
+		return "ok"
+	case SandboxTunnelStatusPortNotAllowed:
+		return "port not allowed"
+	case SandboxTunnelStatusDialFailed:
+		return "dial failed"
+	case SandboxTunnelStatusUnsupportedVersion:
+		return "unsupported protocol version"
+	default:
+		return "unknown"
+	}
+}
+
+// SandboxTunnelParams configures a TCP tunnel to a sandbox port.
+type SandboxTunnelParams struct {
+	LocalPort     int
+	MaxReconnects int
+}
+
+// SandboxTunnelStatusError is returned when the sandbox daemon rejects a tunnel
+// stream connection.
+type SandboxTunnelStatusError struct {
+	RemotePort int
+	Status     SandboxTunnelStatus
+}
+
+func (e *SandboxTunnelStatusError) Error() string {
+	return fmt.Sprintf("sandbox tunnel rejected port %d: %s", e.RemotePort, e.Status.Reason())
+}
+
+// SandboxTunnelStream is a single connected stream to a TCP port inside a
+// sandbox.
+type SandboxTunnelStream struct {
+	RemotePort int
+
+	stream       *yamuxStream
+	session      *yamuxSession
+	closeSession bool
+}
+
+// SandboxTunnel forwards local TCP connections to a port inside a sandbox.
+type SandboxTunnel struct {
+	LocalPort  int
+	RemotePort int
+
+	dataplaneURL  string
+	opts          []option.RequestOption
+	maxReconnects int
+
+	listener net.Listener
+	session  *yamuxSession
+	mu       sync.Mutex
+	closed   bool
+}
+
+// Tunnel opens a TCP tunnel to a port inside the named sandbox.
+func (r *SandboxBoxService) Tunnel(ctx context.Context, name string, remotePort int, params SandboxTunnelParams, opts ...option.RequestOption) (*SandboxTunnel, error) {
+	box, err := r.Get(ctx, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return r.TunnelWithDataplaneURL(ctx, dataplaneURL, remotePort, params, opts...)
+}
+
+// OpenTunnelStream opens a single TCP stream to a port inside the named
+// sandbox. This is useful for stdio bridges such as SSH ProxyCommand.
+func (r *SandboxBoxService) OpenTunnelStream(ctx context.Context, name string, remotePort int, opts ...option.RequestOption) (*SandboxTunnelStream, error) {
+	box, err := r.Get(ctx, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return r.OpenTunnelStreamWithDataplaneURL(ctx, dataplaneURL, remotePort, opts...)
+}
+
+// OpenTunnelStreamWithDataplaneURL opens a single TCP stream directly against a
+// sandbox dataplane URL.
+func (r *SandboxBoxService) OpenTunnelStreamWithDataplaneURL(ctx context.Context, dataplaneURL string, remotePort int, opts ...option.RequestOption) (*SandboxTunnelStream, error) {
+	if err := validateSandboxTunnelPort(remotePort, "remotePort"); err != nil {
+		return nil, err
+	}
+	session, err := connectSandboxTunnelSession(ctx, dataplaneURL, slices.Concat(r.Options, opts))
+	if err != nil {
+		return nil, err
+	}
+	stream, err := openSandboxTunnelStream(session, remotePort, true)
+	if err != nil {
+		session.close()
+		return nil, err
+	}
+	return stream, nil
+}
+
+// TunnelWithDataplaneURL opens a TCP tunnel directly against a sandbox dataplane
+// URL.
+func (r *SandboxBoxService) TunnelWithDataplaneURL(ctx context.Context, dataplaneURL string, remotePort int, params SandboxTunnelParams, opts ...option.RequestOption) (*SandboxTunnel, error) {
+	if err := validateSandboxTunnelPort(remotePort, "remotePort"); err != nil {
+		return nil, err
+	}
+	if params.LocalPort < 0 || params.LocalPort > 65535 {
+		return nil, fmt.Errorf("localPort must be between 0 and 65535, got %d", params.LocalPort)
+	}
+	maxReconnects := params.MaxReconnects
+	if maxReconnects == 0 {
+		maxReconnects = 3
+	}
+	t := &SandboxTunnel{
+		RemotePort:    remotePort,
+		dataplaneURL:  dataplaneURL,
+		opts:          slices.Concat(r.Options, opts),
+		maxReconnects: maxReconnects,
+	}
+	if err := t.start(ctx, params.LocalPort); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// OpenTunnelStream opens a single TCP stream to a port inside this sandbox.
+func (s *Sandbox) OpenTunnelStream(ctx context.Context, remotePort int, opts ...option.RequestOption) (*SandboxTunnelStream, error) {
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return s.boxes.OpenTunnelStreamWithDataplaneURL(ctx, dataplaneURL, remotePort, opts...)
+}
+
+// Tunnel opens a TCP tunnel from localhost to a port inside this sandbox.
+func (s *Sandbox) Tunnel(ctx context.Context, remotePort int, params SandboxTunnelParams, opts ...option.RequestOption) (*SandboxTunnel, error) {
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return s.boxes.TunnelWithDataplaneURL(ctx, dataplaneURL, remotePort, params, opts...)
+}
+
+// Close shuts down the tunnel.
+func (t *SandboxTunnel) Close() error {
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return nil
+	}
+	t.closed = true
+	listener := t.listener
+	session := t.session
+	t.mu.Unlock()
+
+	var err error
+	if listener != nil {
+		err = listener.Close()
+	}
+	if session != nil {
+		session.close()
+	}
+	return err
+}
+
+// Dial opens a single stream over this tunnel's managed session.
+func (t *SandboxTunnel) Dial(ctx context.Context) (*SandboxTunnelStream, error) {
+	session, err := t.ensureSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return openSandboxTunnelStream(session, t.RemotePort, false)
+}
+
+// Read implements io.Reader.
+func (s *SandboxTunnelStream) Read(p []byte) (int, error) {
+	return s.stream.Read(p)
+}
+
+// Write implements io.Writer.
+func (s *SandboxTunnelStream) Write(p []byte) (int, error) {
+	return s.stream.Write(p)
+}
+
+// Close closes the stream. Streams opened with OpenTunnelStream also close
+// their underlying tunnel session.
+func (s *SandboxTunnelStream) Close() error {
+	err := s.stream.Close()
+	if s.closeSession && s.session != nil {
+		s.session.close()
+	}
+	return err
+}

--- a/sandbox_tunnel_bridge.go
+++ b/sandbox_tunnel_bridge.go
@@ -1,0 +1,215 @@
+package langsmith
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+// BridgeSandboxTunnel copies bytes bidirectionally between two read/write
+// closers until either side closes or ctx is cancelled. Both sides are closed
+// before it returns.
+func BridgeSandboxTunnel(ctx context.Context, a io.ReadWriteCloser, b io.ReadWriteCloser) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		copySandboxTunnelUntilDone(ctx, b, a, a)
+	}()
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		copySandboxTunnelUntilDone(ctx, a, b, b)
+	}()
+	wg.Wait()
+	_ = a.Close()
+	_ = b.Close()
+}
+
+// BridgeSandboxTunnelIO bridges input/output streams to a tunnel stream. It is
+// intended for stdio-style integrations.
+func BridgeSandboxTunnelIO(ctx context.Context, stream io.ReadWriteCloser, input io.Reader, output io.Writer) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errs := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(stream, input)
+		errs <- err
+		cancel()
+		_ = stream.Close()
+	}()
+	go func() {
+		_, err := io.Copy(output, stream)
+		errs <- err
+		cancel()
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = stream.Close()
+		return nil
+	case err := <-errs:
+		_ = stream.Close()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+}
+
+func (t *SandboxTunnel) start(ctx context.Context, localPort int) error {
+	session, err := t.connect(ctx)
+	if err != nil {
+		return err
+	}
+	t.session = session
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", localPort))
+	if err != nil {
+		session.close()
+		return err
+	}
+	t.listener = listener
+	t.LocalPort = listener.Addr().(*net.TCPAddr).Port
+
+	go t.acceptLoop()
+	return nil
+}
+
+func (t *SandboxTunnel) acceptLoop() {
+	for {
+		conn, err := t.listener.Accept()
+		if err != nil {
+			return
+		}
+		go t.handleConn(conn)
+	}
+}
+
+func (t *SandboxTunnel) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	stream, err := t.Dial(context.Background())
+	if err != nil {
+		return
+	}
+	defer stream.Close()
+
+	BridgeSandboxTunnel(context.Background(), stream, conn)
+}
+
+func (t *SandboxTunnel) ensureSession(ctx context.Context) (*yamuxSession, error) {
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return nil, errors.New("sandbox tunnel is closed")
+	}
+	if t.session != nil && !t.session.isClosed() {
+		session := t.session
+		t.mu.Unlock()
+		return session, nil
+	}
+	t.mu.Unlock()
+
+	var lastErr error
+	for attempt := 0; attempt < t.maxReconnects; attempt++ {
+		session, err := t.connect(ctx)
+		if err == nil {
+			t.mu.Lock()
+			if t.session != nil {
+				t.session.close()
+			}
+			t.session = session
+			t.mu.Unlock()
+			return session, nil
+		}
+		lastErr = err
+		delay := 500 * time.Millisecond << attempt
+		if delay > 8*time.Second {
+			delay = 8 * time.Second
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return nil, fmt.Errorf("sandbox tunnel reconnect failed after %d attempts: %w", t.maxReconnects, lastErr)
+}
+
+func (t *SandboxTunnel) connect(ctx context.Context) (*yamuxSession, error) {
+	return connectSandboxTunnelSession(ctx, t.dataplaneURL, t.opts)
+}
+
+func connectSandboxTunnelSession(ctx context.Context, dataplaneURL string, opts []option.RequestOption) (*yamuxSession, error) {
+	wsURL, err := sandboxTunnelWebSocketURL(dataplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	ws, err := dialSandboxWebSocketURL(ctx, wsURL, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return newYamuxSession(newWebSocketByteStream(ws)), nil
+}
+
+func openSandboxTunnelStream(session *yamuxSession, remotePort int, closeSession bool) (*SandboxTunnelStream, error) {
+	stream, err := session.openStream()
+	if err != nil {
+		return nil, err
+	}
+	header := []byte{SandboxTunnelProtocolVersion, byte(remotePort >> 8), byte(remotePort)}
+	if _, err := stream.write(header); err != nil {
+		stream.close()
+		return nil, err
+	}
+	status := []byte{0}
+	if _, err := io.ReadFull(stream, status); err != nil {
+		stream.close()
+		return nil, err
+	}
+	tunnelStatus := SandboxTunnelStatus(status[0])
+	if tunnelStatus != SandboxTunnelStatusOK {
+		stream.close()
+		return nil, &SandboxTunnelStatusError{RemotePort: remotePort, Status: tunnelStatus}
+	}
+	return &SandboxTunnelStream{
+		RemotePort:   remotePort,
+		stream:       stream,
+		session:      session,
+		closeSession: closeSession,
+	}, nil
+}
+
+func validateSandboxTunnelPort(port int, name string) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("%s must be between 1 and 65535, got %d", name, port)
+	}
+	return nil
+}
+
+func copySandboxTunnelUntilDone(ctx context.Context, dst io.Writer, src io.Reader, srcCloser io.Closer) {
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(dst, src)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		_ = srcCloser.Close()
+		<-done
+	}
+}

--- a/sandbox_tunnel_test.go
+++ b/sandbox_tunnel_test.go
@@ -1,0 +1,279 @@
+package langsmith_test
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/option"
+	"golang.org/x/net/websocket"
+)
+
+func TestSandboxTunnelWithDataplaneURL(t *testing.T) {
+	serverDone := make(chan error, 1)
+
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		reader := &testWSFrameReader{ws: ws}
+
+		msgType, flags, streamID, payload, err := reader.readFrame()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if msgType != 1 || flags != 1 || streamID != 1 || len(payload) != 0 {
+			serverDone <- fmt.Errorf("unexpected open stream frame: type=%d flags=%d stream=%d payload=%v", msgType, flags, streamID, payload)
+			return
+		}
+
+		msgType, flags, streamID, payload, err = reader.readFrame()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if msgType != 0 || flags != 0 || streamID != 1 || !equalBytes(payload, []byte{1, 31, 144}) {
+			serverDone <- fmt.Errorf("unexpected tunnel connect frame: type=%d flags=%d stream=%d payload=%v", msgType, flags, streamID, payload)
+			return
+		}
+		if err := sendTestYamuxFrame(ws, 0, 0, 1, []byte{0}); err != nil {
+			serverDone <- err
+			return
+		}
+
+		msgType, flags, streamID, payload, err = reader.readFrame()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if msgType != 0 || flags != 0 || streamID != 1 || string(payload) != "ping" {
+			serverDone <- fmt.Errorf("unexpected tunnel data frame: type=%d flags=%d stream=%d payload=%q", msgType, flags, streamID, string(payload))
+			return
+		}
+		if err := sendTestYamuxFrame(ws, 0, 0, 1, []byte("pong")); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- nil
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	tunnel, err := client.Sandboxes.Boxes.TunnelWithDataplaneURL(context.Background(), srv.URL, 8080, langsmith.SandboxTunnelParams{LocalPort: 0})
+	if err != nil {
+		t.Fatalf("TunnelWithDataplaneURL returned error: %v", err)
+	}
+	defer tunnel.Close()
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", tunnel.LocalPort), time.Second)
+	if err != nil {
+		t.Fatalf("dial local tunnel: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(time.Second))
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write tunnel data: %v", err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read tunnel data: %v", err)
+	}
+	if string(buf) != "pong" {
+		t.Fatalf("unexpected tunnel response: %q", string(buf))
+	}
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for tunnel server")
+	}
+}
+
+func TestSandboxOpenTunnelStreamWithDataplaneURL(t *testing.T) {
+	serverDone := make(chan error, 1)
+	remotePort := 9000
+
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		reader := &testWSFrameReader{ws: ws}
+		msgType, flags, streamID, payload, err := reader.readFrame()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if msgType != 1 || flags != 1 || streamID != 1 || len(payload) != 0 {
+			serverDone <- fmt.Errorf("unexpected open stream frame: type=%d flags=%d stream=%d payload=%v", msgType, flags, streamID, payload)
+			return
+		}
+
+		_, _, streamID, payload, err = reader.readFrame()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		expectedHeader := []byte{byte(langsmith.SandboxTunnelProtocolVersion), byte(remotePort >> 8), byte(remotePort)}
+		if !equalBytes(payload, expectedHeader) {
+			serverDone <- fmt.Errorf("unexpected connect header: %v", payload)
+			return
+		}
+		if err := sendTestYamuxFrame(ws, 0, 0, streamID, []byte{byte(langsmith.SandboxTunnelStatusOK)}); err != nil {
+			serverDone <- err
+			return
+		}
+
+		_, _, streamID, payload, err = reader.readFrame()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if string(payload) != "ping" {
+			serverDone <- fmt.Errorf("unexpected stream payload: %q", string(payload))
+			return
+		}
+		if err := sendTestYamuxFrame(ws, 0, 0, streamID, []byte("pong")); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- nil
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	stream, err := client.Sandboxes.Boxes.OpenTunnelStreamWithDataplaneURL(context.Background(), srv.URL, remotePort)
+	if err != nil {
+		t.Fatalf("OpenTunnelStreamWithDataplaneURL returned error: %v", err)
+	}
+	defer stream.Close()
+	if stream.RemotePort != remotePort {
+		t.Fatalf("expected remote port %d, got %d", remotePort, stream.RemotePort)
+	}
+	if _, err := stream.Write([]byte("ping")); err != nil {
+		t.Fatalf("write stream: %v", err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(stream, buf); err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+	if string(buf) != "pong" {
+		t.Fatalf("unexpected stream response: %q", string(buf))
+	}
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for tunnel server")
+	}
+}
+
+func TestSandboxOpenTunnelStreamStatusError(t *testing.T) {
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		reader := &testWSFrameReader{ws: ws}
+		_, _, streamID, _, err := reader.readFrame()
+		if err != nil {
+			t.Errorf("read open frame: %v", err)
+			return
+		}
+		if _, _, _, _, err := reader.readFrame(); err != nil {
+			t.Errorf("read connect frame: %v", err)
+			return
+		}
+		if err := sendTestYamuxFrame(ws, 0, 0, streamID, []byte{byte(langsmith.SandboxTunnelStatusDialFailed)}); err != nil {
+			t.Errorf("send status: %v", err)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	_, err := client.Sandboxes.Boxes.OpenTunnelStreamWithDataplaneURL(context.Background(), srv.URL, 5432)
+	if err == nil {
+		t.Fatal("expected status error")
+	}
+	var statusErr *langsmith.SandboxTunnelStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("expected SandboxTunnelStatusError, got %T: %v", err, err)
+	}
+	if statusErr.Status != langsmith.SandboxTunnelStatusDialFailed || statusErr.RemotePort != 5432 {
+		t.Fatalf("unexpected status error: %#v", statusErr)
+	}
+	if statusErr.Status.Reason() != "dial failed" {
+		t.Fatalf("unexpected status reason: %q", statusErr.Status.Reason())
+	}
+}
+
+type testWSFrameReader struct {
+	ws  *websocket.Conn
+	buf []byte
+}
+
+func (r *testWSFrameReader) read(n int) ([]byte, error) {
+	for len(r.buf) < n {
+		var msg []byte
+		if err := websocket.Message.Receive(r.ws, &msg); err != nil {
+			return nil, err
+		}
+		r.buf = append(r.buf, msg...)
+	}
+	out := append([]byte(nil), r.buf[:n]...)
+	r.buf = r.buf[n:]
+	return out, nil
+}
+
+func (r *testWSFrameReader) readFrame() (msgType byte, flags uint16, streamID uint32, payload []byte, err error) {
+	header, err := r.read(12)
+	if err != nil {
+		return 0, 0, 0, nil, err
+	}
+	length := binary.BigEndian.Uint32(header[8:12])
+	if length > 0 {
+		payload, err = r.read(int(length))
+		if err != nil {
+			return 0, 0, 0, nil, err
+		}
+	}
+	return header[1], binary.BigEndian.Uint16(header[2:4]), binary.BigEndian.Uint32(header[4:8]), payload, nil
+}
+
+func sendTestYamuxFrame(ws *websocket.Conn, msgType byte, flags uint16, streamID uint32, payload []byte) error {
+	frame := make([]byte, 12+len(payload))
+	frame[1] = msgType
+	binary.BigEndian.PutUint16(frame[2:4], flags)
+	binary.BigEndian.PutUint32(frame[4:8], streamID)
+	binary.BigEndian.PutUint32(frame[8:12], uint32(len(payload)))
+	copy(frame[12:], payload)
+	return websocket.Message.Send(ws, frame)
+}
+
+func equalBytes(a []byte, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/sandbox_tunnel_ws.go
+++ b/sandbox_tunnel_ws.go
@@ -1,0 +1,68 @@
+package langsmith
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+
+	"golang.org/x/net/websocket"
+)
+
+func sandboxTunnelWebSocketURL(dataplaneURL string) (string, error) {
+	u, err := url.Parse(dataplaneURL)
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "ws", "wss":
+	default:
+		return "", fmt.Errorf("unsupported sandbox dataplane URL scheme %q", u.Scheme)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/tunnel"
+	u.RawQuery = ""
+	return u.String(), nil
+}
+
+type webSocketByteStream struct {
+	ws      *websocket.Conn
+	readMu  sync.Mutex
+	writeMu sync.Mutex
+	buf     []byte
+}
+
+func newWebSocketByteStream(ws *websocket.Conn) *webSocketByteStream {
+	return &webSocketByteStream{ws: ws}
+}
+
+func (s *webSocketByteStream) Read(p []byte) (int, error) {
+	s.readMu.Lock()
+	defer s.readMu.Unlock()
+	for len(s.buf) == 0 {
+		var msg []byte
+		if err := websocket.Message.Receive(s.ws, &msg); err != nil {
+			return 0, err
+		}
+		s.buf = msg
+	}
+	n := copy(p, s.buf)
+	s.buf = s.buf[n:]
+	return n, nil
+}
+
+func (s *webSocketByteStream) Write(p []byte) (int, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if err := websocket.Message.Send(s.ws, p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (s *webSocketByteStream) Close() error {
+	return s.ws.Close()
+}

--- a/sandbox_tunnel_yamux.go
+++ b/sandbox_tunnel_yamux.go
@@ -1,0 +1,321 @@
+package langsmith
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"sync"
+	"time"
+)
+
+type yamuxSession struct {
+	conn      io.ReadWriteCloser
+	streams   map[uint32]*yamuxStream
+	nextID    uint32
+	mu        sync.Mutex
+	writeMu   sync.Mutex
+	closed    bool
+	closeOnce sync.Once
+}
+
+func newYamuxSession(conn io.ReadWriteCloser) *yamuxSession {
+	s := &yamuxSession{
+		conn:    conn,
+		streams: make(map[uint32]*yamuxStream),
+		nextID:  1,
+	}
+	go s.readLoop()
+	go s.keepAliveLoop()
+	return s
+}
+
+func (s *yamuxSession) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+func (s *yamuxSession) openStream() (*yamuxStream, error) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, errors.New("yamux session is closed")
+	}
+	id := s.nextID
+	s.nextID += 2
+	stream := newYamuxStream(id, s)
+	s.streams[id] = stream
+	s.mu.Unlock()
+
+	if err := s.sendFrame(yamuxTypeWindowUpdate, yamuxFlagSYN, id, 0); err != nil {
+		return nil, err
+	}
+	return stream, nil
+}
+
+func (s *yamuxSession) close() {
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		for _, stream := range s.streams {
+			stream.receiveRST()
+		}
+		s.mu.Unlock()
+		_ = s.sendFrame(yamuxTypeGoAway, 0, 0, 0)
+		_ = s.conn.Close()
+	})
+}
+
+func (s *yamuxSession) readLoop() {
+	header := make([]byte, yamuxHeaderSize)
+	for {
+		if _, err := io.ReadFull(s.conn, header); err != nil {
+			s.close()
+			return
+		}
+		msgType := header[1]
+		flags := binary.BigEndian.Uint16(header[2:4])
+		streamID := binary.BigEndian.Uint32(header[4:8])
+		length := binary.BigEndian.Uint32(header[8:12])
+
+		switch msgType {
+		case yamuxTypeData:
+			payload := make([]byte, length)
+			if length > 0 {
+				if _, err := io.ReadFull(s.conn, payload); err != nil {
+					s.close()
+					return
+				}
+			}
+			s.handleData(flags, streamID, payload)
+		case yamuxTypeWindowUpdate:
+			s.handleWindowUpdate(flags, streamID, length)
+		case yamuxTypePing:
+			if flags&yamuxFlagSYN != 0 {
+				_ = s.sendFrame(yamuxTypePing, yamuxFlagACK, 0, length)
+			}
+		case yamuxTypeGoAway:
+			s.close()
+			return
+		}
+	}
+}
+
+func (s *yamuxSession) handleData(flags uint16, streamID uint32, payload []byte) {
+	stream := s.getStream(streamID)
+	if stream == nil {
+		return
+	}
+	if len(payload) > 0 {
+		stream.receiveData(payload)
+	}
+	if flags&yamuxFlagFIN != 0 {
+		stream.receiveFIN()
+	}
+	if flags&yamuxFlagRST != 0 {
+		stream.receiveRST()
+	}
+}
+
+func (s *yamuxSession) handleWindowUpdate(flags uint16, streamID uint32, delta uint32) {
+	stream := s.getStream(streamID)
+	if stream == nil {
+		return
+	}
+	if delta > 0 {
+		stream.updateSendWindow(delta)
+	}
+	if flags&yamuxFlagFIN != 0 {
+		stream.receiveFIN()
+	}
+	if flags&yamuxFlagRST != 0 {
+		stream.receiveRST()
+	}
+}
+
+func (s *yamuxSession) keepAliveLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	var ping uint32
+	for range ticker.C {
+		if s.isClosed() {
+			return
+		}
+		ping++
+		if err := s.sendFrame(yamuxTypePing, yamuxFlagSYN, 0, ping); err != nil {
+			s.close()
+			return
+		}
+	}
+}
+
+func (s *yamuxSession) getStream(streamID uint32) *yamuxStream {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.streams[streamID]
+}
+
+func (s *yamuxSession) sendFrame(msgType byte, flags uint16, streamID uint32, length uint32) error {
+	var header [yamuxHeaderSize]byte
+	header[0] = yamuxVersion
+	header[1] = msgType
+	binary.BigEndian.PutUint16(header[2:4], flags)
+	binary.BigEndian.PutUint32(header[4:8], streamID)
+	binary.BigEndian.PutUint32(header[8:12], length)
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.conn.Write(header[:])
+	return err
+}
+
+func (s *yamuxSession) sendData(streamID uint32, data []byte) error {
+	var header [yamuxHeaderSize]byte
+	header[0] = yamuxVersion
+	header[1] = yamuxTypeData
+	binary.BigEndian.PutUint32(header[4:8], streamID)
+	binary.BigEndian.PutUint32(header[8:12], uint32(len(data)))
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if _, err := s.conn.Write(header[:]); err != nil {
+		return err
+	}
+	_, err := s.conn.Write(data)
+	return err
+}
+
+func (s *yamuxSession) sendWindowUpdate(streamID uint32, delta uint32) error {
+	return s.sendFrame(yamuxTypeWindowUpdate, 0, streamID, delta)
+}
+
+type yamuxStream struct {
+	id      uint32
+	session *yamuxSession
+
+	recvMu     sync.Mutex
+	recvCond   *sync.Cond
+	recvBuf    []byte
+	recvClosed bool
+	recvErr    bool
+	recvWindow uint32
+
+	sendMu     sync.Mutex
+	sendCond   *sync.Cond
+	sendClosed bool
+	sendWindow uint32
+}
+
+func newYamuxStream(id uint32, session *yamuxSession) *yamuxStream {
+	stream := &yamuxStream{
+		id:         id,
+		session:    session,
+		recvWindow: yamuxInitialWindowSize,
+		sendWindow: yamuxInitialWindowSize,
+	}
+	stream.recvCond = sync.NewCond(&stream.recvMu)
+	stream.sendCond = sync.NewCond(&stream.sendMu)
+	return stream
+}
+
+func (s *yamuxStream) Read(p []byte) (int, error) {
+	s.recvMu.Lock()
+	for len(s.recvBuf) == 0 && !s.recvClosed && !s.recvErr {
+		s.recvCond.Wait()
+	}
+	if s.recvErr && len(s.recvBuf) == 0 {
+		s.recvMu.Unlock()
+		return 0, io.ErrUnexpectedEOF
+	}
+	if len(s.recvBuf) == 0 {
+		s.recvMu.Unlock()
+		return 0, io.EOF
+	}
+	n := copy(p, s.recvBuf)
+	s.recvBuf = s.recvBuf[n:]
+	consumed := yamuxInitialWindowSize - s.recvWindow
+	if consumed >= yamuxInitialWindowSize/2 {
+		s.recvWindow += consumed
+		s.recvMu.Unlock()
+		_ = s.session.sendWindowUpdate(s.id, consumed)
+		return n, nil
+	}
+	s.recvMu.Unlock()
+	return n, nil
+}
+
+func (s *yamuxStream) Write(p []byte) (int, error) {
+	return s.write(p)
+}
+
+func (s *yamuxStream) write(p []byte) (int, error) {
+	offset := 0
+	for offset < len(p) {
+		s.sendMu.Lock()
+		for s.sendWindow == 0 && !s.sendClosed {
+			s.sendCond.Wait()
+		}
+		if s.sendClosed {
+			s.sendMu.Unlock()
+			return offset, io.ErrClosedPipe
+		}
+		chunk := min(len(p)-offset, int(s.sendWindow))
+		s.sendWindow -= uint32(chunk)
+		s.sendMu.Unlock()
+
+		if err := s.session.sendData(s.id, p[offset:offset+chunk]); err != nil {
+			return offset, err
+		}
+		offset += chunk
+	}
+	return len(p), nil
+}
+
+func (s *yamuxStream) Close() error {
+	s.close()
+	return nil
+}
+
+func (s *yamuxStream) close() {
+	s.sendMu.Lock()
+	if !s.sendClosed {
+		s.sendClosed = true
+		_ = s.session.sendFrame(yamuxTypeData, yamuxFlagFIN, s.id, 0)
+	}
+	s.sendMu.Unlock()
+	s.recvMu.Lock()
+	s.recvClosed = true
+	s.recvCond.Broadcast()
+	s.recvMu.Unlock()
+}
+
+func (s *yamuxStream) receiveData(data []byte) {
+	s.recvMu.Lock()
+	s.recvBuf = append(s.recvBuf, data...)
+	s.recvWindow -= uint32(len(data))
+	s.recvCond.Broadcast()
+	s.recvMu.Unlock()
+}
+
+func (s *yamuxStream) receiveFIN() {
+	s.recvMu.Lock()
+	s.recvClosed = true
+	s.recvCond.Broadcast()
+	s.recvMu.Unlock()
+}
+
+func (s *yamuxStream) receiveRST() {
+	s.recvMu.Lock()
+	s.recvErr = true
+	s.recvCond.Broadcast()
+	s.recvMu.Unlock()
+	s.sendMu.Lock()
+	s.sendClosed = true
+	s.sendCond.Broadcast()
+	s.sendMu.Unlock()
+}
+
+func (s *yamuxStream) updateSendWindow(delta uint32) {
+	s.sendMu.Lock()
+	s.sendWindow += delta
+	s.sendCond.Broadcast()
+	s.sendMu.Unlock()
+}

--- a/sandbox_utils_test.go
+++ b/sandbox_utils_test.go
@@ -1,0 +1,250 @@
+package langsmith_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+func TestSandboxFileReadWriteWithDataplaneURL(t *testing.T) {
+	var uploadedPath string
+	var uploadedContent string
+	var uploadAPIKey string
+	var readAPIKey string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/upload":
+			uploadAPIKey = r.Header.Get("X-API-Key")
+			uploadedPath = r.URL.Query().Get("path")
+			file, _, err := r.FormFile("file")
+			if err != nil {
+				t.Fatalf("read upload file: %v", err)
+			}
+			defer file.Close()
+			data, err := io.ReadAll(file)
+			if err != nil {
+				t.Fatalf("read upload content: %v", err)
+			}
+			uploadedContent = string(data)
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/download":
+			readAPIKey = r.Header.Get("X-API-Key")
+			if r.URL.Query().Get("path") != "/app/test.txt" {
+				t.Fatalf("unexpected read path: %q", r.URL.Query().Get("path"))
+			}
+			_, _ = w.Write([]byte("file contents"))
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	if err := client.Sandboxes.Boxes.WriteFileWithDataplaneURL(context.Background(), srv.URL, "/app/test.txt", []byte("hello world")); err != nil {
+		t.Fatalf("WriteFileWithDataplaneURL returned error: %v", err)
+	}
+	if uploadedPath != "/app/test.txt" {
+		t.Fatalf("unexpected upload path: %q", uploadedPath)
+	}
+	if uploadedContent != "hello world" {
+		t.Fatalf("unexpected upload content: %q", uploadedContent)
+	}
+	if uploadAPIKey != "test-api-key" {
+		t.Fatalf("expected upload API key header, got %q", uploadAPIKey)
+	}
+
+	content, err := client.Sandboxes.Boxes.ReadFileWithDataplaneURL(context.Background(), srv.URL, "/app/test.txt")
+	if err != nil {
+		t.Fatalf("ReadFileWithDataplaneURL returned error: %v", err)
+	}
+	if string(content) != "file contents" {
+		t.Fatalf("unexpected read content: %q", string(content))
+	}
+	if readAPIKey != "test-api-key" {
+		t.Fatalf("expected read API key header, got %q", readAPIKey)
+	}
+}
+
+func TestSandboxWaitHelpers(t *testing.T) {
+	var sandboxStatusCalls atomic.Int64
+	var snapshotGetCalls atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/test-box/status":
+			if sandboxStatusCalls.Add(1) == 1 {
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "provisioning"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ready"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/test-box":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":            "box-id",
+				"name":          "test-box",
+				"status":        "ready",
+				"dataplane_url": "http://dataplane.test",
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes/snapshots":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":                "snap-1",
+				"name":              "snap",
+				"status":            "building",
+				"fs_capacity_bytes": 1024,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/snapshots/snap-1":
+			if snapshotGetCalls.Add(1) == 1 {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":                "snap-1",
+					"name":              "snap",
+					"status":            "building",
+					"fs_capacity_bytes": 1024,
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":                "snap-1",
+				"name":              "snap",
+				"status":            "ready",
+				"fs_capacity_bytes": 1024,
+			})
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+
+	sandbox, err := client.Sandboxes.Boxes.WaitSandbox(context.Background(), "test-box", langsmith.SandboxWaitParams{
+		Timeout:      time.Second,
+		PollInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("WaitSandbox returned error: %v", err)
+	}
+	if sandbox.Name != "test-box" || sandbox.DataplaneURL != "http://dataplane.test" {
+		t.Fatalf("unexpected sandbox: %#v", sandbox)
+	}
+	if sandboxStatusCalls.Load() != 2 {
+		t.Fatalf("expected 2 sandbox status calls, got %d", sandboxStatusCalls.Load())
+	}
+
+	snapshot, err := client.Sandboxes.Snapshots.NewAndWait(context.Background(), langsmith.SandboxSnapshotNewParams{
+		Name:            langsmith.String("snap"),
+		DockerImage:     langsmith.String("python:3.12-slim"),
+		FsCapacityBytes: langsmith.Int(1024),
+	}, langsmith.SnapshotWaitParams{
+		Timeout:      time.Second,
+		PollInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewAndWait returned error: %v", err)
+	}
+	if snapshot.ID != "snap-1" || snapshot.Status != "ready" {
+		t.Fatalf("unexpected snapshot: %#v", snapshot)
+	}
+	if snapshotGetCalls.Load() != 2 {
+		t.Fatalf("expected 2 snapshot get calls, got %d", snapshotGetCalls.Load())
+	}
+}
+
+func TestSandboxServiceURLRefreshAndRequest(t *testing.T) {
+	var serviceURLCalls atomic.Int64
+	var firstPayload map[string]any
+	var serviceAuthHeader string
+	var serviceCustomHeader string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes/boxes/test-box/service-url":
+			call := serviceURLCalls.Add(1)
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode service URL request: %v", err)
+			}
+			if call == 1 {
+				firstPayload = payload
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"browser_url": srvURL(r) + "/browser",
+					"service_url": srvURL(r) + "/service",
+					"token":       "token-1",
+					"expires_at":  time.Now().Add(time.Second).UTC().Format(time.RFC3339),
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"browser_url": srvURL(r) + "/browser",
+				"service_url": srvURL(r) + "/service",
+				"token":       "token-2",
+				"expires_at":  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/service/path":
+			serviceAuthHeader = r.Header.Get("X-Langsmith-Sandbox-Service-Token")
+			serviceCustomHeader = r.Header.Get("X-Test")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	service, err := client.Sandboxes.Boxes.Service(context.Background(), "test-box", langsmith.SandboxBoxGenerateServiceURLParams{
+		Port: langsmith.Int(3000),
+	})
+	if err != nil {
+		t.Fatalf("Service returned error: %v", err)
+	}
+	if firstPayload["port"] != float64(3000) {
+		t.Fatalf("unexpected service port payload: %#v", firstPayload["port"])
+	}
+	if firstPayload["expires_in_seconds"] != float64(600) {
+		t.Fatalf("expected default service URL TTL, got %#v", firstPayload["expires_in_seconds"])
+	}
+
+	token, err := service.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token returned error: %v", err)
+	}
+	if token != "token-2" {
+		t.Fatalf("expected refreshed token, got %q", token)
+	}
+	if serviceURLCalls.Load() != 2 {
+		t.Fatalf("expected 2 service URL calls, got %d", serviceURLCalls.Load())
+	}
+
+	resp, err := service.Get(context.Background(), "/path", http.Header{"X-Test": []string{"yes"}})
+	if err != nil {
+		t.Fatalf("service Get returned error: %v", err)
+	}
+	_ = resp.Body.Close()
+	if serviceAuthHeader != "token-2" {
+		t.Fatalf("expected service auth token header, got %q", serviceAuthHeader)
+	}
+	if serviceCustomHeader != "yes" {
+		t.Fatalf("expected custom service header, got %q", serviceCustomHeader)
+	}
+}

--- a/sandbox_wait.go
+++ b/sandbox_wait.go
@@ -1,0 +1,89 @@
+package langsmith
+
+import (
+	"context"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+// SandboxWaitParams configures polling for sandbox readiness.
+type SandboxWaitParams struct {
+	Timeout      time.Duration
+	PollInterval time.Duration
+}
+
+// Wait polls the generated status endpoint until the sandbox is ready or failed.
+func (r *SandboxBoxService) Wait(ctx context.Context, name string, params SandboxWaitParams, opts ...option.RequestOption) (*SandboxBoxGetResponse, error) {
+	timeout := params.Timeout
+	if timeout == 0 {
+		timeout = 120 * time.Second
+	}
+	pollInterval := params.PollInterval
+	if pollInterval == 0 {
+		pollInterval = time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	lastStatus := ""
+
+	for {
+		status, err := r.GetStatus(ctx, name, opts...)
+		if err != nil {
+			return nil, err
+		}
+		lastStatus = status.Status
+		switch status.Status {
+		case "ready":
+			return r.Get(ctx, name, opts...)
+		case "failed":
+			return nil, &SandboxResourceCreationError{
+				ResourceType: "sandbox",
+				ResourceID:   name,
+				Message:      status.StatusMessage,
+			}
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, &SandboxResourceTimeoutError{
+				ResourceType: "sandbox",
+				ResourceID:   name,
+				LastStatus:   lastStatus,
+				Timeout:      timeout,
+			}
+		}
+		delay := minDuration(pollInterval, remaining)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+// WaitSandbox polls until ready and returns the convenience wrapper.
+func (r *SandboxBoxService) WaitSandbox(ctx context.Context, name string, params SandboxWaitParams, opts ...option.RequestOption) (*Sandbox, error) {
+	res, err := r.Wait(ctx, name, params, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return sandboxFromGetResponse(res, r), nil
+}
+
+// StartAndWait starts a stopped sandbox and waits until it is ready.
+func (r *SandboxBoxService) StartAndWait(ctx context.Context, name string, params SandboxWaitParams, opts ...option.RequestOption) (*SandboxBoxGetResponse, error) {
+	if _, err := r.Start(ctx, name, opts...); err != nil {
+		return nil, err
+	}
+	return r.Wait(ctx, name, params, opts...)
+}
+
+// StartSandbox starts a stopped sandbox and returns the convenience wrapper once
+// it is ready.
+func (r *SandboxBoxService) StartSandbox(ctx context.Context, name string, params SandboxWaitParams, opts ...option.RequestOption) (*Sandbox, error) {
+	res, err := r.StartAndWait(ctx, name, params, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return sandboxFromGetResponse(res, r), nil
+}

--- a/sandbox_wait_test.go
+++ b/sandbox_wait_test.go
@@ -1,0 +1,106 @@
+package langsmith_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+func TestSandboxWaitFailureAndTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/failed-box/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":         "failed",
+				"status_message": "boot failed",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/slow-box/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "starting"})
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+
+	_, err := client.Sandboxes.Boxes.Wait(context.Background(), "failed-box", langsmith.SandboxWaitParams{
+		Timeout:      time.Second,
+		PollInterval: time.Millisecond,
+	})
+	var creationErr *langsmith.SandboxResourceCreationError
+	if !errors.As(err, &creationErr) {
+		t.Fatalf("expected SandboxResourceCreationError, got %T: %v", err, err)
+	}
+	if creationErr.Message != "boot failed" {
+		t.Fatalf("unexpected creation error: %#v", creationErr)
+	}
+
+	_, err = client.Sandboxes.Boxes.Wait(context.Background(), "slow-box", langsmith.SandboxWaitParams{
+		Timeout:      time.Millisecond,
+		PollInterval: time.Millisecond,
+	})
+	var timeoutErr *langsmith.SandboxResourceTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("expected SandboxResourceTimeoutError, got %T: %v", err, err)
+	}
+	if timeoutErr.LastStatus != "starting" {
+		t.Fatalf("unexpected timeout error: %#v", timeoutErr)
+	}
+}
+
+func TestSandboxStartAndWait(t *testing.T) {
+	var statusCalls int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes/boxes/box-a/start":
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "starting"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/box-a/status":
+			statusCalls++
+			status := "starting"
+			if statusCalls > 1 {
+				status = "ready"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": status})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/box-a":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":          "box-a",
+				"status":        "ready",
+				"dataplane_url": "https://sandbox.example",
+			})
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client := langsmith.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	sandbox, err := client.Sandboxes.Boxes.StartSandbox(context.Background(), "box-a", langsmith.SandboxWaitParams{
+		Timeout:      time.Second,
+		PollInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("StartSandbox returned error: %v", err)
+	}
+	if sandbox.Name != "box-a" || sandbox.Status != "ready" {
+		t.Fatalf("unexpected sandbox: %#v", sandbox)
+	}
+}


### PR DESCRIPTION
Adds first-class Go SDK helpers for sandbox command/runtime workflows while keeping tunnel support out of this PR.

## What changed
- Adds blocking command execution and streaming command handles over the sandbox dataplane.
- Adds command reconnects, stdin, kill, callbacks, and auto-reconnect handling.
- Adds sandbox wrapper helpers, readiness waiters, snapshot waiters, file IO, and service URL helpers.
- Splits the handwritten SDK layer into smaller files by responsibility.
- Adds focused tests for each command/runtime helper file.

## Base
- Targets `next`.

## Not in this PR
- Tunnel helpers are split into stacked follow-up PR #80.

## Test plan
- go test ./...
- go test . -race -run 'TestSandbox(CommandHandleWebSocketLifecycle|ReconnectCommandWithDataplaneURL|RunWithCallbacks|CommandHandleAutoReconnect|CommandWrapperRunUsesCurrentDataplaneURL|FileMethodsResolveNamedSandbox|CaptureSnapshotAndWait)'