### PR TITLE
feat: openai: add tool calls to `/responses`

### DIFF
--- a/instrumentation/traceopenai/openaitrace.go
+++ b/instrumentation/traceopenai/openaitrace.go
@@ -363,11 +363,18 @@ func parseRequestBody(body []byte) requestFields {
 
 	// Input — Responses API (string or array)
 	if input, ok := req["input"]; ok {
+		var msgs []any
+		if instr, ok := req["instructions"].(string); ok && instr != "" {
+			msgs = append(msgs, map[string]any{"role": "system", "content": instr})
+		}
 		switch v := input.(type) {
 		case string:
-			fields.inputMessages = marshalMessages([]any{map[string]any{"role": "user", "content": v}})
+			msgs = append(msgs, map[string]any{"role": "user", "content": v})
 		case []any:
-			fields.inputMessages = marshalMessages(v)
+			msgs = append(msgs, normalizeResponsesInput(v)...)
+		}
+		if len(msgs) > 0 {
+			fields.inputMessages = marshalMessages(msgs)
 		}
 		return fields
 	}
@@ -387,6 +394,227 @@ func marshalMessages(messages []any) string {
 		return ""
 	}
 	return string(out)
+}
+
+// normalizeResponsesInput converts Responses API input items into
+// chat-completions messages that LangSmith can render.
+func normalizeResponsesInput(items []any) []any {
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			out = append(out, item)
+			continue
+		}
+
+		itemType, _ := m["type"].(string)
+
+		// Items with a role are messages.
+		if role, ok := m["role"].(string); ok {
+			msg := map[string]any{"role": role}
+			switch content := m["content"].(type) {
+			case string:
+				msg["content"] = content
+			case []any:
+				if text := flattenContentParts(content); text != "" {
+					msg["content"] = text
+				} else {
+					b, _ := json.Marshal(content)
+					msg["content"] = string(b)
+				}
+			}
+			out = append(out, msg)
+			continue
+		}
+
+		// Non-message items: convert to chat-completions equivalents.
+		switch itemType {
+		case "function_call_output":
+			out = append(out, toolOutputFromItem(m, "call_id"))
+		case "computer_call_output":
+			out = append(out, toolOutputFromItem(m, "call_id"))
+		case "mcp_call_output":
+			out = append(out, toolOutputFromItem(m, "id"))
+		case "mcp_approval_response":
+			msg := map[string]any{"role": "tool"}
+			if reqID, ok := m["approval_request_id"].(string); ok {
+				msg["tool_call_id"] = reqID
+			}
+			approved, _ := m["approve"].(bool)
+			msg["content"] = fmt.Sprintf("approved: %v", approved)
+			out = append(out, msg)
+		case "reasoning":
+			if text := extractSummaryText(m); text != "" {
+				out = append(out, map[string]any{
+					"role":    "assistant",
+					"content": "[reasoning] " + text,
+				})
+			}
+		case "item_reference", "compaction":
+			continue
+		default:
+			if tc, ok := responsesItemToToolCall(itemType, m); ok {
+				out = append(out, map[string]any{
+					"role":       "assistant",
+					"tool_calls": []any{tc},
+				})
+			} else if itemType != "" {
+				out = append(out, map[string]any{
+					"role":    "assistant",
+					"content": "[" + itemType + "]",
+				})
+			}
+		}
+	}
+	return out
+}
+
+// toolOutputFromItem builds a tool-output message from a Responses API output item.
+func toolOutputFromItem(m map[string]any, idKey string) map[string]any {
+	msg := map[string]any{"role": "tool"}
+	if callID, ok := m[idKey].(string); ok {
+		msg["tool_call_id"] = callID
+	}
+	switch v := m["output"].(type) {
+	case string:
+		msg["content"] = v
+	case []any:
+		if text := flattenContentParts(v); text != "" {
+			msg["content"] = text
+		} else {
+			b, _ := json.Marshal(v)
+			msg["content"] = string(b)
+		}
+	}
+	return msg
+}
+
+// responsesItemToToolCall converts a Responses API tool item into a
+// chat-completions tool_call. Returns false for unknown types.
+func responsesItemToToolCall(itemType string, m map[string]any) (map[string]any, bool) {
+	switch itemType {
+	case "function_call":
+		name, _ := m["name"].(string)
+		args, _ := m["arguments"].(string)
+		return chatToolCall(m["call_id"], name, args), true
+	case "web_search_call":
+		args := make(map[string]any)
+		if status, ok := m["status"].(string); ok {
+			args["status"] = status
+		}
+		if action, ok := m["action"].(map[string]any); ok {
+			if q, ok := action["query"].(string); ok {
+				args["query"] = q
+			}
+		}
+		b, _ := json.Marshal(args)
+		return chatToolCall(m["id"], "web_search", string(b)), true
+	case "file_search_call":
+		args := make(map[string]any)
+		if q, ok := m["queries"].([]any); ok {
+			args["queries"] = q
+		}
+		if r, ok := m["results"].([]any); ok {
+			args["results"] = r
+		}
+		b, _ := json.Marshal(args)
+		return chatToolCall(m["id"], "file_search", string(b)), true
+	case "code_interpreter_call":
+		args := make(map[string]any)
+		if code, ok := m["code"].(string); ok {
+			args["code"] = code
+		}
+		if r, ok := m["results"].([]any); ok {
+			args["results"] = r
+		}
+		b, _ := json.Marshal(args)
+		return chatToolCall(m["id"], "code_interpreter", string(b)), true
+	case "computer_call":
+		args := make(map[string]any)
+		if action, ok := m["action"].(map[string]any); ok {
+			args["action"] = action
+		}
+		b, _ := json.Marshal(args)
+		return chatToolCall(m["call_id"], "computer", string(b)), true
+	case "mcp_call":
+		name := "mcp"
+		if sl, ok := m["server_label"].(string); ok {
+			if tn, ok := m["name"].(string); ok {
+				name = sl + ":" + tn
+			}
+		}
+		args, _ := m["arguments"].(string)
+		if args == "" {
+			args = "{}"
+		}
+		return chatToolCall(m["id"], name, args), true
+	case "mcp_list_tools":
+		return chatToolCall(m["id"], "mcp_list_tools", marshalToolArgs(m, "server_label")), true
+	case "mcp_approval_request":
+		name := "mcp_approval_request"
+		if n, ok := m["name"].(string); ok {
+			name = n
+		}
+		args, _ := m["arguments"].(string)
+		if args == "" {
+			args = "{}"
+		}
+		return chatToolCall(m["id"], name, args), true
+	case "image_generation_call":
+		return chatToolCall(m["id"], "image_generation", marshalToolArgs(m, "status")), true
+	default:
+		return nil, false
+	}
+}
+
+// extractSummaryText extracts text from a reasoning item's summary.
+func extractSummaryText(m map[string]any) string {
+	summary, ok := m["summary"].([]any)
+	if !ok {
+		return ""
+	}
+	var b strings.Builder
+	for _, s := range summary {
+		sMap, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if text, ok := sMap["text"].(string); ok {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(text)
+		}
+	}
+	return b.String()
+}
+
+// flattenContentParts extracts text from Responses API content part arrays.
+func flattenContentParts(parts []any) string {
+	var b strings.Builder
+	for _, part := range parts {
+		pm, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch pm["type"] {
+		case "input_text", "output_text", "text":
+			if text, ok := pm["text"].(string); ok {
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(text)
+			}
+		case "refusal":
+			if text, ok := pm["refusal"].(string); ok {
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(text)
+			}
+		}
+	}
+	return b.String()
 }
 
 // extractStreamingCompletion parses an SSE response body, aggregates
