### PR TITLE
feat(auth): add OAuth user ID header from JWT

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	authpkg "github.com/langchain-ai/langsmith-go/internal/auth"
 	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
 	"github.com/langchain-ai/langsmith-go/option"
 )
@@ -172,10 +173,12 @@ func WithProfile(profileName string) option.RequestOption {
 func withProfileAuth(auth *profileAuth) option.RequestOption {
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		name, value, token := auth.currentAuthHeader()
-		if token != "" {
+		useProfileAuth := name != "" && (r.APIKey == "" || auth.override)
+		if useProfileAuth && token != "" {
 			r.OAuthAccessToken = token
+			authpkg.SetUserIDHeaderFromAccessToken(r.Request.Header, token)
 		}
-		if name != "" && (r.APIKey == "" || auth.override) {
+		if useProfileAuth {
 			if auth.override && !strings.EqualFold(name, "X-API-Key") {
 				r.APIKey = ""
 				r.Request.Header.Del("X-API-Key")
@@ -185,17 +188,22 @@ func withProfileAuth(auth *profileAuth) option.RequestOption {
 		return r.Apply(option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 			if req.Header.Get("X-API-Key") != "" && !auth.override {
 				req.Header.Del("Authorization")
+				req.Header.Del("X-User-Id")
 				return next(req)
 			}
-			name, value, _ := auth.authHeader(req.Context())
+			name, value, token := auth.authHeader(req.Context())
 			if name != "" {
 				if auth.override && !strings.EqualFold(name, "X-API-Key") {
 					req.Header.Del("X-API-Key")
 				}
 				if strings.EqualFold(name, "X-API-Key") {
 					req.Header.Del("Authorization")
+					req.Header.Del("X-User-Id")
 				}
 				req.Header.Set(name, value)
+				if token != "" {
+					authpkg.SetUserIDHeaderFromAccessToken(req.Header, token)
+				}
 			}
 			return next(req)
 		}))

--- a/config_test.go
+++ b/config_test.go
@@ -2,8 +2,10 @@ package langsmith
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,6 +19,13 @@ import (
 	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
 	"github.com/langchain-ai/langsmith-go/option"
 )
+
+func jwtWithSubject(t *testing.T, sub string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"sub":%q}`, sub)))
+	return header + "." + payload + "."
+}
 
 func TestLoadProfileOptions_NoFile(t *testing.T) {
 	t.Setenv("LANGSMITH_CONFIG_FILE", "/nonexistent/path/config.json")
@@ -216,6 +225,7 @@ func TestDefaultClientOptions_WorkspaceIDEnvAlias(t *testing.T) {
 
 func TestLoadProfileOptions_OAuthAccessToken(t *testing.T) {
 	clearAuthEnv(t)
+	accessToken := jwtWithSubject(t, "user-123")
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
 	content := `{
@@ -223,7 +233,7 @@ func TestLoadProfileOptions_OAuthAccessToken(t *testing.T) {
     "default": {
       "api_url": "https://api.smith.langchain.com",
       "oauth": {
-        "access_token": "test-access-token"
+        "access_token": "` + accessToken + `"
       }
     }
   }
@@ -237,11 +247,81 @@ func TestLoadProfileOptions_OAuthAccessToken(t *testing.T) {
 
 	opts := loadProfileOptions()
 	cfg := applyOptions(t, opts)
-	if cfg.OAuthAccessToken != "test-access-token" {
+	if cfg.OAuthAccessToken != accessToken {
 		t.Fatalf("expected profile access token to become OAuth access token, got %q", cfg.OAuthAccessToken)
 	}
-	if got := cfg.Request.Header.Get("authorization"); got != "Bearer test-access-token" {
+	if got := cfg.Request.Header.Get("authorization"); got != "Bearer "+accessToken {
 		t.Fatalf("expected Authorization bearer header, got %q", got)
+	}
+	if got := cfg.Request.Header.Get("X-User-Id"); got != "user-123" {
+		t.Fatalf("expected X-User-Id from access token subject, got %q", got)
+	}
+}
+
+func TestLoadProfileOptions_APIKeyOverrideDropsOAuthUserID(t *testing.T) {
+	clearAuthEnv(t)
+	accessToken := jwtWithSubject(t, "profile-user")
+	var gotAuth string
+	var gotAPIKey string
+	var gotUserID string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("X-API-Key")
+		gotUserID = r.Header.Get("X-User-Id")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "profiles": {
+    "default": {
+      "api_url": "` + ts.URL + `",
+      "oauth": {
+        "access_token": "` + accessToken + `"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	opts := append(loadProfileOptions(), option.WithAPIKey("override-api-key"))
+	cfg := applyOptions(t, opts)
+	if cfg.OAuthAccessToken != "" {
+		t.Fatalf("expected API key override to clear OAuth access token, got %q", cfg.OAuthAccessToken)
+	}
+	if got := cfg.Request.Header.Get("X-User-Id"); got != "" {
+		t.Fatalf("expected API key override to clear initial X-User-Id, got %q", got)
+	}
+
+	preProfileOpts := append([]option.RequestOption{option.WithAPIKey("override-api-key")}, loadProfileOptions()...)
+	cfg = applyOptions(t, preProfileOpts)
+	if cfg.OAuthAccessToken != "" {
+		t.Fatalf("expected pre-existing API key to suppress OAuth access token, got %q", cfg.OAuthAccessToken)
+	}
+	if got := cfg.Request.Header.Get("X-User-Id"); got != "" {
+		t.Fatalf("expected pre-existing API key to suppress X-User-Id, got %q", got)
+	}
+
+	var out map[string]string
+	if err := requestconfig.ExecuteNewRequest(context.Background(), http.MethodGet, "/info", nil, &out, opts...); err != nil {
+		t.Fatal(err)
+	}
+	if gotAPIKey != "override-api-key" {
+		t.Fatalf("expected API key override, got %q", gotAPIKey)
+	}
+	if gotAuth != "" {
+		t.Fatalf("expected OAuth Authorization to be removed, got %q", gotAuth)
+	}
+	if gotUserID != "" {
+		t.Fatalf("expected OAuth X-User-Id to be removed, got %q", gotUserID)
 	}
 }
 

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// SetUserIDHeaderFromAccessToken sets X-User-Id from the access token's JWT
+// subject when present.
+func SetUserIDHeaderFromAccessToken(header http.Header, accessToken string) {
+	if userID := UserIDFromAccessToken(accessToken); userID != "" {
+		header.Set("X-User-Id", userID)
+	}
+}
+
+// UserIDFromAccessToken extracts the subject from a JWT access token.
+func UserIDFromAccessToken(accessToken string) string {
+	parts := strings.Split(accessToken, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return ""
+		}
+	}
+
+	var claims struct {
+		Subject string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	return claims.Subject
+}

--- a/lib/langsmithtracing/internal/models/write_endpoint.go
+++ b/lib/langsmithtracing/internal/models/write_endpoint.go
@@ -1,6 +1,10 @@
 package models
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/langchain-ai/langsmith-go/internal/auth"
+)
 
 // WriteEndpoint identifies a LangSmith API endpoint to send traces to.
 type WriteEndpoint struct {
@@ -15,6 +19,7 @@ type WriteEndpoint struct {
 func (ep WriteEndpoint) SetAuthHeader(req *http.Request) {
 	if ep.OAuthAccessToken != "" {
 		req.Header.Set("Authorization", "Bearer "+ep.OAuthAccessToken)
+		auth.SetUserIDHeaderFromAccessToken(req.Header, ep.OAuthAccessToken)
 	} else if ep.Key != "" {
 		req.Header.Set("X-API-Key", ep.Key)
 	}

--- a/lib/langsmithtracing/internal/models/write_endpoint_test.go
+++ b/lib/langsmithtracing/internal/models/write_endpoint_test.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func jwtWithSubject(t *testing.T, sub string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"sub":%q}`, sub)))
+	return header + "." + payload + "."
+}
+
+func TestWriteEndpointSetAuthHeaderAddsUserIDFromOAuthJWTSubject(t *testing.T) {
+	accessToken := jwtWithSubject(t, "user-123")
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/runs/multipart", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	WriteEndpoint{OAuthAccessToken: accessToken}.SetAuthHeader(req)
+
+	if got, want := req.Header.Get("Authorization"), "Bearer "+accessToken; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+	if got, want := req.Header.Get("X-User-Id"), "user-123"; got != want {
+		t.Fatalf("X-User-Id = %q, want %q", got, want)
+	}
+}

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -270,6 +270,9 @@ func WithEnvironmentProduction() RequestOption {
 func WithAPIKey(value string) RequestOption {
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		r.APIKey = value
+		r.OAuthAccessToken = ""
+		r.Request.Header.Del("Authorization")
+		r.Request.Header.Del("X-User-Id")
 		return r.Apply(WithHeader("X-API-Key", r.APIKey))
 	})
 }


### PR DESCRIPTION
Adds X-User-Id for OAuth-authenticated requests by extracting the JWT subject from profile OAuth access tokens. This is stacked on top of the OAuth refresh file-locking PR.

Test Plan:
- go test ./...