### PR TITLE
feat(sandbox): expose console command controls

### DIFF
--- a/sandbox_command_handle.go
+++ b/sandbox_command_handle.go
@@ -2,6 +2,7 @@ package langsmith
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -136,6 +137,40 @@ func (h *SandboxCommandHandle) SendInput(data string) error {
 	return websocket.JSON.Send(h.ws, map[string]string{"type": "input", "data": data})
 }
 
+// Resize updates the command PTY size.
+func (h *SandboxCommandHandle) Resize(cols int, rows int) error {
+	if cols <= 0 || rows <= 0 {
+		return errors.New("cols and rows must be greater than zero")
+	}
+	h.sendMu.Lock()
+	defer h.sendMu.Unlock()
+	return websocket.JSON.Send(h.ws, map[string]any{"type": "resize", "cols": cols, "rows": rows})
+}
+
+// SendSSHAgentData sends SSH agent response bytes for a forwarded channel.
+func (h *SandboxCommandHandle) SendSSHAgentData(channelID string, data []byte) error {
+	if channelID == "" {
+		return errors.New("missing SSH agent channel ID")
+	}
+	h.sendMu.Lock()
+	defer h.sendMu.Unlock()
+	return websocket.JSON.Send(h.ws, map[string]string{
+		"type":       "ssh_agent_data",
+		"channel_id": channelID,
+		"data":       base64.StdEncoding.EncodeToString(data),
+	})
+}
+
+// CloseSSHAgentChannel tells the sandbox that a forwarded SSH agent channel is closed.
+func (h *SandboxCommandHandle) CloseSSHAgentChannel(channelID string) error {
+	if channelID == "" {
+		return errors.New("missing SSH agent channel ID")
+	}
+	h.sendMu.Lock()
+	defer h.sendMu.Unlock()
+	return websocket.JSON.Send(h.ws, map[string]string{"type": "ssh_agent_close", "channel_id": channelID})
+}
+
 // Kill sends a kill request for the running command.
 func (h *SandboxCommandHandle) Kill() error {
 	h.sendMu.Lock()
@@ -205,6 +240,10 @@ func (h *SandboxCommandHandle) readLoop() {
 		case "error":
 			h.setErr(sandboxErrorFromWSMessage(msg, h.CommandID))
 			return
+		case "ssh_agent_data":
+			h.invokeSSHAgentData(msg)
+		case "ssh_agent_close":
+			h.invokeSSHAgentClose(msg.ChannelID)
 		case "started":
 			if h.CommandID == "" {
 				h.CommandID = msg.CommandID
@@ -283,6 +322,23 @@ func (h *SandboxCommandHandle) invokeCallback(chunk SandboxOutputChunk) {
 	}
 	if chunk.Stream == "stderr" && h.callbacks.OnStderr != nil {
 		h.callbacks.OnStderr(chunk.Data)
+	}
+}
+
+func (h *SandboxCommandHandle) invokeSSHAgentData(msg sandboxWSMessage) {
+	if h.callbacks.OnSSHAgentData == nil || msg.ChannelID == "" || msg.Data == "" {
+		return
+	}
+	data, err := base64.StdEncoding.DecodeString(msg.Data)
+	if err != nil {
+		return
+	}
+	h.callbacks.OnSSHAgentData(msg.ChannelID, data)
+}
+
+func (h *SandboxCommandHandle) invokeSSHAgentClose(channelID string) {
+	if h.callbacks.OnSSHAgentClose != nil && channelID != "" {
+		h.callbacks.OnSSHAgentClose(channelID)
 	}
 }
 

--- a/sandbox_commands.go
+++ b/sandbox_commands.go
@@ -61,6 +61,7 @@ type SandboxCommandStartParams struct {
 	KillOnDisconnect   param.Field[bool]              `json:"kill_on_disconnect"`
 	TTLSeconds         param.Field[int64]             `json:"ttl_seconds"`
 	Pty                param.Field[bool]              `json:"pty"`
+	SSHAgentForward    param.Field[bool]              `json:"ssh_agent_forward"`
 }
 
 func (r SandboxCommandStartParams) MarshalJSON() (data []byte, err error) {
@@ -86,8 +87,10 @@ type SandboxOutputChunk struct {
 
 // SandboxCommandCallbacks are invoked as streaming command output arrives.
 type SandboxCommandCallbacks struct {
-	OnStdout func(string)
-	OnStderr func(string)
+	OnStdout        func(string)
+	OnStderr        func(string)
+	OnSSHAgentData  func(channelID string, data []byte)
+	OnSSHAgentClose func(channelID string)
 }
 
 // Run executes a command in the named sandbox and waits for completion. The
@@ -280,6 +283,7 @@ type sandboxCommandStartRequest struct {
 	KillOnDisconnect   param.Field[bool]              `json:"kill_on_disconnect"`
 	TTLSeconds         param.Field[int64]             `json:"ttl_seconds"`
 	Pty                param.Field[bool]              `json:"pty"`
+	SSHAgentForward    param.Field[bool]              `json:"ssh_agent_forward"`
 }
 
 func (r sandboxCommandStartRequest) MarshalJSON() (data []byte, err error) {
@@ -299,6 +303,7 @@ type sandboxWSMessage struct {
 	PID       int64  `json:"pid"`
 	Stream    string `json:"stream"`
 	Data      string `json:"data"`
+	ChannelID string `json:"channel_id"`
 	Offset    int64  `json:"offset"`
 	ExitCode  int64  `json:"exit_code"`
 	Error     string `json:"error"`
@@ -334,5 +339,6 @@ func normalizeSandboxCommandStartParams(body SandboxCommandStartParams) (sandbox
 		KillOnDisconnect:   F(sandboxFieldValue(body.KillOnDisconnect, false)),
 		TTLSeconds:         F(sandboxFieldValue(body.TTLSeconds, defaultSandboxCommandTTLSeconds)),
 		Pty:                body.Pty,
+		SSHAgentForward:    body.SSHAgentForward,
 	}, nil
 }

--- a/sandbox_commands.go
+++ b/sandbox_commands.go
@@ -51,6 +51,8 @@ func (r SandboxBoxRunParams) MarshalJSON() (data []byte, err error) {
 }
 
 // SandboxCommandStartParams configures a streaming WebSocket command execution.
+// Command is optional when Pty is true, in which case the sandbox starts the
+// selected shell directly.
 type SandboxCommandStartParams struct {
 	Command            param.Field[string]            `json:"command" api:"required"`
 	TimeoutSeconds     param.Field[int64]             `json:"timeout_seconds"`
@@ -325,12 +327,12 @@ func normalizeSandboxRunParams(body SandboxBoxRunParams) (SandboxBoxRunParams, i
 
 func normalizeSandboxCommandStartParams(body SandboxCommandStartParams) (sandboxCommandStartRequest, error) {
 	command, ok := sandboxRequiredString(body.Command)
-	if !ok {
+	pty := sandboxFieldValue(body.Pty, false)
+	if !ok && !pty {
 		return sandboxCommandStartRequest{}, errors.New("missing required command parameter")
 	}
-	return sandboxCommandStartRequest{
+	out := sandboxCommandStartRequest{
 		Type:               F("execute"),
-		Command:            F(command),
 		TimeoutSeconds:     F(sandboxFieldValue(body.TimeoutSeconds, defaultSandboxCommandTimeoutSeconds)),
 		Env:                body.Env,
 		CWD:                body.CWD,
@@ -340,5 +342,9 @@ func normalizeSandboxCommandStartParams(body SandboxCommandStartParams) (sandbox
 		TTLSeconds:         F(sandboxFieldValue(body.TTLSeconds, defaultSandboxCommandTTLSeconds)),
 		Pty:                body.Pty,
 		SSHAgentForward:    body.SSHAgentForward,
-	}, nil
+	}
+	if ok {
+		out.Command = F(command)
+	}
+	return out, nil
 }

--- a/sandbox_commands_test.go
+++ b/sandbox_commands_test.go
@@ -2,6 +2,7 @@ package langsmith_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -235,6 +236,151 @@ func TestSandboxCommandHandleWebSocketLifecycle(t *testing.T) {
 		t.Fatalf("Result returned error: %v", err)
 	}
 	if result.Stdout != "ready\n" || result.ExitCode != 137 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestSandboxCommandConsoleControls(t *testing.T) {
+	executePayload := make(chan map[string]any, 1)
+	resizePayload := make(chan map[string]any, 1)
+	agentResponsePayload := make(chan map[string]any, 1)
+	agentClosePayload := make(chan map[string]any, 1)
+
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		var msg map[string]any
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive execute: %v", err)
+			return
+		}
+		executePayload <- msg
+		if err := websocket.Message.Send(ws, `{"type":"started","command_id":"cmd-123","pid":42}`); err != nil {
+			t.Errorf("send started: %v", err)
+			return
+		}
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive resize: %v", err)
+			return
+		}
+		resizePayload <- msg
+		if err := websocket.Message.Send(ws, `{"type":"stdout","data":"shell ready\n","offset":0}`); err != nil {
+			t.Errorf("send stdout: %v", err)
+			return
+		}
+		agentRequest := base64.StdEncoding.EncodeToString([]byte("agent-request"))
+		if err := websocket.Message.Send(ws, `{"type":"ssh_agent_data","channel_id":"ch-1","data":"`+agentRequest+`"}`); err != nil {
+			t.Errorf("send agent data: %v", err)
+			return
+		}
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive agent response: %v", err)
+			return
+		}
+		agentResponsePayload <- msg
+		if err := websocket.Message.Send(ws, `{"type":"ssh_agent_close","channel_id":"ch-1"}`); err != nil {
+			t.Errorf("send agent close: %v", err)
+			return
+		}
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			t.Errorf("receive close response: %v", err)
+			return
+		}
+		agentClosePayload <- msg
+		if err := websocket.Message.Send(ws, `{"type":"exit","exit_code":0}`); err != nil {
+			t.Errorf("send exit: %v", err)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	agentData := make(chan []byte, 1)
+	agentClose := make(chan string, 1)
+	client := langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+	handle, err := client.Sandboxes.Boxes.StartCommandWithDataplaneURLAndCallbacks(context.Background(), srv.URL, langsmith.SandboxCommandStartParams{
+		Command:         langsmith.String("/bin/bash"),
+		Pty:             langsmith.Bool(true),
+		SSHAgentForward: langsmith.Bool(true),
+	}, langsmith.SandboxCommandCallbacks{
+		OnSSHAgentData: func(channelID string, data []byte) {
+			if channelID != "ch-1" {
+				t.Errorf("unexpected channel ID: %s", channelID)
+			}
+			agentData <- data
+		},
+		OnSSHAgentClose: func(channelID string) {
+			agentClose <- channelID
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartCommandWithDataplaneURLAndCallbacks returned error: %v", err)
+	}
+
+	execute := <-executePayload
+	if execute["type"] != "execute" || execute["command"] != "/bin/bash" {
+		t.Fatalf("unexpected execute payload: %#v", execute)
+	}
+	if execute["pty"] != true {
+		t.Fatalf("unexpected pty: %#v", execute["pty"])
+	}
+	if execute["ssh_agent_forward"] != true {
+		t.Fatalf("unexpected ssh_agent_forward: %#v", execute["ssh_agent_forward"])
+	}
+
+	if err := handle.Resize(120, 40); err != nil {
+		t.Fatalf("Resize returned error: %v", err)
+	}
+	resize := <-resizePayload
+	if resize["type"] != "resize" || resize["cols"] != float64(120) || resize["rows"] != float64(40) {
+		t.Fatalf("unexpected resize payload: %#v", resize)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	chunk, ok, err := handle.Next(ctx)
+	if err != nil {
+		t.Fatalf("Next returned error: %v", err)
+	}
+	if !ok || chunk.Data != "shell ready\n" {
+		t.Fatalf("unexpected output chunk: %#v", chunk)
+	}
+
+	if got := <-agentData; string(got) != "agent-request" {
+		t.Fatalf("unexpected agent data: %q", string(got))
+	}
+	if err := handle.SendSSHAgentData("ch-1", []byte("agent-response")); err != nil {
+		t.Fatalf("SendSSHAgentData returned error: %v", err)
+	}
+	agentResponse := <-agentResponsePayload
+	if agentResponse["type"] != "ssh_agent_data" || agentResponse["channel_id"] != "ch-1" {
+		t.Fatalf("unexpected agent response payload: %#v", agentResponse)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(agentResponse["data"].(string))
+	if err != nil {
+		t.Fatalf("decode agent response: %v", err)
+	}
+	if string(decoded) != "agent-response" {
+		t.Fatalf("unexpected agent response data: %q", string(decoded))
+	}
+
+	if got := <-agentClose; got != "ch-1" {
+		t.Fatalf("unexpected agent close channel: %q", got)
+	}
+	if err := handle.CloseSSHAgentChannel("ch-1"); err != nil {
+		t.Fatalf("CloseSSHAgentChannel returned error: %v", err)
+	}
+	closePayload := <-agentClosePayload
+	if closePayload["type"] != "ssh_agent_close" || closePayload["channel_id"] != "ch-1" {
+		t.Fatalf("unexpected agent close payload: %#v", closePayload)
+	}
+
+	result, err := handle.Result(ctx)
+	if err != nil {
+		t.Fatalf("Result returned error: %v", err)
+	}
+	if result.Stdout != "shell ready\n" || result.ExitCode != 0 {
 		t.Fatalf("unexpected result: %#v", result)
 	}
 }

--- a/sandbox_commands_test.go
+++ b/sandbox_commands_test.go
@@ -300,9 +300,10 @@ func TestSandboxCommandConsoleControls(t *testing.T) {
 		option.WithMaxRetries(0),
 	)
 	handle, err := client.Sandboxes.Boxes.StartCommandWithDataplaneURLAndCallbacks(context.Background(), srv.URL, langsmith.SandboxCommandStartParams{
-		Command:         langsmith.String("/bin/bash"),
-		Pty:             langsmith.Bool(true),
-		SSHAgentForward: langsmith.Bool(true),
+		Shell:              langsmith.String("/bin/bash"),
+		IdleTimeoutSeconds: langsmith.Int(-1),
+		Pty:                langsmith.Bool(true),
+		SSHAgentForward:    langsmith.Bool(true),
 	}, langsmith.SandboxCommandCallbacks{
 		OnSSHAgentData: func(channelID string, data []byte) {
 			if channelID != "ch-1" {
@@ -319,8 +320,17 @@ func TestSandboxCommandConsoleControls(t *testing.T) {
 	}
 
 	execute := <-executePayload
-	if execute["type"] != "execute" || execute["command"] != "/bin/bash" {
+	if execute["type"] != "execute" {
 		t.Fatalf("unexpected execute payload: %#v", execute)
+	}
+	if _, ok := execute["command"]; ok {
+		t.Fatalf("expected no command for interactive PTY payload, got %#v", execute["command"])
+	}
+	if execute["shell"] != "/bin/bash" {
+		t.Fatalf("unexpected shell: %#v", execute["shell"])
+	}
+	if execute["idle_timeout_seconds"] != float64(-1) {
+		t.Fatalf("unexpected idle_timeout_seconds: %#v", execute["idle_timeout_seconds"])
 	}
 	if execute["pty"] != true {
 		t.Fatalf("unexpected pty: %#v", execute["pty"])


### PR DESCRIPTION
Adds SDK command-handle controls needed by interactive console clients without changing the transport model away from sandbox command WebSockets.

## What changed
- Adds `SSHAgentForward` to `SandboxCommandStartParams`.
- Allows PTY shell sessions without an explicit command.
- Adds command-handle `Resize`, `SendSSHAgentData`, and `CloseSSHAgentChannel`.
- Adds optional SSH-agent data/close callbacks to `SandboxCommandCallbacks`.

## Test plan
- go test ./...