### PR TITLE
fix: type RunStats cost fields as float64, not string

### DIFF
--- a/run.go
+++ b/run.go
@@ -179,7 +179,7 @@ type RunSchema struct {
 	Status                 string                            `json:"status" api:"required"`
 	TraceID                string                            `json:"trace_id" api:"required" format:"uuid"`
 	ChildRunIDs            []string                          `json:"child_run_ids" api:"nullable" format:"uuid"`
-	CompletionCost         string                            `json:"completion_cost" api:"nullable"`
+	CompletionCost         float64                           `json:"completion_cost" api:"nullable"`
 	CompletionCostDetails  map[string]string                 `json:"completion_cost_details" api:"nullable"`
 	CompletionTokenDetails map[string]int64                  `json:"completion_token_details" api:"nullable"`
 	CompletionTokens       int64                             `json:"completion_tokens"`
@@ -205,7 +205,7 @@ type RunSchema struct {
 	ParentRunID            string                            `json:"parent_run_id" api:"nullable" format:"uuid"`
 	ParentRunIDs           []string                          `json:"parent_run_ids" api:"nullable" format:"uuid"`
 	PriceModelID           string                            `json:"price_model_id" api:"nullable" format:"uuid"`
-	PromptCost             string                            `json:"prompt_cost" api:"nullable"`
+	PromptCost             float64                           `json:"prompt_cost" api:"nullable"`
 	PromptCostDetails      map[string]string                 `json:"prompt_cost_details" api:"nullable"`
 	PromptTokenDetails     map[string]int64                  `json:"prompt_token_details" api:"nullable"`
 	PromptTokens           int64                             `json:"prompt_tokens"`
@@ -217,7 +217,7 @@ type RunSchema struct {
 	StartTime              time.Time                         `json:"start_time" format:"date-time"`
 	Tags                   []string                          `json:"tags" api:"nullable"`
 	ThreadID               string                            `json:"thread_id" api:"nullable"`
-	TotalCost              string                            `json:"total_cost" api:"nullable"`
+	TotalCost              float64                           `json:"total_cost" api:"nullable"`
 	TotalTokens            int64                             `json:"total_tokens"`
 	TraceFirstReceivedAt   time.Time                         `json:"trace_first_received_at" api:"nullable" format:"date-time"`
 	TraceMaxStartTime      time.Time                         `json:"trace_max_start_time" api:"nullable" format:"date-time"`
@@ -543,14 +543,14 @@ func init() {
 }
 
 type RunStatsResponseRunStats struct {
-	CompletionCost         string                       `json:"completion_cost" api:"nullable"`
+	CompletionCost         float64                      `json:"completion_cost" api:"nullable"`
 	CompletionCostDetails  map[string]interface{}       `json:"completion_cost_details" api:"nullable"`
 	CompletionTokenDetails map[string]interface{}       `json:"completion_token_details" api:"nullable"`
 	CompletionTokens       int64                        `json:"completion_tokens" api:"nullable"`
 	CompletionTokensP50    int64                        `json:"completion_tokens_p50" api:"nullable"`
 	CompletionTokensP99    int64                        `json:"completion_tokens_p99" api:"nullable"`
-	CostP50                string                       `json:"cost_p50" api:"nullable"`
-	CostP99                string                       `json:"cost_p99" api:"nullable"`
+	CostP50                float64                      `json:"cost_p50" api:"nullable"`
+	CostP99                float64                      `json:"cost_p99" api:"nullable"`
 	ErrorRate              float64                      `json:"error_rate" api:"nullable"`
 	FeedbackStats          map[string]interface{}       `json:"feedback_stats" api:"nullable"`
 	FirstTokenP50          float64                      `json:"first_token_p50" api:"nullable"`
@@ -559,7 +559,7 @@ type RunStatsResponseRunStats struct {
 	LatencyP50             float64                      `json:"latency_p50" api:"nullable"`
 	LatencyP99             float64                      `json:"latency_p99" api:"nullable"`
 	MedianTokens           int64                        `json:"median_tokens" api:"nullable"`
-	PromptCost             string                       `json:"prompt_cost" api:"nullable"`
+	PromptCost             float64                      `json:"prompt_cost" api:"nullable"`
 	PromptCostDetails      map[string]interface{}       `json:"prompt_cost_details" api:"nullable"`
 	PromptTokenDetails     map[string]interface{}       `json:"prompt_token_details" api:"nullable"`
 	PromptTokens           int64                        `json:"prompt_tokens" api:"nullable"`
@@ -569,7 +569,7 @@ type RunStatsResponseRunStats struct {
 	RunFacets              []map[string]interface{}     `json:"run_facets" api:"nullable"`
 	StreamingRate          float64                      `json:"streaming_rate" api:"nullable"`
 	TokensP99              int64                        `json:"tokens_p99" api:"nullable"`
-	TotalCost              string                       `json:"total_cost" api:"nullable"`
+	TotalCost              float64                      `json:"total_cost" api:"nullable"`
 	TotalTokens            int64                        `json:"total_tokens" api:"nullable"`
 	JSON                   runStatsResponseRunStatsJSON `json:"-"`
 }
@@ -624,14 +624,14 @@ type RunStatsResponseMap map[string]RunStatsResponseMapItem
 func (r RunStatsResponseMap) implementsRunStatsResponseUnion() {}
 
 type RunStatsResponseMapItem struct {
-	CompletionCost         string                      `json:"completion_cost" api:"nullable"`
+	CompletionCost         float64                     `json:"completion_cost" api:"nullable"`
 	CompletionCostDetails  map[string]interface{}      `json:"completion_cost_details" api:"nullable"`
 	CompletionTokenDetails map[string]interface{}      `json:"completion_token_details" api:"nullable"`
 	CompletionTokens       int64                       `json:"completion_tokens" api:"nullable"`
 	CompletionTokensP50    int64                       `json:"completion_tokens_p50" api:"nullable"`
 	CompletionTokensP99    int64                       `json:"completion_tokens_p99" api:"nullable"`
-	CostP50                string                      `json:"cost_p50" api:"nullable"`
-	CostP99                string                      `json:"cost_p99" api:"nullable"`
+	CostP50                float64                     `json:"cost_p50" api:"nullable"`
+	CostP99                float64                     `json:"cost_p99" api:"nullable"`
 	ErrorRate              float64                     `json:"error_rate" api:"nullable"`
 	FeedbackStats          map[string]interface{}      `json:"feedback_stats" api:"nullable"`
 	FirstTokenP50          float64                     `json:"first_token_p50" api:"nullable"`
@@ -640,7 +640,7 @@ type RunStatsResponseMapItem struct {
 	LatencyP50             float64                     `json:"latency_p50" api:"nullable"`
 	LatencyP99             float64                     `json:"latency_p99" api:"nullable"`
 	MedianTokens           int64                       `json:"median_tokens" api:"nullable"`
-	PromptCost             string                      `json:"prompt_cost" api:"nullable"`
+	PromptCost             float64                     `json:"prompt_cost" api:"nullable"`
 	PromptCostDetails      map[string]interface{}      `json:"prompt_cost_details" api:"nullable"`
 	PromptTokenDetails     map[string]interface{}      `json:"prompt_token_details" api:"nullable"`
 	PromptTokens           int64                       `json:"prompt_tokens" api:"nullable"`
@@ -650,7 +650,7 @@ type RunStatsResponseMapItem struct {
 	RunFacets              []map[string]interface{}    `json:"run_facets" api:"nullable"`
 	StreamingRate          float64                     `json:"streaming_rate" api:"nullable"`
 	TokensP99              int64                       `json:"tokens_p99" api:"nullable"`
-	TotalCost              string                      `json:"total_cost" api:"nullable"`
+	TotalCost              float64                     `json:"total_cost" api:"nullable"`
 	TotalTokens            int64                       `json:"total_tokens" api:"nullable"`
 	JSON                   runStatsResponseMapItemJSON `json:"-"`
 }


### PR DESCRIPTION
## Summary

Stainless mis-translates `anyOf: [{type: number}, {type: null}]` in the OpenAPI spec into Go `string`. The `/api/v1/runs/stats` response models `total_cost`, `prompt_cost`, `completion_cost`, `cost_p50`, `cost_p99` as nullable numbers in the spec, but the SDK ships them as `string`. The API returns them as JSON numbers (e.g. `8.2e-6`), so `apijson.UnionUnmarshaler` fails to decode `RunStatsResponseRunStats`, silently falls through to `RunStatsResponseMap`, and zeroes every field.

This patches 13 declarations across `RunSchema`, `RunStatsResponseRunStats`, and `RunStatsResponseMapItem` to `float64`, matching the existing nullable-numeric convention in the same file (`ErrorRate`, `LatencyP50`, `StreamingRate`).

## Why hand-patch instead of fixing the spec / Stainless config

The OpenAPI spec already correctly types these fields as `anyOf: [number, null]`. The bug is in Stainless's Go codegen handling of nullable-primitive `anyOf`. Per `CONTRIBUTING.md`, manual edits persist across regens (with possible merge conflicts), so a hand-patch here is the fastest path to unblock callers. The longer-term fix lives on the Stainless side.

## Verification

Built a small client against this branch and called `Runs.Stats` against dev for a project that has cost data:

Before (v0.10.0):
```
total_cost: 0
total_tokens: 0
run_count: 0      # every field zeroed — union fell through to Map
```

After (this patch):
```
total_cost: 0.00125
total_tokens: 326
run_count: 8
```

`go build ./...` and `go test .` both pass.

## Release Note

Fix `Runs.Stats` returning zero-valued fields by typing nullable cost fields as `float64` (matching the OpenAPI spec) instead of `string`.

## Test Plan

- [x] `go build ./...`
- [x] `go test .`
- [x] End-to-end decode against dev `/api/v1/runs/stats` returns real `total_cost` / `total_tokens` / `run_count`
- [x] CLI bump (`langsmith-cli/go.mod`) + revert the `RawPost` workaround in `internal/cmd/trace_stats.go` — follow-up PR after this is tagged
- [x] Same `string` bug pattern still affects `session.go`, `annotationqueue.go`, `datasetgroup.go`, etc. — follow-up to extend the same change once this lands