### PR TITLE
feat(auth): add OAuth refresh file locking

### DIFF
--- a/config.go
+++ b/config.go
@@ -220,15 +220,55 @@ func (a *profileAuth) authHeader(ctx context.Context) (name string, value string
 		return "", "", ""
 	}
 	if shouldRefreshProfileToken(p) {
-		refreshCtx, cancel := context.WithTimeout(ctx, tokenRefreshTimeout)
-		defer cancel()
-		if token, err := refreshOAuthToken(refreshCtx, p.APIURL, p.OAuth.RefreshToken); err == nil {
-			applyTokenResponse(&p, token, time.Now())
-			a.state.cfg.Profiles[a.state.profileName] = p
-			_ = saveConfig(a.state.path, a.state.cfg)
-		}
+		p = a.refreshProfileToken(ctx, p)
 	}
 	return authHeaderFromProfile(p)
+}
+
+func (a *profileAuth) refreshProfileToken(ctx context.Context, p configProfile) configProfile {
+	refreshCtx, cancel := context.WithTimeout(ctx, tokenRefreshTimeout)
+	defer cancel()
+
+	lock, err := acquireOAuthRefreshLock(refreshCtx, a.state.path+".oauth.lock")
+	if err != nil {
+		return p
+	}
+	defer lock.Unlock()
+
+	cfg, fresh, err := loadProfileConfigFromPath(a.state.path, a.state.profileName)
+	if err == nil {
+		a.state.cfg = cfg
+		p = fresh
+		if !shouldRefreshProfileToken(p) {
+			return p
+		}
+	}
+
+	token, err := refreshOAuthToken(refreshCtx, p.APIURL, p.OAuth.RefreshToken)
+	if err != nil {
+		return p
+	}
+	applyTokenResponse(&p, token, time.Now())
+	a.state.cfg.Profiles[a.state.profileName] = p
+	_ = saveConfig(a.state.path, a.state.cfg)
+	return p
+}
+
+func loadProfileConfigFromPath(path, profileName string) (configFile, configProfile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return configFile{}, configProfile{}, err
+	}
+
+	var cfg configFile
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return configFile{}, configProfile{}, err
+	}
+	p, ok := cfg.Profiles[profileName]
+	if !ok {
+		return configFile{}, configProfile{}, fmt.Errorf("LangSmith profile not found: %s", profileName)
+	}
+	return cfg, p, nil
 }
 
 func currentAuthHeaderFromProfile(p configProfile) (name string, value string, token string) {

--- a/config_filelock_dir.go
+++ b/config_filelock_dir.go
@@ -1,0 +1,122 @@
+package langsmith
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	oauthRefreshLockPollInterval  = 10 * time.Millisecond
+	oauthRefreshLockStaleAfter    = 10 * time.Second
+	oauthRefreshLockTimestampFile = "created_at"
+)
+
+type oauthRefreshDirLock struct {
+	path  string
+	owner string
+}
+
+func acquireOAuthRefreshDirLock(ctx context.Context, lockDir string, now func() time.Time) (*oauthRefreshDirLock, error) {
+	owner := newOAuthRefreshDirLockOwner()
+	for {
+		if err := os.Mkdir(lockDir, 0700); err == nil {
+			if err := writeOAuthRefreshLockMetadata(lockDir, now(), owner); err != nil {
+				_ = os.RemoveAll(lockDir)
+				return nil, fmt.Errorf("write OAuth refresh lock metadata: %w", err)
+			}
+			return &oauthRefreshDirLock{path: lockDir, owner: owner}, nil
+		} else if !os.IsExist(err) {
+			return nil, fmt.Errorf("acquire OAuth refresh lock: %w", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		if removed, err := removeStaleOAuthRefreshDirLock(lockDir, now()); err != nil {
+			return nil, err
+		} else if removed {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(oauthRefreshLockPollInterval):
+		}
+	}
+}
+
+func (l *oauthRefreshDirLock) unlock() error {
+	if owner, ok := oauthRefreshDirLockOwner(l.path); !ok || owner != l.owner {
+		return nil
+	}
+	return os.RemoveAll(l.path)
+}
+
+func writeOAuthRefreshLockMetadata(lockDir string, now time.Time, owner string) error {
+	return os.WriteFile(
+		filepath.Join(lockDir, oauthRefreshLockTimestampFile),
+		[]byte(now.UTC().Format(time.RFC3339Nano)+"\n"+owner+"\n"),
+		0600,
+	)
+}
+
+func removeStaleOAuthRefreshDirLock(lockDir string, now time.Time) (bool, error) {
+	createdAt, ok := oauthRefreshDirLockCreatedAt(lockDir)
+	if !ok || now.Sub(createdAt) <= oauthRefreshLockStaleAfter {
+		return false, nil
+	}
+	if err := os.RemoveAll(lockDir); err != nil {
+		return false, fmt.Errorf("remove stale OAuth refresh lock: %w", err)
+	}
+	return true, nil
+}
+
+func oauthRefreshDirLockCreatedAt(lockDir string) (time.Time, bool) {
+	lines, ok := oauthRefreshDirLockMetadata(lockDir)
+	if ok && len(lines) > 0 {
+		createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(lines[0]))
+		if err == nil {
+			return createdAt, true
+		}
+	}
+	info, err := os.Stat(lockDir)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return info.ModTime(), true
+}
+
+func oauthRefreshDirLockOwner(lockDir string) (string, bool) {
+	lines, ok := oauthRefreshDirLockMetadata(lockDir)
+	if !ok || len(lines) < 2 {
+		return "", false
+	}
+	owner := strings.TrimSpace(lines[1])
+	return owner, owner != ""
+}
+
+func oauthRefreshDirLockMetadata(lockDir string) ([]string, bool) {
+	data, err := os.ReadFile(filepath.Join(lockDir, oauthRefreshLockTimestampFile))
+	if err != nil {
+		return nil, false
+	}
+	return strings.Split(strings.TrimRight(string(data), "\n"), "\n"), true
+}
+
+func newOAuthRefreshDirLockOwner() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		return hex.EncodeToString(b[:])
+	}
+	return fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
+}

