### PR TITLE
fix(tests): increase polling timeouts for batch ingestion eventual consistency

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-e1b8e0f48fa29a7c4513dfa177b2d51d1b2c330eb37d608e1508a850aa4373dc.yml
-openapi_spec_hash: fe644bd1887ffcf64957b22d1ad462a0
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-8b883a7b98c5c9ceb3204410f3daa0570010fc73da412e95497816a0eee71532.yml
+openapi_spec_hash: a31ecb25d57099103c89ba5dcf567871
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6768450a0c672d1deba4f3a3e422e5f03259d682d3a40273ad0625a15241efe7.yml
-openapi_spec_hash: f91f6ada9a16f765963d97cecc5a7a22
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c98646927adc5f7a96372b55e2ce59b11bf0e1d963103f80c50ea154bb84f743.yml
+openapi_spec_hash: 7064b40d24d901e8a51e514dd8d96268
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1a51d75678be010c25e6b19aeb1111192e037dbffb89acba68de6b8e710cf1ff.yml
-openapi_spec_hash: e0a55e44fc7f13ca6c1c1b50aaac7899
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7852ae3cf12a3c0c698eb8967c2993eaed3618d0863de2b9a4e0429cce4bdb82.yml
+openapi_spec_hash: a930f2dda180d0274b5e92aed08e4d83
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-b4dcc4f32847ee82a5b385457b5b9654c6a36b229092e3cbe6c9a66c3b8adb02.yml
-openapi_spec_hash: b40c32c133214255116f57106dba80b7
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4728e5b8ca194594a4b26b53f6135f76f0ff5641c65d833677f9cdd6c75bc55f.yml
+openapi_spec_hash: 0aa0bd88ab864038e0351f0e997736f3
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-023111b4ebfa250a976b130826220f059db4b1f923924ca169869cb59ace0d94.yml
-openapi_spec_hash: f8cdc8b3cf32add8ed7daae86497de40
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-e1b8e0f48fa29a7c4513dfa177b2d51d1b2c330eb37d608e1508a850aa4373dc.yml
+openapi_spec_hash: fe644bd1887ffcf64957b22d1ad462a0
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7a756a1c2fd48175370f6bc2c8548e6da3c37361e7239178794d0e6181e24be7.yml
-openapi_spec_hash: 60240e65d2cb3bbc3fb3c8ad12067d4c
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-88eea907a61aa74892e69ad36d47f4304ca86878739ac652d489b55e48f471a5.yml
+openapi_spec_hash: 32664dc2b09f6ed2ee6c79fa21f3251c
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1702dcd7e84d10745028318b285ae7bb09d018d5796355cf90d5fad738676ee7.yml
-openapi_spec_hash: d3bd22b7f298a7b831338677d4fa2318
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3e6732558d55eb96e74aca8777c3e2aa761936a118f8ea7dcdb684caedd33628.yml
+openapi_spec_hash: 2ecd1eb1bc05bdab366c40c38d4a0e7b
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-a0a424fa68ec2b65667c7fab415e736cc5272513e9006aa9872ac360feb76076.yml
-openapi_spec_hash: 39c4e79a33d28e8017130799a4dc424d
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0921cffc7cab3b357fdf6bc143145a407b982e6a9aafa43d98be1f6baaf45644.yml
+openapi_spec_hash: 642dc08239a9d911ce5c3e246ebdca73
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-748363830bdbaccd75902dfee935b36225bf143f93d8a2bae1ea160768d4d2fe.yml
-openapi_spec_hash: 5f016e82b8a83bdf96a58a6d815dc7a7
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-19cd4410085cee2ca09353b4bb19edec9ba6c1c62944a033f23f68df79feca91.yml
+openapi_spec_hash: febf534f84e06ac7de7db30c5cee09f3
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-14d113dd341883ecf2080f975efa6ad7bb4de5e476344eb840446bb55b5822a7.yml
-openapi_spec_hash: bacf441f41658aacd8f837ca5a48ce8c
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-56fd5d890d9479ac0eaf4a721b791aed7e9f254d095f5cdc5d4d840c4b36b37d.yml
+openapi_spec_hash: 3f75743ef3ea0567a895d73d4a515345
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-65a80aebeba078924e315bc5684a73028018fa08b0666986d22783ee8556dcd3.yml
-openapi_spec_hash: 4e15867e32b140b71511563cb783c8ef
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-fb0e430aecc866e29a5834b761a6721f8e49b5478e2cd71be49dd4413a7c6ae1.yml
+openapi_spec_hash: 66823c9088a76ea847511da2a8db49bc
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4c2cf942fd5c739470c4eb3b4573b80cbe37fc8afcc45203f8cad031b0c271f6.yml
-openapi_spec_hash: 9e6ad07ca5efb4798c8ed48fb64d982e
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7e018e03985f76c64cfb6e139081fe3d08365d4ca732803e5827cbac6aaab29e.yml
+openapi_spec_hash: 149fde72b5303787cbb2ea5167ed82bb
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-9045eb6fb9c4f166942c6e58ecebd1bac03e8dc8fcc7af78420f4c18b16cf181.yml
-openapi_spec_hash: 92d803205e57a2c71a8ae60a6c5a2cb1
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-b4dcc4f32847ee82a5b385457b5b9654c6a36b229092e3cbe6c9a66c3b8adb02.yml
+openapi_spec_hash: b40c32c133214255116f57106dba80b7
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-a597ce93ced5c4f138e409ae4fa08e0c039474e045cab84e8110c323258bfd51.yml
-openapi_spec_hash: 91fccea9cd82009b3ba5553aa456dd3b
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-d888a9f739b6ca3f71cf2bf56f7409376cee905ab05fc15af8eb97903f94d214.yml
+openapi_spec_hash: d27d9655a5e642de8b108a2e51956ace
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-05e721b4204c144a014a95817f664294f8e42346014f631584e32b24c9b40578.yml
-openapi_spec_hash: 138deb9efc35cdaf86bcd32937d21657
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ab11ae5f450c608b9dae681c24bf567e413d148c24b6ab3f3af836dcccf1c67e.yml
+openapi_spec_hash: 6c38b527013c2dbfb172910153c0f0f1
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-b831feb9daf75a47ded188ef52bb7a856737a354210c30a8906554ec33105478.yml
-openapi_spec_hash: 017b54b9c0f411fdc64f6b7596bced3b
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-5f492de4898786d03bdd5313a2b9429bb9e3972e7cf3836445a16e285f739772.yml
+openapi_spec_hash: 670cf10bccfa3db3f8e55c3a86c4291e
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-19042cfd06c7e5074b9b6a741027753895f59011fe4be1b0867e3822f9a50c0e.yml
-openapi_spec_hash: f8185dcc07130f7c0c6f1727f3d0ef03
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-daf5298fef35dcfd38c7fedd8712eb7710e8a158601fd12a637ab91c2e272a25.yml
+openapi_spec_hash: 663c9ecbc2e260603a513c24d8416392
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6e429e77984d2aca7d0737b46330ce5c31677b6078eed28cbae47d7eb4a8467a.yml
-openapi_spec_hash: b686b06858cacc62d6308acd1c97b7b5
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4bbb698ca8a6a2bc229b3d1c501d5a5503de588853271a67c3ca60152312c616.yml
+openapi_spec_hash: 28421dc3ee5d4dd77e7b9c32e9b55830
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-e2e9e7e75688dda63ec52cd8a21346cf9e955a1a2230cdade0315555e4b653a6.yml
-openapi_spec_hash: 0d9695e1d9ef24d8e1696c4de6ad07b3
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3d655ecd425bab26542d2013000122194725d411f77afc1285e0255eac114ef1.yml
+openapi_spec_hash: f2b3eddfe7b4550ad8fb287e7f8798da
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-439a24c5ab01f459bd2673b7ddb38d1785df9e20c774d37296ba9d14e3a08dcd.yml
-openapi_spec_hash: 44a30c650cda8bbc6ee09158b0720360
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-a87fac30cf19f5a440fc79842f3aef2235ad04edce6d04ccae1d27f7bebad1c1.yml
+openapi_spec_hash: 81e292a57ce2c401d2b494f62dac7004
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-80a6d6a6597f1599660caee5df7c48b05decbb715737b8ead476588b7090d73a.yml
-openapi_spec_hash: 96d713343ef1ffd7601c54a00594d355
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-a597ce93ced5c4f138e409ae4fa08e0c039474e045cab84e8110c323258bfd51.yml
+openapi_spec_hash: 91fccea9cd82009b3ba5553aa456dd3b
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-01869b4ca4ee628fec6b11ce24d552052120963d96b6b7e15bae3c56f6b05d17.yml
-openapi_spec_hash: 449172245dafd6684f98c751e51cbc3f
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-e45060c4b328b3fa0283de8f5af5fc711f62b14304dd6d270da361475effdfbb.yml
+openapi_spec_hash: b340f549c89fb6a0b4e35ff8f20ce3d9
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-8b883a7b98c5c9ceb3204410f3daa0570010fc73da412e95497816a0eee71532.yml
-openapi_spec_hash: a31ecb25d57099103c89ba5dcf567871
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4d6ee636ea3016faab3da774256314ec6db6f160f43fc9a9aeabe9af644d9910.yml
+openapi_spec_hash: 26cbc6fcf9be77dbdfe024153cbc71c4
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-5a0d075f70faa5cf79cab03cccc02b9d10986abf857bf7860a7af11e140b3ec5.yml
-openapi_spec_hash: fb1d5351686c9b13aa8418b10f0ee6be
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-14d113dd341883ecf2080f975efa6ad7bb4de5e476344eb840446bb55b5822a7.yml
+openapi_spec_hash: bacf441f41658aacd8f837ca5a48ce8c
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-e45060c4b328b3fa0283de8f5af5fc711f62b14304dd6d270da361475effdfbb.yml
-openapi_spec_hash: b340f549c89fb6a0b4e35ff8f20ce3d9
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-9045eb6fb9c4f166942c6e58ecebd1bac03e8dc8fcc7af78420f4c18b16cf181.yml
+openapi_spec_hash: 92d803205e57a2c71a8ae60a6c5a2cb1
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3d655ecd425bab26542d2013000122194725d411f77afc1285e0255eac114ef1.yml
-openapi_spec_hash: f2b3eddfe7b4550ad8fb287e7f8798da
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6f1b8dd382ec587316ad97f3d8bff73cbff90ba1969cb2ca891743e971a9e529.yml
+openapi_spec_hash: 87c570fc5ad1b19c2c67ec6c808f2746
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c1026b5d9fa31d319d31374863a1431f5e44990ac9396b2f134e777c81e37472.yml
-openapi_spec_hash: aecb991881c9ebd3dc0dfb0accbfb991
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-a0a424fa68ec2b65667c7fab415e736cc5272513e9006aa9872ac360feb76076.yml
+openapi_spec_hash: 39c4e79a33d28e8017130799a4dc424d
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-672cea497c5f78b468cb6d2d7d9e0f163ec81ac57c9046f575b08f7b73890888.yml
-openapi_spec_hash: 47cb29378a90b2c9a33f2b254d8e1c04
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-95aab14e07ca9d2be74b6daacb562e3bbea0f757a760e6fb150f99d3c81f011e.yml
+openapi_spec_hash: f11dfb3541edc42b305c512dced4be1d
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-2189189cad0f2b88b2d1f57ef2497442c59cba27358d804c585030557b949b77.yml
-openapi_spec_hash: 5e7e01bc52a1b198c0e5211518b56cce
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6768450a0c672d1deba4f3a3e422e5f03259d682d3a40273ad0625a15241efe7.yml
+openapi_spec_hash: f91f6ada9a16f765963d97cecc5a7a22
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4d6ee636ea3016faab3da774256314ec6db6f160f43fc9a9aeabe9af644d9910.yml
-openapi_spec_hash: 26cbc6fcf9be77dbdfe024153cbc71c4
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-01869b4ca4ee628fec6b11ce24d552052120963d96b6b7e15bae3c56f6b05d17.yml
+openapi_spec_hash: 449172245dafd6684f98c751e51cbc3f
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ec431406a6fbd9ad450a01da1d3e8963d5f36fbeb2fbab6a2978e51e2eaaacbb.yml
-openapi_spec_hash: 1ab2133a90ae17538586dec689cb222d
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-439a24c5ab01f459bd2673b7ddb38d1785df9e20c774d37296ba9d14e3a08dcd.yml
+openapi_spec_hash: 44a30c650cda8bbc6ee09158b0720360
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-d888a9f739b6ca3f71cf2bf56f7409376cee905ab05fc15af8eb97903f94d214.yml
-openapi_spec_hash: d27d9655a5e642de8b108a2e51956ace
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-d52051f1a4058a46d4b15e133768ee78ec7985177fca7763d7ee7f78b6e05ca9.yml
+openapi_spec_hash: 99bad6f50815f4dd34a70690f0e37b43
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-35dafa5fd0c479611997863ce0ae99a3ba262426b488726eb518c15d0aa0d58e.yml
-openapi_spec_hash: af2286ec00290bbee986f6429dc5ea03
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-65a80aebeba078924e315bc5684a73028018fa08b0666986d22783ee8556dcd3.yml
+openapi_spec_hash: 4e15867e32b140b71511563cb783c8ef
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c1553b7b032f16e4a0ba823c97549afbae085d6de60c1c25b1cfc925ef111ddb.yml
-openapi_spec_hash: 031e2951d4c716d2215e80de94e24eeb
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6e429e77984d2aca7d0737b46330ce5c31677b6078eed28cbae47d7eb4a8467a.yml
+openapi_spec_hash: b686b06858cacc62d6308acd1c97b7b5
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7e018e03985f76c64cfb6e139081fe3d08365d4ca732803e5827cbac6aaab29e.yml
-openapi_spec_hash: 149fde72b5303787cbb2ea5167ed82bb
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-18af4e53aafd08c95b2504bf76cf440447a769f5d725cee9354acdb83eadf8c0.yml
+openapi_spec_hash: 6dce3f0f01a34c26cf7dc875b77713e9
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-01869b4ca4ee628fec6b11ce24d552052120963d96b6b7e15bae3c56f6b05d17.yml
-openapi_spec_hash: 449172245dafd6684f98c751e51cbc3f
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-05e721b4204c144a014a95817f664294f8e42346014f631584e32b24c9b40578.yml
+openapi_spec_hash: 138deb9efc35cdaf86bcd32937d21657
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7e018e03985f76c64cfb6e139081fe3d08365d4ca732803e5827cbac6aaab29e.yml
-openapi_spec_hash: 149fde72b5303787cbb2ea5167ed82bb
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-2f8985afb2371f1a3999e0aa94ee549787b4901d8dd008453a3d6f0aafe64abd.yml
+openapi_spec_hash: 2d054a29adac443b237c40e47de75337
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1eacd4ab9a8aedc25d4fa0f6c3372a53295a1c7ddc9239a0c86ca1dd3a7aec8a.yml
-openapi_spec_hash: 39615bcfcae2b21d41aeaf5871fcec19
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-b456ddf7470dc0035687cfe81d5c6080615b125a1e75fd50165369801cb2e6ea.yml
+openapi_spec_hash: 130f2cfe43ef7596da9c072e41926c53
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1eacd4ab9a8aedc25d4fa0f6c3372a53295a1c7ddc9239a0c86ca1dd3a7aec8a.yml
-openapi_spec_hash: 39615bcfcae2b21d41aeaf5871fcec19
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-11d5c35421a44bb84a1e2fde44502a2233b03c1d626fb0eb45462a2bf22f7c3b.yml
+openapi_spec_hash: 8a9571ddfced7d73e8acb508a2aed465
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ad617993692506ebc8f9dd9160d9fe3bbb18dfd625cf6e5daccf5923e69d4407.yml
-openapi_spec_hash: 73492f32ba2e76487dcb43c4b620bc34
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-b831feb9daf75a47ded188ef52bb7a856737a354210c30a8906554ec33105478.yml
+openapi_spec_hash: 017b54b9c0f411fdc64f6b7596bced3b
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-b07de5ee7ca9b6ed6858e9dbe09e664f8de54303d4b36fff924b07dc2d9a877a.yml
-openapi_spec_hash: 098213fc0773a3aa2dde9b808c9d9247
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0d29b2d6da0f459e9b8cd454947184139a0ba8d19c8e4dcff8c7d5be389d19e3.yml
+openapi_spec_hash: 42d787e316e8eee2f686264654f4fb0a
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6768450a0c672d1deba4f3a3e422e5f03259d682d3a40273ad0625a15241efe7.yml
-openapi_spec_hash: f91f6ada9a16f765963d97cecc5a7a22
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0d03df724502a4207c4c3682b2e9d34d200c8204ae20ca915a2b1d451a1205aa.yml
+openapi_spec_hash: 5935007978e5611a9a375b209f198a25
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1bf4ad94c45c143a1d1e55549717cc798e8522f5cc99179396b2ec0d8b92ece0.yml
-openapi_spec_hash: 6dd1b8bd3c1ef74adf7c1acb8e56090e
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6019d08210f2ac79fea45e2095aecf4e2517e44400d28231cb315ef2faadd6e5.yml
+openapi_spec_hash: f8185dcc07130f7c0c6f1727f3d0ef03
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7852ae3cf12a3c0c698eb8967c2993eaed3618d0863de2b9a4e0429cce4bdb82.yml
-openapi_spec_hash: a930f2dda180d0274b5e92aed08e4d83
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0ac320bba587f8b3e5eafe761d03ebb7f68076a3d20e0aa2c304957e065b6f9b.yml
+openapi_spec_hash: 6abaab16d71f94b6752613af945d93f0
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-910be6e8c511042be0bb73b30385c8649ef0ee56b092dbc2e154d63b9d6bd64f.yml
-openapi_spec_hash: ad9a2a8e7d66f98c0841f36b3644d71c
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-50ce259ca2fbefa8852cdeeff071ad46bef76ac4c95e5524c7a8ce947d664869.yml
+openapi_spec_hash: 38c5bf015468a6d79d29e63efb31e23c
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-9c6e073f2b59e960920201a0c67ca9bda26cda6ac585114f28bdca9e02fc61c3.yml
-openapi_spec_hash: 53411e150747790c4dc92257b5cbea8e
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1d1517db7f92499093a3babb4b3ab753bd6fde1e55feb56c750904673e850702.yml
+openapi_spec_hash: 84667ae8b6c323b3f1ba943c1d37222a
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-f66710df71dc7107370c30bf67d912757f1d55beeee1e9f1736fc462cd44989d.yml
-openapi_spec_hash: b00aedc75f29f330e5ce9f1bffb0e9ac
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-f141dbaa77327a7b9c924b4039a50818bf63e42eb46aa589d459290f147d9bc8.yml
+openapi_spec_hash: 3d43e4994b82acfc052ae89150b9b968
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7e018e03985f76c64cfb6e139081fe3d08365d4ca732803e5827cbac6aaab29e.yml
-openapi_spec_hash: 149fde72b5303787cbb2ea5167ed82bb
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-fb746de66c3f65c3126a3a76d34ec554fc37e06a3094e51771b6ddf009b13cb7.yml
+openapi_spec_hash: 44edb37d94de8f11101663b9fca3cd93
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-94830c05b85f1ca03820dc29ee1b150e542b20d1b0cc19ae4c9ba52016fa4176.yml
-openapi_spec_hash: 76841fc777220e581ffdcbf517d23901
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1bf4ad94c45c143a1d1e55549717cc798e8522f5cc99179396b2ec0d8b92ece0.yml
+openapi_spec_hash: 6dd1b8bd3c1ef74adf7c1acb8e56090e
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-fee05164d7d337f26b86923ff6fe817cbcafbf5e2968959397bc7708d4ee105f.yml
-openapi_spec_hash: 607c97050f2ecb56d07ecd69e15a7cd0
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-b07de5ee7ca9b6ed6858e9dbe09e664f8de54303d4b36fff924b07dc2d9a877a.yml
+openapi_spec_hash: 098213fc0773a3aa2dde9b808c9d9247
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-b456ddf7470dc0035687cfe81d5c6080615b125a1e75fd50165369801cb2e6ea.yml
-openapi_spec_hash: 130f2cfe43ef7596da9c072e41926c53
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1702dcd7e84d10745028318b285ae7bb09d018d5796355cf90d5fad738676ee7.yml
+openapi_spec_hash: d3bd22b7f298a7b831338677d4fa2318
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7c14670eb975d4e9b43c3da80d8212b93e6b037e0dc22eacb30a236ec64619c6.yml
-openapi_spec_hash: b4006db9d6d6958c1687068f075029f9
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c1553b7b032f16e4a0ba823c97549afbae085d6de60c1c25b1cfc925ef111ddb.yml
+openapi_spec_hash: 031e2951d4c716d2215e80de94e24eeb
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6f1b8dd382ec587316ad97f3d8bff73cbff90ba1969cb2ca891743e971a9e529.yml
-openapi_spec_hash: 87c570fc5ad1b19c2c67ec6c808f2746
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-19042cfd06c7e5074b9b6a741027753895f59011fe4be1b0867e3822f9a50c0e.yml
+openapi_spec_hash: f8185dcc07130f7c0c6f1727f3d0ef03
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c4b46af33aaf58b7432ea4297febf1e835daf7f958cadd895e7f38f1233e3ab2.yml
-openapi_spec_hash: 1717b458da30b808e09ca250d875c976
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1cc04cce5a158cb65f9d22f1cb610cb79593c857199ebe0166612bf56dc06631.yml
+openapi_spec_hash: f651101dd71c63513c379a2b61c04825
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1b8b09e61252092ce3ed09ad85d7251c2605ed50e8f08485a05723aa76817d72.yml
-openapi_spec_hash: 0e8b9e0248c572f42f9700a6eeffe8fe
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4cefc4c7d5a71f9a90db1336bb842bd032cc4674661bcffe4bbd2d4dfb4e5f15.yml
+openapi_spec_hash: 6824a0c86b0204639e59e0ecea0ea3d0
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-8ebf8e59703be0aba4bf1a7934313740b678263caea3d4fccfeeffbf8ad013af.yml
-openapi_spec_hash: b80225eb7d8b108fbf300bbbb1012278
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-d8390f9d15ae00f9acf5ff063c26e02711a96b08a8ae7bff998fb596703014f1.yml
+openapi_spec_hash: e14113a868616f2f2c57f0b7b8fbf950
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-a87fac30cf19f5a440fc79842f3aef2235ad04edce6d04ccae1d27f7bebad1c1.yml
-openapi_spec_hash: 81e292a57ce2c401d2b494f62dac7004
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1ad26668fe6b157af9a59ab142ba57adb8f3b5e897e80fcffaaa0fac703575ff.yml
+openapi_spec_hash: 1a30696b32999c9cd8af500330787229
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-18af4e53aafd08c95b2504bf76cf440447a769f5d725cee9354acdb83eadf8c0.yml
-openapi_spec_hash: 6dce3f0f01a34c26cf7dc875b77713e9
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3a4c7c7f5cce53747345212509233df3c1d078b9f9fccd37cd09cca1a6ce53e7.yml
+openapi_spec_hash: 904cbb18bc75f3cca9d885b72b4e31c7
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0d29b2d6da0f459e9b8cd454947184139a0ba8d19c8e4dcff8c7d5be389d19e3.yml
-openapi_spec_hash: 42d787e316e8eee2f686264654f4fb0a
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1ced25b11ecf34f71776279acf15421485d3c5896a252d233d76cacd64a98ebb.yml
+openapi_spec_hash: 27324e4c02bab4365fca76e0712313df
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c8206dc758f3cbf0126f2c5777ae964a362b2da50eada6b50adfc07e3cbe9476.yml
-openapi_spec_hash: 2363755ddf88ceacea3ef69779c59392
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6768450a0c672d1deba4f3a3e422e5f03259d682d3a40273ad0625a15241efe7.yml
+openapi_spec_hash: f91f6ada9a16f765963d97cecc5a7a22
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-9ff8c77a9d57aba66557ecdb36f3a133ff6a419e66871c104f5de9631c34eca7.yml
-openapi_spec_hash: b3c8b10f063ce9d520fa93aa9bef6485
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-5a0d075f70faa5cf79cab03cccc02b9d10986abf857bf7860a7af11e140b3ec5.yml
+openapi_spec_hash: fb1d5351686c9b13aa8418b10f0ee6be
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1cc04cce5a158cb65f9d22f1cb610cb79593c857199ebe0166612bf56dc06631.yml
-openapi_spec_hash: f651101dd71c63513c379a2b61c04825
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c97852bc65d9ccc78380951ed03a4fe1e7ea1f0fdb22629ae0cfc37005f958e7.yml
+openapi_spec_hash: d81ee96c5a2395d44063ac1ab1f20563
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-95aab14e07ca9d2be74b6daacb562e3bbea0f757a760e6fb150f99d3c81f011e.yml
-openapi_spec_hash: f11dfb3541edc42b305c512dced4be1d
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4c2cf942fd5c739470c4eb3b4573b80cbe37fc8afcc45203f8cad031b0c271f6.yml
+openapi_spec_hash: 9e6ad07ca5efb4798c8ed48fb64d982e
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-d8390f9d15ae00f9acf5ff063c26e02711a96b08a8ae7bff998fb596703014f1.yml
-openapi_spec_hash: e14113a868616f2f2c57f0b7b8fbf950
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-eac9f556093004338c52ff0c7f9c4cbe1ca1bc11688833ca3818b33443218b83.yml
+openapi_spec_hash: 5cd76055194674e1ac5a706c2c52df57
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1ced25b11ecf34f71776279acf15421485d3c5896a252d233d76cacd64a98ebb.yml
-openapi_spec_hash: 27324e4c02bab4365fca76e0712313df
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3655d4030ad906141890d89a8f39521711202804495f93bc9854fe2c31251387.yml
+openapi_spec_hash: 37b999e11cefde59ea3a07f6bd0a7e0c
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-e025de5aa32bdc3b84e6977fb8d6ea49e4d83f399fe339a46ab813a81ca61d8e.yml
-openapi_spec_hash: 663c9ecbc2e260603a513c24d8416392
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-94830c05b85f1ca03820dc29ee1b150e542b20d1b0cc19ae4c9ba52016fa4176.yml
+openapi_spec_hash: 76841fc777220e581ffdcbf517d23901
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-19cd4410085cee2ca09353b4bb19edec9ba6c1c62944a033f23f68df79feca91.yml
-openapi_spec_hash: febf534f84e06ac7de7db30c5cee09f3
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7a756a1c2fd48175370f6bc2c8548e6da3c37361e7239178794d0e6181e24be7.yml
+openapi_spec_hash: 60240e65d2cb3bbc3fb3c8ad12067d4c
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-d52051f1a4058a46d4b15e133768ee78ec7985177fca7763d7ee7f78b6e05ca9.yml
-openapi_spec_hash: 99bad6f50815f4dd34a70690f0e37b43
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-8ebf8e59703be0aba4bf1a7934313740b678263caea3d4fccfeeffbf8ad013af.yml
+openapi_spec_hash: b80225eb7d8b108fbf300bbbb1012278
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-38b8923a3de44bfb04ab7e3eb9bd7fe77859963461d43e4b7cf619392cd1993a.yml
-openapi_spec_hash: eb6b8d1117990bec2f8681a91f91646d
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7e018e03985f76c64cfb6e139081fe3d08365d4ca732803e5827cbac6aaab29e.yml
+openapi_spec_hash: 149fde72b5303787cbb2ea5167ed82bb
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0a4f67427d0540df9671acd7afb19e769dfcf7c71b19586575bbc10a4c000610.yml
-openapi_spec_hash: 0b10dca92dcc1e77b366b9eb4dc2f23f
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7c14670eb975d4e9b43c3da80d8212b93e6b037e0dc22eacb30a236ec64619c6.yml
+openapi_spec_hash: b4006db9d6d6958c1687068f075029f9
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ec725947bdcd8d575573c98e4c3a21edabc1de138d66374b3b906be8924e8acc.yml
-openapi_spec_hash: 5c44b2540975662bd5745e8747bc5691
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-fe4ad3e8cb0a40c1377621249119bf630c337af13f7bfa281da96c1ebc397604.yml
+openapi_spec_hash: 9123fbc6a1b29162b566e7075f43d026
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-11d5c35421a44bb84a1e2fde44502a2233b03c1d626fb0eb45462a2bf22f7c3b.yml
-openapi_spec_hash: 8a9571ddfced7d73e8acb508a2aed465
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1eacd4ab9a8aedc25d4fa0f6c3372a53295a1c7ddc9239a0c86ca1dd3a7aec8a.yml
+openapi_spec_hash: 39615bcfcae2b21d41aeaf5871fcec19
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-2f8985afb2371f1a3999e0aa94ee549787b4901d8dd008453a3d6f0aafe64abd.yml
-openapi_spec_hash: 2d054a29adac443b237c40e47de75337
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-023111b4ebfa250a976b130826220f059db4b1f923924ca169869cb59ace0d94.yml
+openapi_spec_hash: f8cdc8b3cf32add8ed7daae86497de40
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-f141dbaa77327a7b9c924b4039a50818bf63e42eb46aa589d459290f147d9bc8.yml
-openapi_spec_hash: 3d43e4994b82acfc052ae89150b9b968
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ec431406a6fbd9ad450a01da1d3e8963d5f36fbeb2fbab6a2978e51e2eaaacbb.yml
+openapi_spec_hash: 1ab2133a90ae17538586dec689cb222d
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6768450a0c672d1deba4f3a3e422e5f03259d682d3a40273ad0625a15241efe7.yml
-openapi_spec_hash: f91f6ada9a16f765963d97cecc5a7a22
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ad617993692506ebc8f9dd9160d9fe3bbb18dfd625cf6e5daccf5923e69d4407.yml
+openapi_spec_hash: 73492f32ba2e76487dcb43c4b620bc34
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0ac320bba587f8b3e5eafe761d03ebb7f68076a3d20e0aa2c304957e065b6f9b.yml
-openapi_spec_hash: 6abaab16d71f94b6752613af945d93f0
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4cce25f00124d3d9bd3e04c28a4805d7027a38c5fa4d830549f492c6cca39591.yml
+openapi_spec_hash: 04909fe16c146f4180ae1badfa670833
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-5f492de4898786d03bdd5313a2b9429bb9e3972e7cf3836445a16e285f739772.yml
-openapi_spec_hash: 670cf10bccfa3db3f8e55c3a86c4291e
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0a4f67427d0540df9671acd7afb19e769dfcf7c71b19586575bbc10a4c000610.yml
+openapi_spec_hash: 0b10dca92dcc1e77b366b9eb4dc2f23f
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-6019d08210f2ac79fea45e2095aecf4e2517e44400d28231cb315ef2faadd6e5.yml
-openapi_spec_hash: f8185dcc07130f7c0c6f1727f3d0ef03
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1a51d75678be010c25e6b19aeb1111192e037dbffb89acba68de6b8e710cf1ff.yml
+openapi_spec_hash: e0a55e44fc7f13ca6c1c1b50aaac7899
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0921cffc7cab3b357fdf6bc143145a407b982e6a9aafa43d98be1f6baaf45644.yml
-openapi_spec_hash: 642dc08239a9d911ce5c3e246ebdca73
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-dbbc149e8ca01d89ddfea0b6b5947547c76feac3f38d63254cbffe67adfe919e.yml
+openapi_spec_hash: 2093b62f882da354f44080bce45d9f8f
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c97852bc65d9ccc78380951ed03a4fe1e7ea1f0fdb22629ae0cfc37005f958e7.yml
-openapi_spec_hash: d81ee96c5a2395d44063ac1ab1f20563
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-db24d20fedb908050aee789dedaeb81afca220599e6f72b22eed13fb6b7a7ff8.yml
+openapi_spec_hash: d928a2766f4df548776435a68981cefe
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4bbb698ca8a6a2bc229b3d1c501d5a5503de588853271a67c3ca60152312c616.yml
-openapi_spec_hash: 28421dc3ee5d4dd77e7b9c32e9b55830
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-2189189cad0f2b88b2d1f57ef2497442c59cba27358d804c585030557b949b77.yml
+openapi_spec_hash: 5e7e01bc52a1b198c0e5211518b56cce
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ec431406a6fbd9ad450a01da1d3e8963d5f36fbeb2fbab6a2978e51e2eaaacbb.yml
-openapi_spec_hash: 1ab2133a90ae17538586dec689cb222d
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-2189189cad0f2b88b2d1f57ef2497442c59cba27358d804c585030557b949b77.yml
+openapi_spec_hash: 5e7e01bc52a1b198c0e5211518b56cce
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-db24d20fedb908050aee789dedaeb81afca220599e6f72b22eed13fb6b7a7ff8.yml
-openapi_spec_hash: d928a2766f4df548776435a68981cefe
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-80a6d6a6597f1599660caee5df7c48b05decbb715737b8ead476588b7090d73a.yml
+openapi_spec_hash: 96d713343ef1ffd7601c54a00594d355
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ab11ae5f450c608b9dae681c24bf567e413d148c24b6ab3f3af836dcccf1c67e.yml
-openapi_spec_hash: 6c38b527013c2dbfb172910153c0f0f1
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1b8b09e61252092ce3ed09ad85d7251c2605ed50e8f08485a05723aa76817d72.yml
+openapi_spec_hash: 0e8b9e0248c572f42f9700a6eeffe8fe
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-88eea907a61aa74892e69ad36d47f4304ca86878739ac652d489b55e48f471a5.yml
-openapi_spec_hash: 32664dc2b09f6ed2ee6c79fa21f3251c
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c8206dc758f3cbf0126f2c5777ae964a362b2da50eada6b50adfc07e3cbe9476.yml
+openapi_spec_hash: 2363755ddf88ceacea3ef69779c59392
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-961732792a5e0b0419422c938218734717f6753301b23363d1b065d398d7933b.yml
-openapi_spec_hash: 08cc0ed4875bfac5b252d555f53cb12b
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c1026b5d9fa31d319d31374863a1431f5e44990ac9396b2f134e777c81e37472.yml
+openapi_spec_hash: aecb991881c9ebd3dc0dfb0accbfb991
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1d1517db7f92499093a3babb4b3ab753bd6fde1e55feb56c750904673e850702.yml
-openapi_spec_hash: 84667ae8b6c323b3f1ba943c1d37222a
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-35dafa5fd0c479611997863ce0ae99a3ba262426b488726eb518c15d0aa0d58e.yml
+openapi_spec_hash: af2286ec00290bbee986f6429dc5ea03
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-56fd5d890d9479ac0eaf4a721b791aed7e9f254d095f5cdc5d4d840c4b36b37d.yml
-openapi_spec_hash: 3f75743ef3ea0567a895d73d4a515345
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-748363830bdbaccd75902dfee935b36225bf143f93d8a2bae1ea160768d4d2fe.yml
+openapi_spec_hash: 5f016e82b8a83bdf96a58a6d815dc7a7
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c98646927adc5f7a96372b55e2ce59b11bf0e1d963103f80c50ea154bb84f743.yml
-openapi_spec_hash: 7064b40d24d901e8a51e514dd8d96268
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3f4419399c293c635918f7dc0d80d7f067ee44e21d03fa8af3fa061b9c86cfd9.yml
+openapi_spec_hash: 5e60dc173b9a057001bc00a35659a7b4
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-0d03df724502a4207c4c3682b2e9d34d200c8204ae20ca915a2b1d451a1205aa.yml
-openapi_spec_hash: 5935007978e5611a9a375b209f198a25
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-9ff8c77a9d57aba66557ecdb36f3a133ff6a419e66871c104f5de9631c34eca7.yml
+openapi_spec_hash: b3c8b10f063ce9d520fa93aa9bef6485
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3655d4030ad906141890d89a8f39521711202804495f93bc9854fe2c31251387.yml
-openapi_spec_hash: 37b999e11cefde59ea3a07f6bd0a7e0c
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ec725947bdcd8d575573c98e4c3a21edabc1de138d66374b3b906be8924e8acc.yml
+openapi_spec_hash: 5c44b2540975662bd5745e8747bc5691
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-a87fac30cf19f5a440fc79842f3aef2235ad04edce6d04ccae1d27f7bebad1c1.yml
-openapi_spec_hash: 81e292a57ce2c401d2b494f62dac7004
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-672cea497c5f78b468cb6d2d7d9e0f163ec81ac57c9046f575b08f7b73890888.yml
+openapi_spec_hash: 47cb29378a90b2c9a33f2b254d8e1c04
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4cefc4c7d5a71f9a90db1336bb842bd032cc4674661bcffe4bbd2d4dfb4e5f15.yml
-openapi_spec_hash: 6824a0c86b0204639e59e0ecea0ea3d0
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-01869b4ca4ee628fec6b11ce24d552052120963d96b6b7e15bae3c56f6b05d17.yml
+openapi_spec_hash: 449172245dafd6684f98c751e51cbc3f
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-dbbc149e8ca01d89ddfea0b6b5947547c76feac3f38d63254cbffe67adfe919e.yml
-openapi_spec_hash: 2093b62f882da354f44080bce45d9f8f
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1eacd4ab9a8aedc25d4fa0f6c3372a53295a1c7ddc9239a0c86ca1dd3a7aec8a.yml
+openapi_spec_hash: 39615bcfcae2b21d41aeaf5871fcec19
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-fb746de66c3f65c3126a3a76d34ec554fc37e06a3094e51771b6ddf009b13cb7.yml
-openapi_spec_hash: 44edb37d94de8f11101663b9fca3cd93
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-38b8923a3de44bfb04ab7e3eb9bd7fe77859963461d43e4b7cf619392cd1993a.yml
+openapi_spec_hash: eb6b8d1117990bec2f8681a91f91646d
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c66dabee7521828af01474d2e6860fb1100e5ec0a08ae5606ac6dc99212a4fa0.yml
-openapi_spec_hash: a515268d476970879ebd50632417eb37
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-f66710df71dc7107370c30bf67d912757f1d55beeee1e9f1736fc462cd44989d.yml
+openapi_spec_hash: b00aedc75f29f330e5ce9f1bffb0e9ac
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-daf5298fef35dcfd38c7fedd8712eb7710e8a158601fd12a637ab91c2e272a25.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-e025de5aa32bdc3b84e6977fb8d6ea49e4d83f399fe339a46ab813a81ca61d8e.yml
 openapi_spec_hash: 663c9ecbc2e260603a513c24d8416392
