### PR TITLE
feat: add explicit SDK profile option

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,8 +53,9 @@ type profileState struct {
 }
 
 type profileAuth struct {
-	state *profileState
-	mu    sync.Mutex
+	state    *profileState
+	override bool
+	mu       sync.Mutex
 }
 
 type oauthTokenResponse struct {
@@ -84,13 +85,21 @@ func (e oauthErrorResponse) Error() string {
 //  2. current_profile key in config file
 //  3. "default" profile
 func loadProfileOptions() []option.RequestOption {
-	state := loadProfileState()
+	opts, _ := loadProfileOptionsForProfile("", false)
+	return opts
+}
+
+func loadProfileOptionsForProfile(profileName string, explicit bool) ([]option.RequestOption, error) {
+	state, err := loadProfileState(profileName, explicit)
+	if err != nil {
+		return nil, err
+	}
 	if state == nil {
-		return nil
+		return nil, nil
 	}
 	p, ok := state.cfg.Profiles[state.profileName]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	envAuthSet := os.Getenv("LANGSMITH_API_KEY") != ""
@@ -102,7 +111,7 @@ func loadProfileOptions() []option.RequestOption {
 	}
 	if !envAuthSet {
 		if hasOAuth {
-			opts = append(opts, withProfileAuth(&profileAuth{state: state}))
+			opts = append(opts, withProfileAuth(&profileAuth{state: state, override: explicit}))
 		} else if p.APIKey != "" {
 			opts = append(opts, option.WithAPIKey(p.APIKey))
 		}
@@ -110,30 +119,54 @@ func loadProfileOptions() []option.RequestOption {
 	if p.WorkspaceID != "" {
 		opts = append(opts, option.WithTenantID(p.WorkspaceID))
 	}
-	return opts
+	return opts, nil
 }
 
-func loadProfileState() *profileState {
+func loadProfileState(profileName string, explicit bool) (*profileState, error) {
 	path := configPath()
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil
+		if explicit {
+			return nil, fmt.Errorf("reading LangSmith config: %w", err)
+		}
+		return nil, nil
 	}
 
 	var cfg configFile
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil
+		if explicit {
+			return nil, fmt.Errorf("parsing LangSmith config: %w", err)
+		}
+		return nil, nil
 	}
 
-	profileName := resolveProfileName(cfg)
 	if profileName == "" {
-		return nil
+		profileName = resolveProfileName(cfg)
+	}
+	if profileName == "" {
+		return nil, nil
 	}
 
 	if _, ok := cfg.Profiles[profileName]; !ok {
-		return nil
+		if explicit {
+			return nil, fmt.Errorf("LangSmith profile not found: %s", profileName)
+		}
+		return nil, nil
 	}
-	return &profileState{path: path, cfg: cfg, profileName: profileName}
+	return &profileState{path: path, cfg: cfg, profileName: profileName}, nil
+}
+
+// WithProfile returns a request option that uses a named profile from the
+// LangSmith config file. It is equivalent to selecting LANGSMITH_PROFILE for a
+// single client without mutating process-wide environment variables.
+func WithProfile(profileName string) option.RequestOption {
+	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+		opts, err := loadProfileOptionsForProfile(profileName, true)
+		if err != nil {
+			return err
+		}
+		return r.Apply(opts...)
+	})
 }
 
 func withProfileAuth(auth *profileAuth) option.RequestOption {
@@ -142,16 +175,23 @@ func withProfileAuth(auth *profileAuth) option.RequestOption {
 		if token != "" {
 			r.OAuthAccessToken = token
 		}
-		if name != "" && r.APIKey == "" {
+		if name != "" && (r.APIKey == "" || auth.override) {
+			if auth.override && !strings.EqualFold(name, "X-API-Key") {
+				r.APIKey = ""
+				r.Request.Header.Del("X-API-Key")
+			}
 			r.Request.Header.Set(name, value)
 		}
 		return r.Apply(option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
-			if req.Header.Get("X-API-Key") != "" {
+			if req.Header.Get("X-API-Key") != "" && !auth.override {
 				req.Header.Del("Authorization")
 				return next(req)
 			}
 			name, value, _ := auth.authHeader(req.Context())
 			if name != "" {
+				if auth.override && !strings.EqualFold(name, "X-API-Key") {
+					req.Header.Del("X-API-Key")
+				}
 				if strings.EqualFold(name, "X-API-Key") {
 					req.Header.Del("Authorization")
 				}

--- a/config_test.go
+++ b/config_test.go
@@ -561,6 +561,86 @@ func TestLoadProfileOptions_EnvAuthSuppressesProfileAuth(t *testing.T) {
 	}
 }
 
+func TestWithProfileOverridesDefaultProfile(t *testing.T) {
+	clearAuthEnv(t)
+	var gotAPIKey string
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/info" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		gotAPIKey = r.Header.Get("X-API-Key")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"version": "test"})
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "current_profile": "default",
+  "profiles": {
+    "default": {
+      "api_key": "default-api-key"
+    },
+    "prod": {
+      "oauth": {
+        "access_token": "prod-access-token"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	client := NewClient(WithProfile("prod"), option.WithBaseURL(ts.URL), option.WithMaxRetries(0))
+	if _, err := client.Info.List(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer prod-access-token" {
+		t.Fatalf("expected explicit profile bearer auth, got %q", gotAuth)
+	}
+	if gotAPIKey != "" {
+		t.Fatalf("expected explicit OAuth profile to override default API key, got %q", gotAPIKey)
+	}
+}
+
+func TestWithProfileMissingProfileReturnsError(t *testing.T) {
+	clearAuthEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_key": "default-api-key"
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := requestconfig.RequestConfig{Request: req, HTTPClient: http.DefaultClient}
+	err = cfg.Apply(WithProfile("missing"))
+	if err == nil {
+		t.Fatal("expected missing profile error")
+	}
+	if !strings.Contains(err.Error(), "profile not found: missing") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func applyOptions(t *testing.T, opts []option.RequestOption) requestconfig.RequestConfig {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)


### PR DESCRIPTION
Adds `langsmith.WithProfile(name)` so callers can choose a LangSmith config profile directly without mutating process environment. Explicit profile OAuth credentials now override default/current profile API-key credentials, which lets callers such as the CLI delegate token refresh to the SDK.

## Test Plan
- [x] go test ./...