--- a/config_filelock_other.go
+++ b/config_filelock_other.go
@@ -1,0 +1,31 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd
+
+package langsmith
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type oauthRefreshLock struct {
+	dir *oauthRefreshDirLock
+}
+
+func acquireOAuthRefreshLock(ctx context.Context, path string) (*oauthRefreshLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("create OAuth refresh lock directory: %w", err)
+	}
+
+	lock, err := acquireOAuthRefreshDirLock(ctx, path+".lock", time.Now)
+	if err != nil {
+		return nil, err
+	}
+	return &oauthRefreshLock{dir: lock}, nil
+}
+
+func (l *oauthRefreshLock) Unlock() error {
+	return l.dir.unlock()
+}

--- a/config_filelock_unix.go
+++ b/config_filelock_unix.go
@@ -1,0 +1,54 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package langsmith
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+type oauthRefreshLock struct {
+	file *os.File
+}
+
+func acquireOAuthRefreshLock(ctx context.Context, path string) (*oauthRefreshLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("create OAuth refresh lock directory: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open OAuth refresh lock file: %w", err)
+	}
+
+	for {
+		err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return &oauthRefreshLock{file: file}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			_ = file.Close()
+			return nil, fmt.Errorf("acquire OAuth refresh lock: %w", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			_ = file.Close()
+			return nil, ctx.Err()
+		case <-time.After(oauthRefreshLockPollInterval):
+		}
+	}
+}
+
+func (l *oauthRefreshLock) Unlock() error {
+	err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	closeErr := l.file.Close()
+	if err != nil {
+		return fmt.Errorf("release OAuth refresh lock: %w", err)
+	}
+	return closeErr
+}