-config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea
+config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3f4419399c293c635918f7dc0d80d7f067ee44e21d03fa8af3fa061b9c86cfd9.yml
-openapi_spec_hash: 5e60dc173b9a057001bc00a35659a7b4
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-ec431406a6fbd9ad450a01da1d3e8963d5f36fbeb2fbab6a2978e51e2eaaacbb.yml
+openapi_spec_hash: 1ab2133a90ae17538586dec689cb222d
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-50ce259ca2fbefa8852cdeeff071ad46bef76ac4c95e5524c7a8ce947d664869.yml
-openapi_spec_hash: 38c5bf015468a6d79d29e63efb31e23c
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-e2e9e7e75688dda63ec52cd8a21346cf9e955a1a2230cdade0315555e4b653a6.yml
+openapi_spec_hash: 0d9695e1d9ef24d8e1696c4de6ad07b3
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4cce25f00124d3d9bd3e04c28a4805d7027a38c5fa4d830549f492c6cca39591.yml
-openapi_spec_hash: 04909fe16c146f4180ae1badfa670833
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c66dabee7521828af01474d2e6860fb1100e5ec0a08ae5606ac6dc99212a4fa0.yml
+openapi_spec_hash: a515268d476970879ebd50632417eb37
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1ad26668fe6b157af9a59ab142ba57adb8f3b5e897e80fcffaaa0fac703575ff.yml
-openapi_spec_hash: 1a30696b32999c9cd8af500330787229
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-a87fac30cf19f5a440fc79842f3aef2235ad04edce6d04ccae1d27f7bebad1c1.yml
+openapi_spec_hash: 81e292a57ce2c401d2b494f62dac7004
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3e6732558d55eb96e74aca8777c3e2aa761936a118f8ea7dcdb684caedd33628.yml
-openapi_spec_hash: 2ecd1eb1bc05bdab366c40c38d4a0e7b
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-c4b46af33aaf58b7432ea4297febf1e835daf7f958cadd895e7f38f1233e3ab2.yml
+openapi_spec_hash: 1717b458da30b808e09ca250d875c976
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1b3b902137c683ecc971c6788925730e98efe3a4ea78b378db42edba7ed66c2f.yml
-openapi_spec_hash: 0a4c7683e58e1fe045c8328f98b2ebc6
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-910be6e8c511042be0bb73b30385c8649ef0ee56b092dbc2e154d63b9d6bd64f.yml
+openapi_spec_hash: ad9a2a8e7d66f98c0841f36b3644d71c
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-4728e5b8ca194594a4b26b53f6135f76f0ff5641c65d833677f9cdd6c75bc55f.yml
-openapi_spec_hash: 0aa0bd88ab864038e0351f0e997736f3
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-7e018e03985f76c64cfb6e139081fe3d08365d4ca732803e5827cbac6aaab29e.yml
+openapi_spec_hash: 149fde72b5303787cbb2ea5167ed82bb
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-fb0e430aecc866e29a5834b761a6721f8e49b5478e2cd71be49dd4413a7c6ae1.yml
-openapi_spec_hash: 66823c9088a76ea847511da2a8db49bc
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-1b3b902137c683ecc971c6788925730e98efe3a4ea78b378db42edba7ed66c2f.yml
+openapi_spec_hash: 0a4c7683e58e1fe045c8328f98b2ebc6
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-fe4ad3e8cb0a40c1377621249119bf630c337af13f7bfa281da96c1ebc397604.yml
-openapi_spec_hash: 9123fbc6a1b29162b566e7075f43d026
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-9c6e073f2b59e960920201a0c67ca9bda26cda6ac585114f28bdca9e02fc61c3.yml
+openapi_spec_hash: 53411e150747790c4dc92257b5cbea8e
 config_hash: 43f0f4cb84ef2a3e47ec4f1a2297f5ea

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 125
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-3a4c7c7f5cce53747345212509233df3c1d078b9f9fccd37cd09cca1a6ce53e7.yml
-openapi_spec_hash: 904cbb18bc75f3cca9d885b72b4e31c7
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/langsmith/langsmith-api-961732792a5e0b0419422c938218734717f6753301b23363d1b065d398d7933b.yml
+openapi_spec_hash: 08cc0ed4875bfac5b252d555f53cb12b
 config_hash: ae3cb858ab7acded1d7ada7b913179d4

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -215,10 +215,10 @@ func TestRunIngestAndQuery(t *testing.T) {
 		t.Fatalf("ingest batch: %v", err)
 	}
 
