### PR TITLE
fix: trace Anthropic-compatible messages endpoints

### DIFF
--- a/instrumentation/traceanthropic/traceanthropic.go
+++ b/instrumentation/traceanthropic/traceanthropic.go
@@ -117,7 +117,7 @@ func newRoundTripper(base http.RoundTripper, tp trace.TracerProvider, runName st
 // RoundTrip intercepts requests/responses to add OpenTelemetry tracing.
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Only trace Anthropic API requests
-	if !strings.Contains(req.URL.Host, "api.anthropic.com") {
+	if !shouldTrace(req) {
 		return rt.base.RoundTrip(req)
 	}
 
@@ -256,9 +256,23 @@ func isFirstContent(chunk map[string]any) bool {
 	return t == "content_block_delta"
 }
 
+func shouldTrace(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	if strings.Contains(req.URL.Host, "api.anthropic.com") {
+		return true
+	}
+	return isAnthropicEndpoint(req.URL.Path)
+}
+
+func isAnthropicEndpoint(path string) bool {
+	return strings.Contains(path, "/v1/messages")
+}
+
 // getSpanName returns an appropriate span name based on the API endpoint.
 func getSpanName(path string) string {
-	if strings.Contains(path, "/v1/messages") {
+	if isAnthropicEndpoint(path) {
 		return "anthropic.messages"
 	}
 	return "anthropic.request"
@@ -266,7 +280,7 @@ func getSpanName(path string) string {
 
 // getOperationName returns the operation name for Gen AI semantic conventions.
 func getOperationName(path string) string {
-	if strings.Contains(path, "/v1/messages") {
+	if isAnthropicEndpoint(path) {
 		return "chat"
 	}
 	return "request"

--- a/instrumentation/traceanthropic/traceanthropic_test.go
+++ b/instrumentation/traceanthropic/traceanthropic_test.go
@@ -28,6 +28,23 @@ func (t *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}, nil
 }
 
+type captureTransport struct {
+	body []byte
+	reqs chan *http.Request
+}
+
+func (t *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.reqs != nil {
+		t.reqs <- req
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(t.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
 // hasEvent reports whether any exported span contains an event with the given name.
 func hasEvent(spans tracetest.SpanStubs, name string) bool {
 	for _, s := range spans {
@@ -64,6 +81,87 @@ func doStreamingMessages(t *testing.T, client *http.Client) {
 		t.Fatal(err)
 	}
 	resp.Body.Close()
+}
+
+func TestRoundTrip_AnthropicCompatibleMessagesHost(t *testing.T) {
+	respBody := `{"model":"accounts/fireworks/models/test","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":3,"output_tokens":1},"stop_reason":"end_turn"}`
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	seen := make(chan *http.Request, 1)
+	client := WrapClient(
+		&http.Client{Transport: &captureTransport{body: []byte(respBody), reqs: seen}},
+		WithTracerProvider(tp),
+	)
+
+	body := `{"model":"accounts/fireworks/models/test","messages":[{"role":"user","content":"hi"}],"max_tokens":16}`
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"https://api.fireworks.ai/inference/v1/messages",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	gotReq := <-seen
+	if gotReq.URL.Host != "api.fireworks.ai" {
+		t.Fatalf("upstream host = %q, want api.fireworks.ai", gotReq.URL.Host)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	if spans[0].Name != "anthropic.messages" {
+		t.Fatalf("span name = %q, want anthropic.messages", spans[0].Name)
+	}
+	var gotURL string
+	for _, attr := range spans[0].Attributes {
+		if string(attr.Key) == "http.url" {
+			gotURL = attr.Value.AsString()
+			break
+		}
+	}
+	if gotURL != "https://api.fireworks.ai/inference/v1/messages" {
+		t.Fatalf("http.url = %q, want Fireworks URL", gotURL)
+	}
+}
+
+func TestRoundTrip_UnrelatedHostAndPathNotTraced(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	client := WrapClient(
+		&http.Client{Transport: &fakeTransport{body: []byte(`{"ok":true}`)}},
+		WithTracerProvider(tp),
+	)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"https://example.com/v1/models",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if got := len(exporter.GetSpans()); got != 0 {
+		t.Fatalf("got %d spans, want 0", got)
+	}
 }
 
 func TestRoundTrip_StreamingEmitsNewTokenOnFirstContentDelta(t *testing.T) {


### PR DESCRIPTION
## Summary
Trace Anthropic-compatible `/v1/messages` endpoints even when they are served from non-Anthropic hosts, such as Fireworks.

Native `api.anthropic.com` traffic keeps the existing host-based behavior. Other hosts are traced only when the request path is Anthropic Messages-compatible, which matches how `traceopenai` supports OpenAI-compatible providers by endpoint shape.

## Test Plan
- [x] `go test ./instrumentation/traceanthropic -count=1`