### PR TITLE
add missing anthropic cost dimentons

### DIFF
--- a/instrumentation/traceanthropic/traceanthropic.go
+++ b/instrumentation/traceanthropic/traceanthropic.go
@@ -541,7 +541,7 @@ func extractResponseAttributes(span trace.Span, body []byte, parentSpan trace.Sp
 //	}
 //
 // Only token-count fields map into usage_metadata; non-token fields
-// (server_tool_use, service_tier, inference_geo) are handled by the caller.
+// (server_tool_use, service_tier, inference_geo, speed) are handled by the caller.
 func buildUsageMetadata(usage map[string]interface{}) (usageMetadata map[string]any, totalInput, outputTokens int64) {
 	// getInt reads a token count, defaulting to 0 when the field is absent.
 	// Anthropic omits zero-valued usage fields, and both the streaming and
@@ -658,8 +658,8 @@ func setUsageAttributes(span trace.Span, usage map[string]interface{}, parentSpa
 	}
 
 	// These are request counts (server_tool_use) and price modifiers
-	// (service_tier, inference_geo), not token counts, so they go in metadata.
-	// Putting them in usage_metadata token details would corrupt cost math.
+	// (service_tier, inference_geo, speed), not token counts, so they go in
+	// metadata. Putting them in usage_metadata token details would corrupt cost math.
 	if stu, ok := usage["server_tool_use"].(map[string]interface{}); ok {
 		for k, raw := range stu {
 			if v, ok := raw.(float64); ok && v > 0 {
@@ -672,5 +672,9 @@ func setUsageAttributes(span trace.Span, usage map[string]interface{}, parentSpa
 	}
 	if geo, ok := usage["inference_geo"].(string); ok && geo != "" {
 		span.SetAttributes(genaiattr.InferenceGeoKey.String(geo))
+	}
+	// speed is the latency tier (standard/fast) on the beta usage object.
+	if speed, ok := usage["speed"].(string); ok && speed != "" {
+		span.SetAttributes(genaiattr.SpeedKey.String(speed))
 	}
 }

--- a/instrumentation/traceanthropic/traceanthropic.go
+++ b/instrumentation/traceanthropic/traceanthropic.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/langchain-ai/langsmith-go/internal/genaiattr"
 	"github.com/langchain-ai/langsmith-go/internal/traceutil"
 )
 
@@ -338,10 +339,15 @@ func extractRequestAttributes(span trace.Span, body []byte) (streaming bool) {
 // usage tokens, and cache breakdown.
 //
 // Anthropic SSE events of interest:
-//   - message_start       — contains message.usage (input_tokens, cache tokens)
+//   - message_start       — contains message.usage (input_tokens, cache tokens,
+//     cache_creation breakdown)
 //   - content_block_start — initialises a content block (text or tool_use)
 //   - content_block_delta — text_delta or input_json_delta carries incremental data
-//   - message_delta       — contains usage.output_tokens and stop_reason
+//   - message_delta       — contains usage.output_tokens (plus output_tokens_details,
+//     server_tool_use) and stop_reason
+//
+// Usage fields from message_start and message_delta are merged into a single
+// map and handed to setUsageAttributes, which captures every token type.
 func extractStreamingResponseAttributes(span trace.Span, data []byte, parentSpan trace.Span) {
 	chunks, err := traceutil.ParseSSEChunks(bytes.NewReader(data))
 	if err != nil || len(chunks) == 0 {
@@ -512,61 +518,159 @@ func extractResponseAttributes(span trace.Span, body []byte, parentSpan trace.Sp
 	}
 }
 
-// setUsageAttributes sets usage-related attributes on the span.
-func setUsageAttributes(span trace.Span, usage map[string]interface{}, parentSpan trace.Span) {
-	var inputTokens, outputTokens, totalTokens int64
-
-	if v, ok := usage["input_tokens"].(float64); ok {
-		inputTokens = int64(v)
-	}
-	if v, ok := usage["output_tokens"].(float64); ok {
-		outputTokens = int64(v)
-	}
-	if v, ok := usage["total_tokens"].(float64); ok {
-		totalTokens = int64(v)
-	}
-
-	// Handle cache tokens if present
-	var cacheCreate, cacheRead int64
-	if v, ok := usage["cache_creation_input_tokens"].(float64); ok {
-		cacheCreate = int64(v)
-	}
-	if v, ok := usage["cache_read_input_tokens"].(float64); ok {
-		cacheRead = int64(v)
-	}
-
-	// Total prompt tokens includes cache
-	totalPrompt := inputTokens + cacheCreate + cacheRead
-
-	if totalPrompt > 0 {
-		span.SetAttributes(attribute.Int64("gen_ai.usage.input_tokens", totalPrompt))
-		// Propagate usage to parent span if it exists and is valid
-		// This ensures token counts appear in Thread list view (which aggregates from root spans)
-		if parentSpan.SpanContext().IsValid() && parentSpan.IsRecording() {
-			parentSpan.SetAttributes(attribute.Int64("gen_ai.usage.input_tokens", totalPrompt))
+// buildUsageMetadata maps an Anthropic Messages API usage object onto the
+// LangSmith usage_metadata schema. It is pure (no span side-effects) and
+// returns the assembled usage_metadata map along with the inclusive input and
+// output token totals (used for flat gen_ai.usage.* aggregation).
+//
+// The full Anthropic usage object (see the official Messages API reference at
+// https://platform.claude.com/docs/en/api/messages/create) looks like:
+//
+//	"usage": {
+//	  "input_tokens": 2095,                       // uncached input only
+//	  "output_tokens": 503,
+//	  "cache_creation_input_tokens": 2051,        // total written to cache
+//	  "cache_read_input_tokens": 1800,            // read from cache
+//	  "cache_creation": {                         // cache-write TTL breakdown
+//	    "ephemeral_5m_input_tokens": 1951,
+//	    "ephemeral_1h_input_tokens": 100
+//	  },
+//	  "output_tokens_details": {"thinking_tokens": 64},
+//	  "server_tool_use": {"web_search_requests": 1, "web_fetch_requests": 0},
+//	  "service_tier": "standard"
+//	}
+//
+// Only token-count fields map into usage_metadata; non-token fields
+// (server_tool_use, service_tier, inference_geo) are handled by the caller.
+func buildUsageMetadata(usage map[string]interface{}) (usageMetadata map[string]any, totalInput, outputTokens int64) {
+	// getInt reads a token count, defaulting to 0 when the field is absent.
+	// Anthropic omits zero-valued usage fields, and both the streaming and
+	// non-streaming paths decode JSON numbers as float64, so a missing/0 field
+	// are equivalent here — every emission below is guarded by a > 0 check.
+	getInt := func(m map[string]interface{}, key string) int64 {
+		if v, ok := m[key].(float64); ok {
+			return int64(v)
 		}
+		return 0
+	}
+	getNested := func(key string) map[string]interface{} {
+		if m, ok := usage[key].(map[string]interface{}); ok {
+			return m
+		}
+		return nil
+	}
+
+	inputTokens := getInt(usage, "input_tokens")
+	outputTokens = getInt(usage, "output_tokens")
+	cacheCreate := getInt(usage, "cache_creation_input_tokens")
+	cacheRead := getInt(usage, "cache_read_input_tokens")
+
+	// LangChain/LangSmith convention: input_tokens is the inclusive total
+	// (uncached + cache-write + cache-read). The cache portions are surfaced
+	// as a subset in input_token_details so pricing doesn't double-count.
+	totalInput = inputTokens + cacheCreate + cacheRead
+
+	inputTokenDetails := map[string]any{}
+	if cacheRead > 0 {
+		inputTokenDetails["cache_read"] = cacheRead
+	}
+	// Prefer the cache-write TTL breakdown (5m at 1.25x, 1h at 2x base price)
+	// when present. Its parts sum to cache_creation_input_tokens, so emitting
+	// both the total and the breakdown double-counts cache-write tokens. This
+	// mirrors the langsmith Python client (wrappers/_anthropic._create_usage_metadata),
+	// keeping cost identical across the Go and Python ingest stacks.
+	var ephemeral5m, ephemeral1h int64
+	if cc := getNested("cache_creation"); cc != nil {
+		ephemeral5m = getInt(cc, "ephemeral_5m_input_tokens")
+		ephemeral1h = getInt(cc, "ephemeral_1h_input_tokens")
+	}
+	switch {
+	case ephemeral5m > 0 || ephemeral1h > 0:
+		if ephemeral5m > 0 {
+			inputTokenDetails["ephemeral_5m_input_tokens"] = ephemeral5m
+		}
+		if ephemeral1h > 0 {
+			inputTokenDetails["ephemeral_1h_input_tokens"] = ephemeral1h
+		}
+	case cacheCreate > 0:
+		inputTokenDetails["cache_creation"] = cacheCreate
+	}
+
+	outputTokenDetails := map[string]any{}
+	// Extended-thinking (reasoning) tokens are a subset of output_tokens.
+	if otd := getNested("output_tokens_details"); otd != nil {
+		if v := getInt(otd, "thinking_tokens"); v > 0 {
+			outputTokenDetails["reasoning"] = v
+		}
+	}
+
+	usageMetadata = map[string]any{}
+	if totalInput > 0 {
+		usageMetadata["input_tokens"] = totalInput
 	}
 	if outputTokens > 0 {
-		span.SetAttributes(attribute.Int64("gen_ai.usage.output_tokens", outputTokens))
-		// Propagate usage to parent span if it exists and is valid
-		if parentSpan.SpanContext().IsValid() && parentSpan.IsRecording() {
-			parentSpan.SetAttributes(attribute.Int64("gen_ai.usage.output_tokens", outputTokens))
+		usageMetadata["output_tokens"] = outputTokens
+	}
+	if totalInput > 0 || outputTokens > 0 {
+		usageMetadata["total_tokens"] = totalInput + outputTokens
+	}
+	if len(inputTokenDetails) > 0 {
+		usageMetadata["input_token_details"] = inputTokenDetails
+	}
+	if len(outputTokenDetails) > 0 {
+		usageMetadata["output_token_details"] = outputTokenDetails
+	}
+	return usageMetadata, totalInput, outputTokens
+}
+
+// setUsageAttributes records token usage on the span. It emits a single
+// langsmith.usage_metadata JSON attribute (the converter's preferred,
+// cost-driving path) plus the flat gen_ai.usage.* attributes that
+// Thread-list aggregation reads from root spans. Non-token usage fields are
+// recorded as run metadata.
+func setUsageAttributes(span trace.Span, usage map[string]interface{}, parentSpan trace.Span) {
+	usageMetadata, totalInput, outputTokens := buildUsageMetadata(usage)
+	totalTokens := totalInput + outputTokens
+
+	if len(usageMetadata) > 0 {
+		if out, err := json.Marshal(usageMetadata); err == nil {
+			span.SetAttributes(genaiattr.UsageMetadataKey.String(string(out)))
 		}
 	}
+
+	// Flat gen_ai.usage.* attributes drive Thread-list aggregation, which
+	// reads token counts from root spans rather than usage_metadata. Input and
+	// output are propagated to the parent so root-span totals are populated.
+	setSelfAndParent := func(kv attribute.KeyValue) {
+		span.SetAttributes(kv)
+		if parentSpan.SpanContext().IsValid() && parentSpan.IsRecording() {
+			parentSpan.SetAttributes(kv)
+		}
+	}
+	if totalInput > 0 {
+		setSelfAndParent(genaiattr.UsageInputTokensKey.Int64(totalInput))
+	}
+	if outputTokens > 0 {
+		setSelfAndParent(genaiattr.UsageOutputTokensKey.Int64(outputTokens))
+	}
 	if totalTokens > 0 {
-		span.SetAttributes(attribute.Int64("gen_ai.usage.total_tokens", totalTokens))
+		span.SetAttributes(genaiattr.UsageTotalTokensKey.Int64(totalTokens))
 	}
 
-	// Cache breakdown in metadata
-	if cacheCreate > 0 {
-		span.SetAttributes(attribute.Int64("langsmith.metadata.usage_metadata.input_token_details.cache_creation", cacheCreate))
+	// These are request counts (server_tool_use) and price modifiers
+	// (service_tier, inference_geo), not token counts, so they go in metadata.
+	// Putting them in usage_metadata token details would corrupt cost math.
+	if stu, ok := usage["server_tool_use"].(map[string]interface{}); ok {
+		for k, raw := range stu {
+			if v, ok := raw.(float64); ok && v > 0 {
+				span.SetAttributes(attribute.Int64(genaiattr.ServerToolUseMetadataKeyPrefix+k, int64(v)))
+			}
+		}
 	}
-	if cacheRead > 0 {
-		span.SetAttributes(attribute.Int64("langsmith.metadata.usage_metadata.input_token_details.cache_read", cacheRead))
+	if st, ok := usage["service_tier"].(string); ok && st != "" {
+		span.SetAttributes(genaiattr.ServiceTierKey.String(st))
 	}
-
-	// Reasoning tokens if present (for Claude Sonnet 4.5+)
-	if v, ok := usage["reasoning_tokens"].(float64); ok {
-		span.SetAttributes(attribute.Int64("gen_ai.usage.details.reasoning_tokens", int64(v)))
+	if geo, ok := usage["inference_geo"].(string); ok && geo != "" {
+		span.SetAttributes(genaiattr.InferenceGeoKey.String(geo))
 	}
 }

--- a/instrumentation/traceanthropic/traceanthropic_test.go
+++ b/instrumentation/traceanthropic/traceanthropic_test.go
@@ -619,7 +619,9 @@ func TestSetUsageAttributes_AllTokenTypes(t *testing.T) {
 			"web_search_requests": float64(2),
 			"web_fetch_requests":  float64(1),
 		},
-		"service_tier": "standard",
+		"service_tier":  "standard",
+		"inference_geo": "us",
+		"speed":         "fast",
 	}
 	setUsageAttributes(span, usage, parentSpan)
 
@@ -658,6 +660,12 @@ func TestSetUsageAttributes_AllTokenTypes(t *testing.T) {
 	}
 	if v, ok := getAttr(span, "langsmith.metadata.service_tier"); !ok || v.AsString() != "standard" {
 		t.Errorf("service_tier: got %v, ok=%v", v, ok)
+	}
+	if v, ok := getAttr(span, "langsmith.metadata.inference_geo"); !ok || v.AsString() != "us" {
+		t.Errorf("inference_geo: got %v, ok=%v", v, ok)
+	}
+	if v, ok := getAttr(span, "langsmith.metadata.speed"); !ok || v.AsString() != "fast" {
+		t.Errorf("speed: got %v, ok=%v", v, ok)
 	}
 }
 

--- a/instrumentation/traceanthropic/traceanthropic_test.go
+++ b/instrumentation/traceanthropic/traceanthropic_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -496,11 +497,18 @@ func TestSetUsageAttributes(t *testing.T) {
 	if v, ok := getAttr(span, "gen_ai.usage.output_tokens"); !ok || v.AsInt64() != 50 {
 		t.Errorf("output_tokens: got %v", v)
 	}
-	if v, ok := getAttr(span, "langsmith.metadata.usage_metadata.input_token_details.cache_creation"); !ok || v.AsInt64() != 10 {
-		t.Errorf("cache_creation: got %v", v)
+
+	// Cache details are carried inside the langsmith.usage_metadata JSON
+	// (input_token_details), not as flat langsmith.metadata.* attributes.
+	details, ok := parseUsageMetadata(t, span)["input_token_details"].(map[string]any)
+	if !ok {
+		t.Fatal("expected input_token_details in usage_metadata")
 	}
-	if v, ok := getAttr(span, "langsmith.metadata.usage_metadata.input_token_details.cache_read"); !ok || v.AsInt64() != 5 {
-		t.Errorf("cache_read: got %v", v)
+	if v, _ := details["cache_creation"].(float64); v != 10 {
+		t.Errorf("cache_creation: got %v, want 10", details["cache_creation"])
+	}
+	if v, _ := details["cache_read"].(float64); v != 5 {
+		t.Errorf("cache_read: got %v, want 5", details["cache_read"])
 	}
 }
 
@@ -573,5 +581,175 @@ func TestExtractResponseAttributes_FullRoundTrip(t *testing.T) {
 	}
 	if !strings.Contains(v.AsString(), "calculator") {
 		t.Errorf("completion should contain tool_use: %s", v.AsString())
+	}
+}
+
+// parseUsageMetadata reads and JSON-decodes the langsmith.usage_metadata attr.
+func parseUsageMetadata(t *testing.T, span sdktrace.ReadWriteSpan) map[string]any {
+	t.Helper()
+	v, ok := getAttr(span, "langsmith.usage_metadata")
+	if !ok {
+		t.Fatal("expected langsmith.usage_metadata attribute")
+	}
+	var um map[string]any
+	if err := json.Unmarshal([]byte(v.AsString()), &um); err != nil {
+		t.Fatalf("failed to decode usage_metadata: %v", err)
+	}
+	return um
+}
+
+func TestSetUsageAttributes_AllTokenTypes(t *testing.T) {
+	span, _ := startTestSpan(t)
+	parentSpan, _ := startTestSpan(t)
+
+	// Mirrors the full Anthropic Messages API usage object.
+	usage := map[string]interface{}{
+		"input_tokens":                float64(2095),
+		"output_tokens":               float64(503),
+		"cache_creation_input_tokens": float64(2051),
+		"cache_read_input_tokens":     float64(1800),
+		"cache_creation": map[string]any{
+			"ephemeral_5m_input_tokens": float64(1951),
+			"ephemeral_1h_input_tokens": float64(100),
+		},
+		"output_tokens_details": map[string]any{
+			"thinking_tokens": float64(64),
+		},
+		"server_tool_use": map[string]any{
+			"web_search_requests": float64(2),
+			"web_fetch_requests":  float64(1),
+		},
+		"service_tier": "standard",
+	}
+	setUsageAttributes(span, usage, parentSpan)
+
+	// usage_metadata is JSON round-tripped, so numbers decode as float64. A
+	// full comparison also asserts the cache_creation total is dropped in favor
+	// of the ephemeral breakdown and that non-token fields never leak in.
+	// Inclusive input: 2095 + 2051 + 1800 = 5946.
+	wantUM := map[string]any{
+		"input_tokens":  float64(5946),
+		"output_tokens": float64(503),
+		"total_tokens":  float64(6449),
+		"input_token_details": map[string]any{
+			"cache_read":                float64(1800),
+			"ephemeral_5m_input_tokens": float64(1951),
+			"ephemeral_1h_input_tokens": float64(100),
+		},
+		"output_token_details": map[string]any{
+			"reasoning": float64(64),
+		},
+	}
+	if um := parseUsageMetadata(t, span); !reflect.DeepEqual(um, wantUM) {
+		t.Errorf("usage_metadata mismatch:\n got: %#v\nwant: %#v", um, wantUM)
+	}
+
+	// Token totals are also emitted as flat gen_ai.usage.* attributes.
+	if v, ok := getAttr(span, "gen_ai.usage.total_tokens"); !ok || v.AsInt64() != 6449 {
+		t.Errorf("gen_ai.usage.total_tokens: got %v, ok=%v", v, ok)
+	}
+
+	// Non-token fields are recorded as separate span metadata attributes.
+	if v, ok := getAttr(span, "langsmith.metadata.server_tool_use.web_search_requests"); !ok || v.AsInt64() != 2 {
+		t.Errorf("web_search_requests: got %v, ok=%v", v, ok)
+	}
+	if v, ok := getAttr(span, "langsmith.metadata.server_tool_use.web_fetch_requests"); !ok || v.AsInt64() != 1 {
+		t.Errorf("web_fetch_requests: got %v, ok=%v", v, ok)
+	}
+	if v, ok := getAttr(span, "langsmith.metadata.service_tier"); !ok || v.AsString() != "standard" {
+		t.Errorf("service_tier: got %v, ok=%v", v, ok)
+	}
+}
+
+// TestBuildUsageMetadata exercises the pure usage -> usage_metadata mapping.
+// Comparing the whole returned map with DeepEqual also guards against stray
+// keys (e.g. a cache_creation total leaking in alongside the ephemeral split).
+func TestBuildUsageMetadata(t *testing.T) {
+	tests := []struct {
+		name       string
+		usage      map[string]interface{}
+		wantUM     map[string]any
+		wantInput  int64
+		wantOutput int64
+	}{
+		{
+			name:       "basic input/output only",
+			usage:      map[string]interface{}{"input_tokens": float64(10), "output_tokens": float64(5)},
+			wantUM:     map[string]any{"input_tokens": int64(10), "output_tokens": int64(5), "total_tokens": int64(15)},
+			wantInput:  10,
+			wantOutput: 5,
+		},
+		{
+			name: "cache total without TTL breakdown",
+			usage: map[string]interface{}{
+				"input_tokens": float64(100), "output_tokens": float64(50),
+				"cache_creation_input_tokens": float64(10), "cache_read_input_tokens": float64(5),
+			},
+			// Inclusive total: 100 + 10 + 5 = 115.
+			wantUM: map[string]any{
+				"input_tokens": int64(115), "output_tokens": int64(50), "total_tokens": int64(165),
+				"input_token_details": map[string]any{"cache_creation": int64(10), "cache_read": int64(5)},
+			},
+			wantInput:  115,
+			wantOutput: 50,
+		},
+		{
+			name: "ephemeral breakdown omits cache_creation total",
+			usage: map[string]interface{}{
+				"input_tokens": float64(2095), "output_tokens": float64(503),
+				"cache_creation_input_tokens": float64(2051), "cache_read_input_tokens": float64(1800),
+				"cache_creation": map[string]any{
+					"ephemeral_5m_input_tokens": float64(1951),
+					"ephemeral_1h_input_tokens": float64(100),
+				},
+			},
+			// Inclusive total: 2095 + 2051 + 1800 = 5946; cache_creation total
+			// omitted to avoid double-counting the ephemeral split.
+			wantUM: map[string]any{
+				"input_tokens": int64(5946), "output_tokens": int64(503), "total_tokens": int64(6449),
+				"input_token_details": map[string]any{
+					"cache_read":                int64(1800),
+					"ephemeral_5m_input_tokens": int64(1951),
+					"ephemeral_1h_input_tokens": int64(100),
+				},
+			},
+			wantInput:  5946,
+			wantOutput: 503,
+		},
+		{
+			name: "thinking maps to reasoning",
+			usage: map[string]interface{}{
+				"input_tokens": float64(10), "output_tokens": float64(64),
+				"output_tokens_details": map[string]any{"thinking_tokens": float64(40)},
+			},
+			wantUM: map[string]any{
+				"input_tokens": int64(10), "output_tokens": int64(64), "total_tokens": int64(74),
+				"output_token_details": map[string]any{"reasoning": int64(40)},
+			},
+			wantInput:  10,
+			wantOutput: 64,
+		},
+		{
+			name:       "empty usage",
+			usage:      map[string]interface{}{},
+			wantUM:     map[string]any{},
+			wantInput:  0,
+			wantOutput: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			um, totalInput, outputTokens := buildUsageMetadata(tt.usage)
+			if totalInput != tt.wantInput {
+				t.Errorf("totalInput: got %d, want %d", totalInput, tt.wantInput)
+			}
+			if outputTokens != tt.wantOutput {
+				t.Errorf("outputTokens: got %d, want %d", outputTokens, tt.wantOutput)
+			}
+			if !reflect.DeepEqual(um, tt.wantUM) {
+				t.Errorf("usage_metadata mismatch:\n got: %#v\nwant: %#v", um, tt.wantUM)
+			}
+		})
 	}
 }

--- a/internal/genaiattr/genaiattr.go
+++ b/internal/genaiattr/genaiattr.go
@@ -72,6 +72,11 @@ const (
 	// per-token price modifier kept in metadata rather than usage_metadata.
 	InferenceGeoKey = attribute.Key("langsmith.metadata.inference_geo")
 
+	// SpeedKey records the latency tier the request was served on (e.g.
+	// standard/fast). Like ServiceTierKey it is a price modifier rather than a
+	// token count, so it lives in metadata rather than usage_metadata.
+	SpeedKey = attribute.Key("langsmith.metadata.speed")
+
 	// ServerToolUseMetadataKeyPrefix is prefixed to server-side tool request
 	// counts (e.g. web_search_requests). These are billed on a separate
 	// dimension from tokens, so they are recorded in metadata.

--- a/internal/genaiattr/genaiattr.go
+++ b/internal/genaiattr/genaiattr.go
@@ -32,11 +32,24 @@ const (
 	// The converter uses this to populate run outputs.
 	CompletionKey = attribute.Key("gen_ai.completion")
 
+	// UsageInputTokensKey is the total number of input (prompt) tokens used.
+	UsageInputTokensKey = attribute.Key("gen_ai.usage.input_tokens")
+
+	// UsageOutputTokensKey is the total number of output (completion) tokens used.
+	UsageOutputTokensKey = attribute.Key("gen_ai.usage.output_tokens")
+
 	// UsageTotalTokensKey is the total number of tokens used (input + output).
 	UsageTotalTokensKey = attribute.Key("gen_ai.usage.total_tokens")
 
 	// UsageReasoningTokensKey is the number of tokens used for reasoning/thinking.
 	UsageReasoningTokensKey = attribute.Key("gen_ai.usage.details.reasoning_tokens")
+
+	// UsageMetadataKey is a JSON-serialized LangSmith usage_metadata object.
+	// The OTLP converter reads this in preference to the flat gen_ai.usage.*
+	// keys and uses it to populate run outputs.usage_metadata, which drives
+	// token-cost calculation. See langchainplus/smith-go/otel/otel_converter.go
+	// (LangSmithUsageMetadata) and queue/ingest/token_cost.go.
+	UsageMetadataKey = attribute.Key("langsmith.usage_metadata")
 )
 
 // HTTP semantic convention attribute keys.
@@ -49,6 +62,20 @@ const (
 const (
 	// StopReasonKey records the model's stop/finish reason in LangSmith metadata.
 	StopReasonKey = attribute.Key("langsmith.metadata.stop_reason")
+
+	// ServiceTierKey records the provider service tier the request was served
+	// on (e.g. standard/priority/batch). It is a per-token price modifier, not
+	// a token count, so it lives in metadata rather than usage_metadata.
+	ServiceTierKey = attribute.Key("langsmith.metadata.service_tier")
+
+	// InferenceGeoKey records the inference geography (e.g. us/global), a
+	// per-token price modifier kept in metadata rather than usage_metadata.
+	InferenceGeoKey = attribute.Key("langsmith.metadata.inference_geo")
+
+	// ServerToolUseMetadataKeyPrefix is prefixed to server-side tool request
+	// counts (e.g. web_search_requests). These are billed on a separate
+	// dimension from tokens, so they are recorded in metadata.
+	ServerToolUseMetadataKeyPrefix = "langsmith.metadata.server_tool_use."
 )
 
 // Legacy Gen AI attribute keys that the LangSmith OTLP converter reads.


### PR DESCRIPTION
Some of the details for pricing were missing or mapped incorrectly.

We're also adding the region (inference_geo) and tier to metadata, so that langsmith may adjust pricing accordingly.

## Testing

Existing tests pass

New unit test against the full set of properties

Trace against langsmith to trigger the "usage" details in anthropic API reponses.

<img width="626" height="485" alt="image" src="https://github.com/user-attachments/assets/f1ccc106-1a50-4ad4-965b-0165bf4b4a1e" />

