### PR TITLE
feat(runsv2): add client for POST /v2/runs/query

### DIFF
--- a/lib/runsv2/runsv2.go
+++ b/lib/runsv2/runsv2.go
@@ -1,0 +1,254 @@
+// Package runsv2 provides a hand-written client for the LangSmith v2 runs
+// query endpoint (POST /v2/runs/query), which is backed by SmithDB.
+//
+// This sits alongside the generated SDK because the v2 endpoint is not yet
+// part of the OpenAPI spec that drives Stainless code generation. The package
+// follows the same convention as lib/langsmithtracing: a self-contained
+// subpackage outside the regenerated surface.
+package runsv2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// SortOrder is the start_time sort direction returned in a query result.
+type SortOrder string
+
+const (
+	SortOrderAsc  SortOrder = "ASC"
+	SortOrderDesc SortOrder = "DESC"
+)
+
+// SelectField identifies a run property that can be requested in QueryRequest.Selects.
+// Values mirror smith-go/runs/v2/query/types.go RunSelectField.
+type SelectField string
+
+const (
+	SelectID                     SelectField = "ID"
+	SelectName                   SelectField = "NAME"
+	SelectRunType                SelectField = "RUN_TYPE"
+	SelectStatus                 SelectField = "STATUS"
+	SelectStartTime              SelectField = "START_TIME"
+	SelectEndTime                SelectField = "END_TIME"
+	SelectLatencySeconds         SelectField = "LATENCY_SECONDS"
+	SelectFirstTokenTime         SelectField = "FIRST_TOKEN_TIME"
+	SelectError                  SelectField = "ERROR"
+	SelectErrorPreview           SelectField = "ERROR_PREVIEW"
+	SelectExtra                  SelectField = "EXTRA"
+	SelectMetadata               SelectField = "METADATA"
+	SelectEvents                 SelectField = "EVENTS"
+	SelectInputs                 SelectField = "INPUTS"
+	SelectInputsPreview          SelectField = "INPUTS_PREVIEW"
+	SelectOutputs                SelectField = "OUTPUTS"
+	SelectOutputsPreview         SelectField = "OUTPUTS_PREVIEW"
+	SelectManifest               SelectField = "MANIFEST"
+	SelectParentRunIDs           SelectField = "PARENT_RUN_IDS"
+	SelectProjectID              SelectField = "PROJECT_ID"
+	SelectTraceID                SelectField = "TRACE_ID"
+	SelectThreadID               SelectField = "THREAD_ID"
+	SelectDottedOrder            SelectField = "DOTTED_ORDER"
+	SelectTags                   SelectField = "TAGS"
+	SelectReferenceExampleID     SelectField = "REFERENCE_EXAMPLE_ID"
+	SelectReferenceDatasetID     SelectField = "REFERENCE_DATASET_ID"
+	SelectAppPath                SelectField = "APP_PATH"
+	SelectIsRoot                 SelectField = "IS_ROOT"
+	SelectTotalTokens            SelectField = "TOTAL_TOKENS"
+	SelectPromptTokens           SelectField = "PROMPT_TOKENS"
+	SelectCompletionTokens       SelectField = "COMPLETION_TOKENS"
+	SelectPromptTokenDetails     SelectField = "PROMPT_TOKEN_DETAILS"
+	SelectCompletionTokenDetails SelectField = "COMPLETION_TOKEN_DETAILS"
+	SelectTotalCost              SelectField = "TOTAL_COST"
+	SelectPromptCost             SelectField = "PROMPT_COST"
+	SelectCompletionCost         SelectField = "COMPLETION_COST"
+	SelectPromptCostDetails      SelectField = "PROMPT_COST_DETAILS"
+	SelectCompletionCostDetails  SelectField = "COMPLETION_COST_DETAILS"
+	SelectAttachments            SelectField = "ATTACHMENTS"
+	SelectIsInDataset            SelectField = "IS_IN_DATASET"
+	SelectShareURL               SelectField = "SHARE_URL"
+	SelectFeedbackStats          SelectField = "FEEDBACK_STATS"
+	SelectPriceModelID           SelectField = "PRICE_MODEL_ID"
+)
+
+// QueryRequest is the JSON body for POST /v2/runs/query.
+// Field names and semantics mirror smith-go/runs/v2/query/types.go QueryRunsRequestBody.
+type QueryRequest struct {
+	IDs               []string      `json:"ids,omitempty"`
+	TraceID           *string       `json:"trace_id,omitempty"`
+	RunType           *string       `json:"run_type,omitempty"`
+	ProjectIDs        []string      `json:"project_ids,omitempty"`
+	ReferenceExamples []string      `json:"reference_examples,omitempty"`
+	MinStartTime      *string       `json:"min_start_time,omitempty"`
+	MaxStartTime      *string       `json:"max_start_time,omitempty"`
+	HasError          *bool         `json:"has_error,omitempty"`
+	AIQuery           *string       `json:"ai_query,omitempty"`
+	Filter            *string       `json:"filter,omitempty"`
+	TraceFilter       *string       `json:"trace_filter,omitempty"`
+	TreeFilter        *string       `json:"tree_filter,omitempty"`
+	IsRoot            *bool         `json:"is_root,omitempty"`
+	Cursor            *string       `json:"cursor,omitempty"`
+	PageSize          *uint64       `json:"page_size,omitempty"`
+	Selects           []SelectField `json:"selects,omitempty"`
+	SortOrder         *SortOrder    `json:"sort_order,omitempty"`
+}
+
+// QueryResponse is the response body for POST /v2/runs/query.
+type QueryResponse struct {
+	Items      []Run   `json:"items"`
+	NextCursor *string `json:"next_cursor,omitempty"`
+	HasMore    bool    `json:"has_more"`
+}
+
+// Run is one entry in QueryResponse.Items. Fields are pointers so unset values
+// (those not requested via Selects, or null in the response) can be distinguished
+// from zero values. JSON-typed fields (inputs, outputs, extra, metadata, manifest)
+// are returned as raw bytes so callers can decode them on demand.
+type Run struct {
+	ID                 *string         `json:"id,omitempty"`
+	TraceID            *string         `json:"trace_id,omitempty"`
+	Name               *string         `json:"name,omitempty"`
+	RunType            *string         `json:"run_type,omitempty"`
+	StartTime          *string         `json:"start_time,omitempty"`
+	EndTime            *string         `json:"end_time,omitempty"`
+	Status             *string         `json:"status,omitempty"`
+	ParentRunIDs       []string        `json:"parent_run_ids,omitempty"`
+	ProjectID          *string         `json:"project_id,omitempty"`
+	ReferenceExampleID *string         `json:"reference_example_id,omitempty"`
+	ReferenceDatasetID *string         `json:"reference_dataset_id,omitempty"`
+	DottedOrder        *string         `json:"dotted_order,omitempty"`
+	Tags               []string        `json:"tags,omitempty"`
+	ThreadID           *string         `json:"thread_id,omitempty"`
+	AppPath            *string         `json:"app_path,omitempty"`
+	IsRoot             *bool           `json:"is_root,omitempty"`
+	TotalTokens        *int64          `json:"total_tokens,omitempty"`
+	PromptTokens       *int64          `json:"prompt_tokens,omitempty"`
+	CompletionTokens   *int64          `json:"completion_tokens,omitempty"`
+	TotalCost          *float64        `json:"total_cost,omitempty"`
+	PromptCost         *float64        `json:"prompt_cost,omitempty"`
+	CompletionCost     *float64        `json:"completion_cost,omitempty"`
+	FirstTokenTime     *string         `json:"first_token_time,omitempty"`
+	LatencySeconds     *float64        `json:"latency_seconds,omitempty"`
+	Inputs             json.RawMessage `json:"inputs,omitempty"`
+	Outputs            json.RawMessage `json:"outputs,omitempty"`
+	InputsPreview      *string         `json:"inputs_preview,omitempty"`
+	OutputsPreview     *string         `json:"outputs_preview,omitempty"`
+	Error              *string         `json:"error,omitempty"`
+	ErrorPreview       *string         `json:"error_preview,omitempty"`
+	Extra              json.RawMessage `json:"extra,omitempty"`
+	Metadata           json.RawMessage `json:"metadata,omitempty"`
+	Manifest           json.RawMessage `json:"manifest,omitempty"`
+	Attachments        json.RawMessage `json:"attachments,omitempty"`
+	IsInDataset        *bool           `json:"is_in_dataset,omitempty"`
+	ShareURL           *string         `json:"share_url,omitempty"`
+	FeedbackStats      json.RawMessage `json:"feedback_stats,omitempty"`
+	PriceModelID       *string         `json:"price_model_id,omitempty"`
+}
+
+// HTTPError is returned by Client.Query when the server responds with a non-2xx
+// status. Callers can type-assert on this to drive fallback behaviour (e.g. retry
+// against the v1 endpoint when v2 returns 4xx).
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("runsv2: HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("runsv2: HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// Client calls the v2 runs query endpoint.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithHTTPClient overrides the default http.Client.
+func WithHTTPClient(c *http.Client) Option {
+	return func(cl *Client) {
+		if c != nil {
+			cl.httpClient = c
+		}
+	}
+}
+
+// NewClient builds a Client for the given LangSmith endpoint and API key.
+// baseURL may include a trailing "/api/v1" suffix (common for self-hosted
+// LANGSMITH_ENDPOINT values); the suffix is stripped so the v2 path is
+// appended cleanly. apiKey is sent as X-API-Key on every request and is
+// never logged by this package.
+func NewClient(baseURL, apiKey string, opts ...Option) *Client {
+	c := &Client{
+		baseURL:    normalizeBaseURL(baseURL),
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: 60 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func normalizeBaseURL(raw string) string {
+	u := strings.TrimRight(raw, "/")
+	u = strings.TrimSuffix(u, "/api/v1")
+	return strings.TrimRight(u, "/")
+}
+
+// Query posts the request to /v2/runs/query and decodes the response.
+// A non-2xx status is returned as *HTTPError.
+func (c *Client) Query(ctx context.Context, body QueryRequest) (*QueryResponse, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("runsv2: marshal request: %w", err)
+	}
+	endpoint, err := url.JoinPath(c.baseURL, "v2", "runs", "query")
+	if err != nil {
+		return nil, fmt.Errorf("runsv2: build url: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("runsv2: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("runsv2: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("runsv2: read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &HTTPError{StatusCode: resp.StatusCode, Body: string(respBytes)}
+	}
+
+	var out QueryResponse
+	if err := json.Unmarshal(respBytes, &out); err != nil {
+		return nil, fmt.Errorf("runsv2: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// Ptr is a small helper for constructing pointer fields on QueryRequest.
+func Ptr[T any](v T) *T { return &v }

--- a/lib/runsv2/runsv2_test.go
+++ b/lib/runsv2/runsv2_test.go
@@ -1,0 +1,142 @@
+package runsv2_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/langchain-ai/langsmith-go/lib/runsv2"
+)
+
+func TestQuery_BuildsRequestAndDecodesResponse(t *testing.T) {
+	var (
+		gotMethod   string
+		gotPath     string
+		gotAPIKey   string
+		gotBody     map[string]any
+		nextCursor  = "next-cursor-abc"
+		hasMore     = true
+		respPayload = map[string]any{
+			"items": []map[string]any{
+				{
+					"id":        "018e4c7e-a9fb-7ef0-a5b6-6ea3a82e9327",
+					"name":      "ChatOpenAI",
+					"run_type":  "llm",
+					"status":    "SUCCESS",
+					"is_root":   true,
+					"trace_id":  "018e4c7e-a9fb-7ef0-a5b6-6ea3a82e9327",
+					"project_id": "0190a1b2-c3d4-7ef0-a5b6-6ea3a82e9328",
+				},
+			},
+			"next_cursor": nextCursor,
+			"has_more":    hasMore,
+		}
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("X-API-Key")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(respPayload)
+	}))
+	defer srv.Close()
+
+	c := runsv2.NewClient(srv.URL, "secret-key")
+	projectID := "0190a1b2-c3d4-7ef0-a5b6-6ea3a82e9328"
+	minStart := "2024-01-01T00:00:00Z"
+
+	resp, err := c.Query(context.Background(), runsv2.QueryRequest{
+		ProjectIDs:   []string{projectID},
+		MinStartTime: &minStart,
+		IsRoot:       runsv2.Ptr(true),
+		PageSize:     runsv2.Ptr(uint64(50)),
+		Selects:      []runsv2.SelectField{runsv2.SelectID, runsv2.SelectName, runsv2.SelectRunType},
+	})
+	if err != nil {
+		t.Fatalf("Query returned error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v2/runs/query" {
+		t.Errorf("path = %q, want /v2/runs/query", gotPath)
+	}
+	if gotAPIKey != "secret-key" {
+		t.Errorf("X-API-Key = %q, want secret-key", gotAPIKey)
+	}
+	if ids, _ := gotBody["project_ids"].([]any); len(ids) != 1 || ids[0] != projectID {
+		t.Errorf("project_ids = %v, want [%q]", gotBody["project_ids"], projectID)
+	}
+	if gotBody["min_start_time"] != minStart {
+		t.Errorf("min_start_time = %v, want %q", gotBody["min_start_time"], minStart)
+	}
+	if gotBody["is_root"] != true {
+		t.Errorf("is_root = %v, want true", gotBody["is_root"])
+	}
+	if _, ok := gotBody["sort_order"]; ok {
+		t.Errorf("sort_order should be omitted when nil")
+	}
+
+	if len(resp.Items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(resp.Items))
+	}
+	if resp.Items[0].Name == nil || *resp.Items[0].Name != "ChatOpenAI" {
+		t.Errorf("items[0].Name = %v, want ChatOpenAI", resp.Items[0].Name)
+	}
+	if resp.NextCursor == nil || *resp.NextCursor != nextCursor {
+		t.Errorf("NextCursor = %v, want %q", resp.NextCursor, nextCursor)
+	}
+	if !resp.HasMore {
+		t.Errorf("HasMore = false, want true")
+	}
+}
+
+func TestQuery_StripsTrailingAPIV1FromBaseURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"items":[],"has_more":false}`))
+	}))
+	defer srv.Close()
+
+	c := runsv2.NewClient(srv.URL+"/api/v1", "k")
+	if _, err := c.Query(context.Background(), runsv2.QueryRequest{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotPath != "/v2/runs/query" {
+		t.Errorf("path = %q, want /v2/runs/query (api/v1 suffix should be stripped)", gotPath)
+	}
+}
+
+func TestQuery_ReturnsHTTPErrorOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":"missing project_ids"}`))
+	}))
+	defer srv.Close()
+
+	c := runsv2.NewClient(srv.URL, "k")
+	_, err := c.Query(context.Background(), runsv2.QueryRequest{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	httpErr, ok := err.(*runsv2.HTTPError)
+	if !ok {
+		t.Fatalf("error type = %T, want *HTTPError", err)
+	}
+	if httpErr.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("StatusCode = %d, want 422", httpErr.StatusCode)
+	}
+	if !strings.Contains(httpErr.Body, "missing project_ids") {
+		t.Errorf("Body = %q, want it to contain server detail", httpErr.Body)
+	}
+}


### PR DESCRIPTION
Adds a new `lib/runsv2` subpackage with a thin client for the v2 runs query endpoint (`POST /v2/runs/query`), which is backed by SmithDB. The endpoint isn't in the OpenAPI spec that drives Stainless code generation yet, so this lives outside the regenerated surface — same convention as `lib/langsmithtracing`.

Pairs with the langsmith-cli `--version v2` flag in [LSEN-149](https://linear.app/langchain/issue/LSEN-149/update-cli-to-support-a-version-v2-flag-for-runs-query). The CLI uses this from its `run list / get / export` commands; the agent is instructed to try v2 first and fall back to v1 if v2 returns an error (the client returns `*HTTPError` with the status code so callers can drive that decision).

Draft until the CLI PR is ready to land.

## Release Note

none

## Test Plan

- [x] `go test ./lib/runsv2/...` — request shape, URL composition, header injection, non-2xx → `*HTTPError`, trailing `/api/v1` stripped from base URL
- [ ] Smoke test against a real LangSmith deployment from the CLI branch