@@ -579,8 +807,7 @@ func extractResponsesUsage(resp map[string]any) usageInfo {
 	return usage
 }
 
-// extractResponsesOutput extracts a {"messages":[...]} JSON string from a
-// Responses API response. Handles message (output_text) and function_call items.
+// extractResponsesOutput builds a chat-completions output from a Responses API response.
 func extractResponsesOutput(resp map[string]any) string {
 	output, ok := resp["output"].([]any)
 	if !ok || len(output) == 0 {
@@ -588,14 +815,17 @@ func extractResponsesOutput(resp map[string]any) string {
 	}
 
 	var textParts []string
-	var functionCalls []map[string]any
+	var refusalParts []string
+	var reasoningParts []string
+	var toolCalls []map[string]any
 
 	for _, item := range output {
 		itemMap, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		switch itemType, _ := itemMap["type"].(string); itemType {
+		itemType, _ := itemMap["type"].(string)
+		switch itemType {
 		case "message":
 			if content, ok := itemMap["content"].([]any); ok {
 				for _, block := range content {
@@ -603,22 +833,26 @@ func extractResponsesOutput(resp map[string]any) string {
 					if !ok {
 						continue
 					}
-					if blockType, _ := blockMap["type"].(string); blockType == "output_text" {
+					switch blockType, _ := blockMap["type"].(string); blockType {
+					case "output_text":
 						if text, ok := blockMap["text"].(string); ok {
 							textParts = append(textParts, text)
+						}
+					case "refusal":
+						if text, ok := blockMap["refusal"].(string); ok {
+							refusalParts = append(refusalParts, text)
 						}
 					}
 				}
 			}
-		case "function_call":
-			fc := map[string]any{
-				"name":      itemMap["name"],
-				"arguments": itemMap["arguments"],
+		case "reasoning":
+			if text := extractSummaryText(itemMap); text != "" {
+				reasoningParts = append(reasoningParts, text)
 			}
-			if callID, ok := itemMap["call_id"].(string); ok {
-				fc["call_id"] = callID
+		default:
+			if tc, ok := responsesItemToToolCall(itemType, itemMap); ok {
+				toolCalls = append(toolCalls, tc)
 			}
-			functionCalls = append(functionCalls, fc)
 		}
 	}
 
@@ -626,11 +860,44 @@ func extractResponsesOutput(resp map[string]any) string {
 	if len(textParts) > 0 {
 		msg["content"] = strings.Join(textParts, "\n")
 	}
-	if len(functionCalls) > 0 {
-		msg["function_calls"] = functionCalls
+	if len(refusalParts) > 0 {
+		msg["refusal"] = strings.Join(refusalParts, "\n")
+	}
+	if len(reasoningParts) > 0 {
+		msg["reasoning"] = strings.Join(reasoningParts, "\n")
+	}
+	if len(toolCalls) > 0 {
+		msg["tool_calls"] = toolCalls
 	}
 	if len(msg) == 1 {
 		return ""
 	}
 	return marshalMessages([]any{msg})
+}
+
+// chatToolCall builds a tool_call in the chat-completions format.
+func chatToolCall(id any, name, arguments string) map[string]any {
+	tc := map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name":      name,
+			"arguments": arguments,
+		},
+	}
+	if s, ok := id.(string); ok {
+		tc["id"] = s
+	}
+	return tc
+}
+
+// marshalToolArgs extracts the given keys from src into a JSON object string.
+func marshalToolArgs(src map[string]any, keys ...string) string {
+	args := make(map[string]any, len(keys))
+	for _, k := range keys {
+		if v, ok := src[k].(string); ok {
+			args[k] = v
+		}
+	}
+	b, _ := json.Marshal(args)
+	return string(b)
 }

--- a/instrumentation/traceopenai/openaitrace.go
+++ b/instrumentation/traceopenai/openaitrace.go
@@ -443,6 +443,21 @@ func normalizeResponsesInput(items []any) []any {
 			approved, _ := m["approve"].(bool)
 			msg["content"] = fmt.Sprintf("approved: %v", approved)
 			out = append(out, msg)
+		case "local_shell_call_output":
+			out = append(out, toolOutputFromItem(m, "id"))
+		case "shell_call_output":
+			out = append(out, toolOutputFromShellCall(m))
+		case "apply_patch_call_output":
+			out = append(out, toolOutputFromItem(m, "call_id"))
+		case "custom_tool_call_output":
+			out = append(out, toolOutputFromItem(m, "call_id"))
+		case "tool_search_output":
+			msg := map[string]any{"role": "tool"}
+			if tools, ok := m["tools"].([]any); ok {
+				b, _ := json.Marshal(tools)
+				msg["content"] = string(b)
+			}
+			out = append(out, msg)
 		case "reasoning":
 			if text := extractSummaryText(m); text != "" {
 				out = append(out, map[string]any{
@@ -489,6 +504,35 @@ func toolOutputFromItem(m map[string]any, idKey string) map[string]any {
 	return msg
 }
 
+// toolOutputFromShellCall builds a tool-output message from a shell_call_output.
+// The output field is an array of {stdout, stderr, outcome} objects.
+func toolOutputFromShellCall(m map[string]any) map[string]any {
+	msg := map[string]any{"role": "tool"}
+	if callID, ok := m["call_id"].(string); ok {
+		msg["tool_call_id"] = callID
+	}
+	if outputs, ok := m["output"].([]any); ok {
+		var sb strings.Builder
+		for _, o := range outputs {
+			om, ok := o.(map[string]any)
+			if !ok {
+				continue
+			}
+			if s, ok := om["stdout"].(string); ok && s != "" {
+				sb.WriteString(s)
+			}
+			if s, ok := om["stderr"].(string); ok && s != "" {
+				if sb.Len() > 0 {
+					sb.WriteByte('\n')
+				}
+				sb.WriteString(s)
+			}
+		}
+		msg["content"] = sb.String()
+	}
+	return msg
+}
+
 // responsesItemToToolCall converts a Responses API tool item into a
 // chat-completions tool_call. Returns false for unknown types.
 func responsesItemToToolCall(itemType string, m map[string]any) (map[string]any, bool) {
@@ -524,8 +568,8 @@ func responsesItemToToolCall(itemType string, m map[string]any) (map[string]any,
 		if code, ok := m["code"].(string); ok {
 			args["code"] = code
 		}
-		if r, ok := m["results"].([]any); ok {
-			args["results"] = r
+		if r, ok := m["outputs"].([]any); ok {
+			args["outputs"] = r
 		}
 		b, _ := json.Marshal(args)
 		return chatToolCall(m["id"], "code_interpreter", string(b)), true
@@ -562,6 +606,34 @@ func responsesItemToToolCall(itemType string, m map[string]any) (map[string]any,
 		return chatToolCall(m["id"], name, args), true
 	case "image_generation_call":
 		return chatToolCall(m["id"], "image_generation", marshalToolArgs(m, "status")), true
+	case "local_shell_call":
+		args := make(map[string]any)
+		if action, ok := m["action"].(map[string]any); ok {
+			args["action"] = action
+		}
+		b, _ := json.Marshal(args)
+		return chatToolCall(m["call_id"], "local_shell", string(b)), true
+	case "shell_call":
+		args := make(map[string]any)
+		if action, ok := m["action"].(map[string]any); ok {
+			args["action"] = action
+		}
+		b, _ := json.Marshal(args)
+		return chatToolCall(m["call_id"], "shell", string(b)), true
+	case "apply_patch_call":
+		args := make(map[string]any)
+		if op, ok := m["operation"].(map[string]any); ok {
+			args["operation"] = op
+		}
+		b, _ := json.Marshal(args)
+		return chatToolCall(m["call_id"], "apply_patch", string(b)), true
+	case "tool_search_call":
+		args := make(map[string]any)
+		if a, ok := m["arguments"]; ok {
+			args["arguments"] = a
+		}
+		b, _ := json.Marshal(args)
+		return chatToolCall(m["call_id"], "tool_search", string(b)), true
 	default:
 		return nil, false
 	}

--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -822,6 +822,75 @@ func TestExtractResponsesOutput_ImageGenerationCall(t *testing.T) {
 	}
 }
 
+func TestExtractResponsesOutput_AgentToolCalls(t *testing.T) {
+	tests := []struct {
+		name     string
+		item     map[string]any
+		contains []string
+	}{
+		{
+			name: "local_shell_call",
+			item: map[string]any{
+				"type": "local_shell_call", "id": "ls_1", "call_id": "lsc_1",
+				"action": map[string]any{"type": "exec", "command": []any{"ls", "-la"}},
+			},
+			contains: []string{"local_shell", "lsc_1", `"type":"function"`},
+		},
+		{
+			name: "shell_call",
+			item: map[string]any{
+				"type": "shell_call", "call_id": "sc_1",
+				"action": map[string]any{"commands": []any{"echo hello"}},
+			},
+			contains: []string{`"shell"`, "sc_1", `"type":"function"`},
+		},
+		{
+			name: "apply_patch_call",
+			item: map[string]any{
+				"type": "apply_patch_call", "call_id": "ap_1",
+				"operation": map[string]any{"type": "create", "path": "foo.txt", "diff": "+hello"},
+			},
+			contains: []string{"apply_patch", `"type":"function"`},
+		},
+		{
+			name: "tool_search_call",
+			item: map[string]any{
+				"type": "tool_search_call", "call_id": "ts_1",
+				"arguments": map[string]any{"query": "find files"},
+			},
+			contains: []string{"tool_search", `"type":"function"`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := map[string]any{"output": []any{tt.item}}
+			result := extractResponsesOutput(resp)
+			for _, s := range tt.contains {
+				if !strings.Contains(result, s) {
+					t.Errorf("expected %q in output: %s", s, result)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractResponsesOutput_CodeInterpreterUsesOutputs(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type": "code_interpreter_call", "id": "ci_1",
+				"code": "print('hi')", "container_id": "ctr_1",
+				"outputs": []any{map[string]any{"type": "logs", "logs": "hi"}},
+				"status":  "completed",
+			},
+		},
+	}
+	result := extractResponsesOutput(resp)
+	if !strings.Contains(result, "outputs") {
+		t.Errorf("expected 'outputs' key (not 'results'), got %s", result)
+	}
+}
+
 func TestExtractResponsesOutput_FunctionCallFormat(t *testing.T) {
 	resp := map[string]any{
 		"output": []any{
@@ -1039,5 +1108,142 @@ func TestNormalizeResponsesInput_UnknownTypeGetsRole(t *testing.T) {
 	content, _ := msg["content"].(string)
 	if !strings.Contains(content, "some_future_type") {
 		t.Errorf("content should contain the type name: %s", content)
+	}
+}
+
+func TestNormalizeResponsesInput_AgentToolCallsBecomeAssistant(t *testing.T) {
+	toolCallItems := []map[string]any{
+		{"type": "local_shell_call", "call_id": "ls_1", "action": map[string]any{"type": "exec"}},
+		{"type": "shell_call", "call_id": "sc_1", "action": map[string]any{"commands": []any{"ls"}}},
+		{"type": "apply_patch_call", "call_id": "ap_1", "operation": map[string]any{"type": "create"}},
+		{"type": "tool_search_call", "call_id": "ts_1"},
+	}
+	for _, item := range toolCallItems {
+		t.Run(item["type"].(string), func(t *testing.T) {
+			result := normalizeResponsesInput([]any{item})
+			if len(result) != 1 {
+				t.Fatalf("expected 1 item, got %d", len(result))
+			}
+			msg := result[0].(map[string]any)
+			if msg["role"] != "assistant" {
+				t.Errorf("role = %v, want assistant", msg["role"])
+			}
+			if _, ok := msg["tool_calls"].([]any); !ok {
+				t.Errorf("expected tool_calls: %+v", msg)
+			}
+		})
+	}
+}
+
+func TestNormalizeResponsesInput_AgentToolOutputs(t *testing.T) {
+	tests := []struct {
+		name       string
+		item       map[string]any
+		wantCallID string
+		wantIn     string
+	}{
+		{
+			name:       "local_shell_call_output",
+			item:       map[string]any{"type": "local_shell_call_output", "id": "lso_1", "output": "command output here"},
+			wantCallID: "lso_1",
+			wantIn:     "command output here",
+		},
+		{
+			name:       "apply_patch_call_output",
+			item:       map[string]any{"type": "apply_patch_call_output", "call_id": "ap_1", "output": "patch applied"},
+			wantCallID: "ap_1",
+			wantIn:     "patch applied",
+		},
+		{
+			name:       "custom_tool_call_output",
+			item:       map[string]any{"type": "custom_tool_call_output", "call_id": "ct_1", "output": "custom result"},
+			wantCallID: "ct_1",
+			wantIn:     "custom result",
+		},
+		{
+			name:       "mcp_approval_response",
+			item:       map[string]any{"type": "mcp_approval_response", "approval_request_id": "ar_1", "approve": true},
+			wantCallID: "ar_1",
+			wantIn:     "approved: true",
+		},
+		{
+			name: "tool_search_output",
+			item: map[string]any{
+				"type":  "tool_search_output",
+				"tools": []any{map[string]any{"name": "grep", "description": "search files"}},
+			},
+			wantIn: "grep",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeResponsesInput([]any{tt.item})
+			if len(result) != 1 {
+				t.Fatalf("expected 1 item, got %d", len(result))
+			}
+			msg := result[0].(map[string]any)
+			if msg["role"] != "tool" {
+				t.Errorf("role = %v, want tool", msg["role"])
+			}
+			if tt.wantCallID != "" && msg["tool_call_id"] != tt.wantCallID {
+				t.Errorf("tool_call_id = %v, want %s", msg["tool_call_id"], tt.wantCallID)
+			}
+			content, _ := msg["content"].(string)
+			if !strings.Contains(content, tt.wantIn) {
+				t.Errorf("content %q should contain %q", content, tt.wantIn)
+			}
+		})
+	}
+}
+
+func TestNormalizeResponsesInput_ShellCallOutputExtractsStdout(t *testing.T) {
+	items := []any{
+		map[string]any{
+			"type":    "shell_call_output",
+			"call_id": "sc_1",
+			"output": []any{
+				map[string]any{
+					"stdout":  "hello world",
+					"stderr":  "",
+					"outcome": map[string]any{"type": "exit", "exit_code": float64(0)},
+				},
+			},
+		},
+	}
+	result := normalizeResponsesInput(items)
+	msg := result[0].(map[string]any)
+	if msg["role"] != "tool" {
+		t.Errorf("role = %v, want tool", msg["role"])
+	}
+	if msg["tool_call_id"] != "sc_1" {
+		t.Errorf("tool_call_id = %v, want sc_1", msg["tool_call_id"])
+	}
+	if !strings.Contains(msg["content"].(string), "hello world") {
+		t.Errorf("content should contain stdout: %v", msg["content"])
+	}
+}
+
+func TestNormalizeResponsesInput_ShellCallOutputConcatsStderr(t *testing.T) {
+	items := []any{
+		map[string]any{
+			"type":    "shell_call_output",
+			"call_id": "sc_2",
+			"output": []any{
+				map[string]any{
+					"stdout":  "some output",
+					"stderr":  "warning: something",
+					"outcome": map[string]any{"type": "exit", "exit_code": float64(1)},
+				},
+			},
+		},
+	}
+	result := normalizeResponsesInput(items)
+	msg := result[0].(map[string]any)
+	content := msg["content"].(string)
+	if !strings.Contains(content, "some output") {
+		t.Errorf("content should contain stdout: %s", content)
+	}
+	if !strings.Contains(content, "warning: something") {
+		t.Errorf("content should contain stderr: %s", content)
 	}
 }

--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -1247,3 +1247,171 @@ func TestNormalizeResponsesInput_ShellCallOutputConcatsStderr(t *testing.T) {
 		t.Errorf("content should contain stderr: %s", content)
 	}
 }
+
+// TestResponsesAPI_RoundTrip exercises parseRequestBody and extractResponsesOutput
+// with a multi-turn conversation modeled after a Codex coding agent session.
+// Field shapes match captured OpenAI wire format (content arrays with input_text,
+// reasoning with encrypted_content, web_search_call with action.queries, etc.).
+func TestResponsesAPI_RoundTrip(t *testing.T) {
+	reqBody := []byte(`{
+		"model": "gpt-5.5",
+		"instructions": "You are a coding agent.",
+		"input": [
+			{"type": "message", "role": "developer", "content": [
+				{"type": "input_text", "text": "Sandbox mode is workspace-write."}
+			]},
+			{"type": "message", "role": "user", "content": [
+				{"type": "input_text", "text": "List the files in my home directory"}
+			]},
+
+			{"type": "reasoning", "summary": [
+				{"type": "summary_text", "text": "I'll run ls to list the directory contents."}
+			], "content": null, "encrypted_content": "enc_abc"},
+			{"type": "function_call", "name": "exec_command", "call_id": "call_ls1",
+			 "arguments": "{\"cmd\":\"ls\",\"workdir\":\"/Users/dev\"}"},
+			{"type": "function_call_output", "call_id": "call_ls1",
+			 "output": "Desktop\nDocuments\nDownloads\nsrc\n"},
+			{"type": "message", "role": "assistant", "content": [
+				{"type": "output_text", "text": "Here are the files in your home directory."}
+			]},
+
+			{"type": "message", "role": "user", "content": [
+				{"type": "input_text", "text": "Now search for recent Go news"}
+			]},
+
+			{"type": "reasoning", "summary": [], "content": null, "encrypted_content": "enc_def"},
+			{"type": "web_search_call", "status": "completed", "action": {
+				"type": "search",
+				"query": "Go programming language news 2026",
+				"queries": ["Go programming language news 2026", "Go 1.25 release"]
+			}},
+			{"type": "message", "role": "assistant", "content": [
+				{"type": "output_text", "text": "Go 1.25 was released with improved generics."}
+			]},
+
+			{"type": "message", "role": "user", "content": [
+				{"type": "input_text", "text": "Create a hello.go file and run it"}
+			]},
+
+			{"type": "shell_call", "call_id": "sc_1", "action": {
+				"type": "exec", "commands": ["echo 'package main' > hello.go"]
+			}},
+			{"type": "shell_call_output", "call_id": "sc_1", "output": [
+				{"stdout": "", "stderr": "", "outcome": {"type": "exit", "exit_code": 0}}
+			]},
+			{"type": "apply_patch_call", "call_id": "ap_1", "operation": {
+				"type": "create", "path": "hello.go",
+				"diff": "+package main\n+\n+func main() {\n+\tprintln(\"hello\")\n+}"
+			}},
+			{"type": "apply_patch_call_output", "call_id": "ap_1", "output": "patch applied"},
+
+			{"type": "message", "role": "user", "content": [
+				{"type": "input_text", "text": "Run it"}
+			]}
+		]
+	}`)
+
+	fields := parseRequestBody(reqBody)
+	if fields.model != "gpt-5.5" {
+		t.Errorf("model = %q, want gpt-5.5", fields.model)
+	}
+
+	in := fields.inputMessages
+	checks := []struct {
+		desc string
+		want string
+	}{
+		{"instructions as system message", "coding agent"},
+		{"developer message", "Sandbox mode"},
+		{"first user message", "List the files"},
+		{"reasoning summary", "run ls"},
+		{"function_call tool_calls", "exec_command"},
+		{"function_call_output as tool role", `"role":"tool"`},
+		{"function output content", "Desktop"},
+		{"assistant reply", "files in your home"},
+		{"second user turn", "search for recent Go"},
+		{"web_search_call", "web_search"},
+		{"third user turn", "Create a hello.go"},
+		{"shell_call", `"shell"`},
+		{"shell_call_output as tool", "sc_1"},
+		{"apply_patch_call", "apply_patch"},
+		{"apply_patch_call_output as tool", "patch applied"},
+		{"final user turn", "Run it"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(in, c.want) {
+			t.Errorf("%s: %q not found in input", c.desc, c.want)
+		}
+	}
+
+	respBody := map[string]any{
+		"id": "resp_abc", "object": "response", "model": "gpt-5.5-2026-04-23",
+		"output": []any{
+			map[string]any{
+				"id": "rs_1", "type": "reasoning",
+				"encrypted_content": "enc_xyz",
+				"summary":           []any{},
+			},
+			map[string]any{
+				"id": "ws_1", "type": "web_search_call",
+				"status": "completed",
+				"action": map[string]any{
+					"type":    "search",
+					"query":   "how to run Go programs",
+					"queries": []any{"how to run Go programs", "go run command"},
+				},
+			},
+			map[string]any{
+				"id": "sc_2", "type": "shell_call", "call_id": "sc_2",
+				"action": map[string]any{"commands": []any{"go run hello.go"}},
+			},
+			map[string]any{
+				"id": "fc_1", "type": "function_call", "call_id": "call_run1",
+				"name": "exec_command", "arguments": `{"cmd":"go run hello.go"}`,
+				"status": "completed",
+			},
+			map[string]any{
+				"id": "msg_1", "type": "message", "role": "assistant",
+				"status": "completed",
+				"content": []any{
+					map[string]any{
+						"type":        "output_text",
+						"text":        "The program printed hello.",
+						"logprobs":    []any{},
+						"annotations": []any{},
+					},
+				},
+			},
+		},
+		"usage": map[string]any{
+			"input_tokens":  float64(500),
+			"output_tokens": float64(50),
+			"total_tokens":  float64(550),
+			"output_tokens_details": map[string]any{
+				"reasoning_tokens": float64(22),
+			},
+		},
+	}
+
+	out := extractResponsesOutput(respBody)
+	if out == "" {
+		t.Fatal("extractResponsesOutput returned empty")
+	}
+
+	outChecks := []struct {
+		desc string
+		want string
+	}{
+		{"web_search as tool call", "web_search"},
+		{"web_search uses function format", `"type":"function"`},
+		{"shell_call name", `"shell"`},
+		{"function_call name", "exec_command"},
+		{"function_call args", "go run hello.go"},
+		{"message text", "printed hello"},
+	}
+	for _, c := range outChecks {
+		if !strings.Contains(out, c.want) {
+			t.Errorf("%s: %q not found in output", c.desc, c.want)
+		}
+	}
+}

--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -650,3 +650,394 @@ func TestExtractResponsesOutput_Empty(t *testing.T) {
 		t.Errorf("expected empty output, got %q", output)
 	}
 }
+
+func TestExtractResponsesOutput_Refusal(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type": "message",
+				"content": []any{
+					map[string]any{"type": "refusal", "refusal": "I cannot help with that"},
+				},
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, "I cannot help with that") {
+		t.Errorf("output should contain refusal text: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_Reasoning(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type": "reasoning",
+				"summary": []any{
+					map[string]any{"type": "summary_text", "text": "Let me think about this"},
+				},
+			},
+			map[string]any{
+				"type": "message",
+				"content": []any{
+					map[string]any{"type": "output_text", "text": "The answer is 42"},
+				},
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, "Let me think about this") {
+		t.Errorf("output should contain reasoning summary: %s", output)
+	}
+	if !strings.Contains(output, "The answer is 42") {
+		t.Errorf("output should contain message text: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_WebSearchCall(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type":   "web_search_call",
+				"id":     "ws_1",
+				"status": "completed",
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, "web_search") {
+		t.Errorf("output should contain web_search tool call: %s", output)
+	}
+	if !strings.Contains(output, `"type":"function"`) {
+		t.Errorf("output should use chat-completions tool_calls format: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_FileSearchCall(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type":    "file_search_call",
+				"id":      "fs_1",
+				"queries": []any{"search query"},
+				"results": []any{map[string]any{"file_id": "f1", "text": "result"}},
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, "file_search") {
+		t.Errorf("output should contain file_search tool call: %s", output)
+	}
+	if !strings.Contains(output, "search query") {
+		t.Errorf("output should contain query: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_CodeInterpreterCall(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type":    "code_interpreter_call",
+				"id":      "ci_1",
+				"code":    "print('hello')",
+				"results": []any{map[string]any{"type": "logs", "logs": "hello"}},
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, "code_interpreter") {
+		t.Errorf("output should contain code_interpreter tool call: %s", output)
+	}
+	if !strings.Contains(output, "print") {
+		t.Errorf("output should contain code: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_ComputerCall(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type":    "computer_call",
+				"call_id": "comp_1",
+				"action":  map[string]any{"type": "click", "x": float64(100), "y": float64(200)},
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, "computer") {
+		t.Errorf("output should contain computer tool call: %s", output)
+	}
+	if !strings.Contains(output, "click") {
+		t.Errorf("output should contain action: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_McpCall(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type":         "mcp_call",
+				"id":           "mcp_1",
+				"server_label": "my_server",
+				"name":         "my_tool",
+				"arguments":    `{"key":"value"}`,
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, "my_server:my_tool") {
+		t.Errorf("output should contain server_label:name: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_McpListTools(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type":         "mcp_list_tools",
+				"id":           "mlt_1",
+				"server_label": "my_server",
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, "mcp_list_tools") {
+		t.Errorf("output should contain mcp_list_tools: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_ImageGenerationCall(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type":   "image_generation_call",
+				"id":     "ig_1",
+				"status": "completed",
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, "image_generation") {
+		t.Errorf("output should contain image_generation tool call: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_FunctionCallFormat(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type":      "function_call",
+				"name":      "get_weather",
+				"arguments": `{"city":"SF"}`,
+				"call_id":   "fc_1",
+			},
+		},
+	}
+	output := extractResponsesOutput(resp)
+	if !strings.Contains(output, `"type":"function"`) {
+		t.Errorf("function_call should use chat-completions format: %s", output)
+	}
+	if !strings.Contains(output, `"name":"get_weather"`) {
+		t.Errorf("should contain function name: %s", output)
+	}
+	if !strings.Contains(output, `"id":"fc_1"`) {
+		t.Errorf("should contain call id: %s", output)
+	}
+}
+
+func TestParseRequestBody_ResponsesAPI_ArrayInput(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-4o",
+		"instructions": "You are a helpful assistant.",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "Hello"}]},
+			{"role": "assistant", "content": [{"type": "output_text", "text": "Hi there"}]},
+			{"role": "user", "content": "What is 2+2?"}
+		]
+	}`)
+	fields := parseRequestBody(body)
+	if fields.model != "gpt-4o" {
+		t.Errorf("model = %q, want gpt-4o", fields.model)
+	}
+	if !strings.Contains(fields.inputMessages, "You are a helpful assistant.") {
+		t.Errorf("should contain instructions as system message: %s", fields.inputMessages)
+	}
+	if !strings.Contains(fields.inputMessages, "Hello") {
+		t.Errorf("should contain flattened input_text: %s", fields.inputMessages)
+	}
+	if !strings.Contains(fields.inputMessages, "Hi there") {
+		t.Errorf("should contain flattened output_text: %s", fields.inputMessages)
+	}
+	if !strings.Contains(fields.inputMessages, "What is 2+2?") {
+		t.Errorf("should contain plain string content: %s", fields.inputMessages)
+	}
+}
+
+func TestParseRequestBody_ResponsesAPI_MultiTurnWithToolCalls(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-4o",
+		"input": [
+			{"role": "user", "content": "What is the weather in SF?"},
+			{"type": "function_call", "name": "get_weather", "arguments": "{\"city\":\"SF\"}", "call_id": "fc_1"},
+			{"type": "function_call_output", "call_id": "fc_1", "output": "72°F and sunny"},
+			{"role": "assistant", "content": "The weather in SF is 72°F and sunny."},
+			{"role": "user", "content": "Thanks!"}
+		]
+	}`)
+	fields := parseRequestBody(body)
+
+	if !strings.Contains(fields.inputMessages, "What is the weather in SF?") {
+		t.Errorf("should contain user message: %s", fields.inputMessages)
+	}
+	if !strings.Contains(fields.inputMessages, "get_weather") {
+		t.Errorf("should contain function_call as tool_calls: %s", fields.inputMessages)
+	}
+	if !strings.Contains(fields.inputMessages, `"role":"tool"`) {
+		t.Errorf("function_call_output should become role:tool message: %s", fields.inputMessages)
+	}
+	if !strings.Contains(fields.inputMessages, "72°F and sunny") {
+		t.Errorf("should contain tool output: %s", fields.inputMessages)
+	}
+	if !strings.Contains(fields.inputMessages, "Thanks!") {
+		t.Errorf("should contain final user message: %s", fields.inputMessages)
+	}
+}
+
+func TestNormalizeResponsesInput_WebSearchInInput(t *testing.T) {
+	items := []any{
+		map[string]any{
+			"type":   "web_search_call",
+			"id":     "ws_1",
+			"status": "completed",
+		},
+	}
+	result := normalizeResponsesInput(items)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result))
+	}
+	msg, ok := result[0].(map[string]any)
+	if !ok {
+		t.Fatal("expected map")
+	}
+	if msg["role"] != "assistant" {
+		t.Errorf("role = %v, want assistant", msg["role"])
+	}
+	tcs, ok := msg["tool_calls"].([]any)
+	if !ok || len(tcs) == 0 {
+		t.Errorf("expected tool_calls: %+v", msg)
+	}
+}
+
+func TestNormalizeResponsesInput_ItemReferenceSkipped(t *testing.T) {
+	items := []any{
+		map[string]any{
+			"type": "item_reference",
+			"id":   "ref_123",
+		},
+		map[string]any{
+			"role":    "user",
+			"content": "Hello",
+		},
+	}
+	result := normalizeResponsesInput(items)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item (item_reference skipped), got %d", len(result))
+	}
+	msg := result[0].(map[string]any)
+	if msg["content"] != "Hello" {
+		t.Errorf("content = %v, want Hello", msg["content"])
+	}
+}
+
+func TestNormalizeResponsesInput_ComputerCallOutput(t *testing.T) {
+	items := []any{
+		map[string]any{
+			"type":    "computer_call",
+			"call_id": "comp_1",
+			"action":  map[string]any{"type": "click", "x": float64(50), "y": float64(100)},
+		},
+		map[string]any{
+			"type":    "computer_call_output",
+			"call_id": "comp_1",
+			"output":  "screenshot captured",
+		},
+	}
+	result := normalizeResponsesInput(items)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(result))
+	}
+	call := result[0].(map[string]any)
+	if call["role"] != "assistant" {
+		t.Errorf("computer_call role = %v, want assistant", call["role"])
+	}
+	output := result[1].(map[string]any)
+	if output["role"] != "tool" {
+		t.Errorf("computer_call_output role = %v, want tool", output["role"])
+	}
+	if output["content"] != "screenshot captured" {
+		t.Errorf("content = %v, want 'screenshot captured'", output["content"])
+	}
+}
+
+func TestNormalizeResponsesInput_ReasoningItem(t *testing.T) {
+	items := []any{
+		map[string]any{
+			"type": "reasoning",
+			"id":   "rs_1",
+			"summary": []any{
+				map[string]any{"type": "summary_text", "text": "Let me think about this"},
+			},
+		},
+	}
+	result := normalizeResponsesInput(items)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result))
+	}
+	msg := result[0].(map[string]any)
+	if msg["role"] != "assistant" {
+		t.Errorf("role = %v, want assistant", msg["role"])
+	}
+	content, _ := msg["content"].(string)
+	if !strings.Contains(content, "Let me think about this") {
+		t.Errorf("content should contain reasoning summary: %s", content)
+	}
+}
+
+func TestNormalizeResponsesInput_ReasoningEmptySummarySkipped(t *testing.T) {
+	items := []any{
+		map[string]any{
+			"type":    "reasoning",
+			"id":      "rs_1",
+			"summary": []any{},
+		},
+		map[string]any{
+			"role":    "user",
+			"content": "Hello",
+		},
+	}
+	result := normalizeResponsesInput(items)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item (empty reasoning skipped), got %d", len(result))
+	}
+}
+
+func TestNormalizeResponsesInput_UnknownTypeGetsRole(t *testing.T) {
+	items := []any{
+		map[string]any{
+			"type": "some_future_type",
+			"id":   "x_1",
+		},
+	}
+	result := normalizeResponsesInput(items)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result))
+	}
+	msg := result[0].(map[string]any)
+	if msg["role"] != "assistant" {
+		t.Errorf("unknown type should get role=assistant, got %v", msg["role"])
+	}
+	content, _ := msg["content"].(string)
+	if !strings.Contains(content, "some_future_type") {
+		t.Errorf("content should contain the type name: %s", content)
+	}
+}


### PR DESCRIPTION
traceopenai.go for `/reponses` did not previously support tool call extraction or proper intermediate message extraction. This PR adds it.

### Testing

- Existing tests pass
- new unit tests for the new response format
- Manual tests in LangSmith

Before
<img width="548" height="447" alt="image" src="https://github.com/user-attachments/assets/d694cabe-6cda-41bf-b7fd-2fcda0faee43" />


After
<img width="535" height="700" alt="image" src="https://github.com/user-attachments/assets/40243c8f-ee1e-4c36-876c-60058d1e5932" />