--- a/config_test.go
+++ b/config_test.go
@@ -3,11 +3,14 @@ package langsmith
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -337,6 +340,207 @@ func TestLoadProfileOptions_RefreshesExpiredAccessToken(t *testing.T) {
 	}
 	if strings.Contains(string(data), `token_type`) || strings.Contains(string(data), `bearer_token`) {
 		t.Fatalf("expected no token_type or bearer_token fields, got:\n%s", data)
+	}
+}
+
+func TestLoadProfileOptions_RefreshesExpiredAccessTokenOnceAcrossAuthStates(t *testing.T) {
+	clearAuthEnv(t)
+	var tokenRequests atomic.Int32
+	var apiRequests atomic.Int32
+	firstTokenStarted := make(chan struct{})
+	releaseTokenRefresh := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			if tokenRequests.Add(1) == 1 {
+				close(firstTokenStarted)
+				<-releaseTokenRefresh
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
+				t.Fatalf("expected old refresh token, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+				AccessToken:  "new-access-token",
+				ExpiresIn:    300,
+				RefreshToken: "new-refresh-token",
+			})
+		case "/info":
+			apiRequests.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer new-access-token" {
+				t.Errorf("expected refreshed bearer token on API request, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_url": "` + ts.URL + `",
+      "oauth": {
+        "access_token": "old-access-token",
+        "refresh_token": "old-refresh-token",
+        "expires_at": "` + time.Now().Add(-time.Minute).UTC().Format(time.RFC3339) + `"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	optsA := loadProfileOptions()
+	optsB := loadProfileOptions()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	request := func(opts []option.RequestOption) {
+		defer wg.Done()
+		var out map[string]string
+		if err := requestconfig.ExecuteNewRequest(context.Background(), http.MethodGet, "/info", nil, &out, opts...); err != nil {
+			t.Error(err)
+		}
+	}
+	go request(optsA)
+
+	select {
+	case <-firstTokenStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first token request did not start")
+	}
+
+	go request(optsB)
+	time.Sleep(25 * time.Millisecond)
+	if got := tokenRequests.Load(); got != 1 {
+		t.Fatalf("expected second auth state to wait on lock, token requests = %d", got)
+	}
+
+	close(releaseTokenRefresh)
+	wg.Wait()
+
+	if got := tokenRequests.Load(); got != 1 {
+		t.Fatalf("expected one token request, got %d", got)
+	}
+	if got := apiRequests.Load(); got != 2 {
+		t.Fatalf("expected two API requests, got %d", got)
+	}
+}
+
+func TestAcquireOAuthRefreshDirLockBreaksExpiredTimestampLock(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	lockDir := filepath.Join(t.TempDir(), "config.json.oauth.lock.lock")
+	if err := os.Mkdir(lockDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(lockDir, oauthRefreshLockTimestampFile),
+		[]byte(now.Add(-oauthRefreshLockStaleAfter-time.Second).Format(time.RFC3339Nano)+"\n"),
+		0600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	lock, err := acquireOAuthRefreshDirLock(context.Background(), lockDir, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.unlock()
+
+	createdAt, ok := oauthRefreshDirLockCreatedAt(lockDir)
+	if !ok {
+		t.Fatal("expected refreshed lock timestamp")
+	}
+	if !createdAt.Equal(now) {
+		t.Fatalf("expected refreshed lock timestamp %s, got %s", now, createdAt)
+	}
+}
+
+func TestAcquireOAuthRefreshDirLockBreaksExpiredLockWithoutTimestamp(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	lockDir := filepath.Join(t.TempDir(), "config.json.oauth.lock.lock")
+	if err := os.Mkdir(lockDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	staleAt := now.Add(-oauthRefreshLockStaleAfter - time.Second)
+	if err := os.Chtimes(lockDir, staleAt, staleAt); err != nil {
+		t.Fatal(err)
+	}
+
+	lock, err := acquireOAuthRefreshDirLock(context.Background(), lockDir, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.unlock()
+
+	if _, err := os.Stat(filepath.Join(lockDir, oauthRefreshLockTimestampFile)); err != nil {
+		t.Fatalf("expected timestamp file after taking stale lock: %v", err)
+	}
+}
+
+func TestOAuthRefreshDirLockUnlockDoesNotRemoveNewOwner(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	lockDir := filepath.Join(t.TempDir(), "config.json.oauth.lock.lock")
+	if err := os.Mkdir(lockDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeOAuthRefreshLockMetadata(
+		lockDir,
+		now.Add(-oauthRefreshLockStaleAfter-time.Second),
+		"stale-owner",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	lock, err := acquireOAuthRefreshDirLock(context.Background(), lockDir, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.unlock()
+
+	staleLock := &oauthRefreshDirLock{path: lockDir, owner: "stale-owner"}
+	if err := staleLock.unlock(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(lockDir); err != nil {
+		t.Fatalf("expected stale owner unlock to leave new lock in place: %v", err)
+	}
+}
+
+func TestAcquireOAuthRefreshDirLockWaitsForFreshLock(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	lockDir := filepath.Join(t.TempDir(), "config.json.oauth.lock.lock")
+	if err := os.Mkdir(lockDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(lockDir, oauthRefreshLockTimestampFile),
+		[]byte(now.Add(-oauthRefreshLockStaleAfter+time.Second).Format(time.RFC3339Nano)+"\n"),
+		0600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err := acquireOAuthRefreshDirLock(ctx, lockDir, func() time.Time { return now })
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline while fresh lock exists, got %v", err)
+	}
+	if _, err := os.Stat(lockDir); err != nil {
+		t.Fatalf("expected fresh lock directory to remain: %v", err)
 	}
 }
 


### PR DESCRIPTION
Adds a filesystem-backed lock around profile OAuth refresh so parallel CLI/SDK processes using the same LangSmith config do not refresh the same expired profile token concurrently. After acquiring the lock, the SDK re-reads the profile config so a waiting process can use the token refreshed by the first process.

Test Plan:
- go test ./...