-	// Query with retries (runs may take a moment to be queryable), then assert round-trip like Python read_run
+	// Query with retries (batch ingestion has eventual consistency; allow up to 75s)
 	var run *langsmith.RunSchema
-	for i := 0; i < 10; i++ {
-		time.Sleep(2 * time.Second)
+	for i := 0; i < 25; i++ {
+		time.Sleep(3 * time.Second)
 		result, err := client.Runs.Query(ctx, langsmith.RunQueryParams{
 			ID: langsmith.F([]string{runID}),
 		})
@@ -442,10 +442,10 @@ func TestRunBatchIngestRoundTrip(t *testing.T) {
 		t.Fatalf("batch ingest: %v", err)
 	}
 
-	// Query by run IDs (shared project has many runs; we only need our three)
+	// Query by run IDs (batch ingestion has eventual consistency; allow up to 75s)
 	var runs []langsmith.RunSchema
-	for i := 0; i < 10; i++ {
-		time.Sleep(2 * time.Second)
+	for i := 0; i < 25; i++ {
+		time.Sleep(3 * time.Second)
 		result, err := client.Runs.Query(ctx, langsmith.RunQueryParams{
 			ID: langsmith.F([]string{run1ID, run2ID, run3ID}),
 		})
@@ -662,8 +662,16 @@ func TestFeedbackCRUD(t *testing.T) {
 		t.Fatalf("ingest run for feedback: %v", err)
 	}
 
-	// Wait for run to be available
-	time.Sleep(3 * time.Second)
+	// Poll for run to be visible before creating feedback (batch ingestion has eventual consistency)
+	for i := 0; i < 25; i++ {
+		time.Sleep(3 * time.Second)
+		result, err := client.Runs.Query(ctx, langsmith.RunQueryParams{
+			ID: langsmith.F([]string{runID}),
+		})
+		if err == nil && len(result.Runs) > 0 {
+			break
+		}
+	}
 
 	// Create feedback
 	fb, err := client.Feedback.New(ctx, langsmith.FeedbackNewParams{
@@ -680,10 +688,20 @@ func TestFeedbackCRUD(t *testing.T) {
 		t.Fatal("expected non-empty feedback ID")
 	}
 
-	// Get feedback and verify both key and score
-	got, err := client.Feedback.Get(ctx, fb.ID, langsmith.FeedbackGetParams{})
-	if err != nil {
-		t.Fatalf("get feedback: %v", err)
+	// Get feedback and verify both key and score - retry briefly for eventual consistency
+	var got *langsmith.FeedbackSchema
+	for i := 0; i < 5; i++ {
+		if i > 0 {
+			time.Sleep(2 * time.Second)
+		}
+		result, getFeedbackErr := client.Feedback.Get(ctx, fb.ID, langsmith.FeedbackGetParams{})
+		if getFeedbackErr == nil {
+			got = result
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("get feedback: not found after retrying")
 	}
 	if got.Key != "correctness" {
 		t.Errorf("feedback key = %q, want 'correctness'", got.Key)

--- a/sandboxbox.go
+++ b/sandboxbox.go
@@ -1795,6 +1795,10 @@ type SandboxBoxNewSnapshotParams struct {
 	Name param.Field[string] `json:"name" api:"required"`
 	// if omitted, creates a fresh checkpoint from the running VM
 	Checkpoint param.Field[string] `json:"checkpoint"`
+	// sandbox-local Docker image to export
+	DockerImage param.Field[string] `json:"docker_image"`
+	// required for Docker image export unless the sandbox has a capacity
+	FsCapacityBytes param.Field[int64] `json:"fs_capacity_bytes"`
 	// IncludeMemory, when true, captures a full VM memory snapshot alongside the
 	// filesystem clone. Only honored when the sandbox is running AND Checkpoint is
 	// omitted (i.e. a fresh in-VM checkpoint is requested). Defaults to false to keep

--- a/sandboxbox_test.go
+++ b/sandboxbox_test.go
@@ -260,9 +260,11 @@ func TestSandboxBoxNewSnapshotWithOptionalParams(t *testing.T) {
 		context.TODO(),
 		"name",
 		langsmith.SandboxBoxNewSnapshotParams{
-			Name:          langsmith.F("name"),
-			Checkpoint:    langsmith.F("checkpoint"),
-			IncludeMemory: langsmith.F(true),
+			Name:            langsmith.F("name"),
+			Checkpoint:      langsmith.F("checkpoint"),
+			DockerImage:     langsmith.F("docker_image"),
+			FsCapacityBytes: langsmith.F(int64(0)),
+			IncludeMemory:   langsmith.F(true),
 		},
 	)
 	if err != nil {

--- a/scripts/test
+++ b/scripts/test
@@ -14,7 +14,7 @@ if [ -n "$GITHUB_ACTIONS" ]; then
   echo "==> Building library and examples"
   go build ./...
   echo "==> Running tests (unit + integration)"
-  go test -tags=integration ./... -count=1 -timeout 300s -v "$@"
+  go test -tags=integration ./... -count=1 -timeout 600s -v "$@"
   exit 0
 fi
 

--- a/workspace.go
+++ b/workspace.go
@@ -215,7 +215,8 @@ func (r WorkspaceUpdateParams) MarshalJSON() (data []byte, err error) {
 }
 
 type WorkspaceListParams struct {
-	IncludeDeleted param.Field[bool] `query:"include_deleted"`
+	DataPlaneID    param.Field[string] `query:"data_plane_id" format:"uuid"`
+	IncludeDeleted param.Field[bool]   `query:"include_deleted"`
 }
 
 // URLQuery serializes [WorkspaceListParams]'s query parameters as `url.Values`.

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -86,6 +86,7 @@ func TestWorkspaceListWithOptionalParams(t *testing.T) {
 		option.WithTenantID("My Tenant ID"),
 	)
 	_, err := client.Workspaces.List(context.TODO(), langsmith.WorkspaceListParams{
+		DataPlaneID:    langsmith.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),
 		IncludeDeleted: langsmith.F(true),
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- **`TestRunIngestAndQuery`** and **`TestRunBatchIngestRoundTrip`**: were polling only 10×2s = 20s before failing, but batch ingestion (`POST /runs/batch`) takes ~30–35s to become queryable. Increased to 25×3s = 75s to match the already-passing `TestRunCreateAndUpdate`.
- **`TestFeedbackCRUD`**: replaced a fixed 3s sleep (too short for run visibility) with a proper polling loop that waits for the run to be available before creating feedback. Also added a short retry on `Feedback.Get` to handle eventual consistency.
- **`scripts/test`**: increased go test timeout from 300s to 600s — the integration suite previously fit within 300s only because the three affected tests failed early; with proper polling they need the extra headroom.

## Root cause

The three failing tests all depend on runs ingested via `POST /runs/batch` being immediately queryable via `POST /api/v1/runs/query`. The API has eventual consistency (~30–35s lag) for batch-ingested runs, which the tests did not account for.

## Test plan

- [ ] CI passes on this branch: all three previously-failing tests (`TestRunIngestAndQuery`, `TestRunBatchIngestRoundTrip`, `TestFeedbackCRUD`) should now pass

Fixes CI failure on [release PR #101](https://github.com/langchain-ai/langsmith-go/pull/101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)