### PR TITLE
fix: fixup gemini usage metadata

### DIFF
--- a/instrumentation/tracegemini/tracegemini.go
+++ b/instrumentation/tracegemini/tracegemini.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
@@ -625,31 +626,186 @@ func buildCompletion(resp map[string]any) (completion, finishReason string) {
 	return string(out), finishReason
 }
 
-// setUsageAttributes sets usage-related attributes on the span.
-// Gemini uses promptTokenCount/candidatesTokenCount instead of input_tokens/output_tokens.
-func setUsageAttributes(span trace.Span, usage map[string]any, parentSpan trace.Span) {
-	var inputTokens, outputTokens int64
-
-	if v, ok := usage["promptTokenCount"].(float64); ok {
-		inputTokens = int64(v)
+// modalityTokens sums tokenCount across a Gemini *TokensDetails array
+// (e.g. promptTokensDetails) for entries matching the given modality
+// (e.g. "AUDIO", "IMAGE", "TEXT").
+func modalityTokens(usage map[string]any, field, modality string) int64 {
+	arr, ok := usage[field].([]any)
+	if !ok {
+		return 0
 	}
-	if v, ok := usage["candidatesTokenCount"].(float64); ok {
-		outputTokens = int64(v)
-	}
-
-	if inputTokens > 0 {
-		span.SetAttributes(semconv.GenAIUsageInputTokens(int(inputTokens)))
-		if parentSpan.SpanContext().IsValid() && parentSpan.IsRecording() {
-			parentSpan.SetAttributes(semconv.GenAIUsageInputTokens(int(inputTokens)))
+	var sum int64
+	for _, e := range arr {
+		m, ok := e.(map[string]any)
+		if !ok {
+			continue
 		}
+		if mod, _ := m["modality"].(string); mod == modality {
+			if tc, ok := m["tokenCount"].(float64); ok {
+				sum += int64(tc)
+			}
+		}
+	}
+	return sum
+}
+
+// buildUsageMetadata maps a Gemini usageMetadata object onto the LangSmith
+// usage_metadata schema. It is pure (no span side-effects) and returns the
+// assembled usage_metadata map along with the input, output, and total token
+// totals (used for flat gen_ai.usage.* aggregation).
+//
+// The full Gemini usageMetadata schema (see the official GenerateContentResponse
+// reference at https://ai.google.dev/api/generate-content#UsageMetadata) is:
+//
+//	"usageMetadata": {
+//	  "promptTokenCount": 2095,            // [used] inclusive input total (cache is a subset)
+//	  "cachedContentTokenCount": 1800,     // [used] prompt tokens served from cache
+//	  "candidatesTokenCount": 503,         // [used] visible output, EXCLUDING thinking
+//	  "thoughtsTokenCount": 64,            // [used] thinking/reasoning tokens
+//	  "toolUsePromptTokenCount": 0,        // [ignored] tokens for tool-use prompts
+//	  "totalTokenCount": 2662,             // [used] grand total (incl. tool-use)
+//	  // The *Details arrays break each count down by modality (TEXT, IMAGE,
+//	  // AUDIO, VIDEO, DOCUMENT). We pull AUDIO out of promptTokensDetails (it
+//	  // has a separate input rate); the rest are not mapped — generated-image
+//	  // output ("image") is priced per-image rather than per-token and has no
+//	  // client convention yet, and no other modality is separately priced.
+//	  "promptTokensDetails":      [{ "modality": "TEXT",  "tokenCount": 2095 }],
+//	  "cacheTokensDetails":       [{ "modality": "TEXT",  "tokenCount": 1800 }],
+//	  "candidatesTokensDetails":  [{ "modality": "TEXT",  "tokenCount": 503  }],
+//	  "toolUsePromptTokensDetails": []
+//	}
+//
+// candidatesTokenCount excludes thinking, so thoughts are folded into
+// output_tokens and cachedContentTokenCount becomes a cache_read subset of
+// input_tokens, mirroring langchain-google-genai (_response_to_result).
+//
+// Long-context tier: above 200k prompt tokens Google bills the whole request
+// (input and output) at the higher rate, not just the overage
+// (https://ai.google.dev/gemini-api/docs/pricing). We route everything into the
+// over_200k / cache_read_over_200k buckets so every token is charged there.
+func buildUsageMetadata(usage map[string]any) (usageMetadata map[string]any, totalInput, outputTokens, totalTokens int64) {
+	getInt := func(key string) int64 {
+		if v, ok := usage[key].(float64); ok {
+			return int64(v)
+		}
+		return 0
+	}
+
+	totalInput = getInt("promptTokenCount")
+	thoughts := getInt("thoughtsTokenCount")
+	outputTokens = getInt("candidatesTokenCount") + thoughts
+	cacheRead := getInt("cachedContentTokenCount")
+
+	// Prefer the API's totalTokenCount (it also accounts for tool-use prompt
+	// tokens); fall back to input+output when absent.
+	totalTokens = getInt("totalTokenCount")
+	if totalTokens == 0 {
+		totalTokens = totalInput + outputTokens
+	}
+
+	// The long-context tier is a cliff keyed on the input prompt size; once
+	// crossed it applies to output too. Threshold and high-tier rates come from
+	// Google's rate card: https://ai.google.dev/gemini-api/docs/pricing
+	// (Vertex AI: https://cloud.google.com/vertex-ai/generative-ai/pricing).
+	const longContextThreshold = 200_000
+	tier200k := totalInput > longContextThreshold
+
+	inputTokenDetails := map[string]any{}
+	switch {
+	case tier200k:
+		// Whole prompt at the high tier: cached portion at cache_read_over_200k,
+		// the rest at over_200k. Together they sum to input_tokens (no leftover
+		// charged at the base rate).
+		if cacheRead > 0 {
+			inputTokenDetails["cache_read_over_200k"] = cacheRead
+		}
+		if nonCached := totalInput - cacheRead; nonCached > 0 {
+			inputTokenDetails["over_200k"] = nonCached
+		}
+	default:
+		// cache_read and audio are independent subsets of input_tokens; the rest
+		// (plain text) is charged at the base rate. (Audio isn't broken out in
+		// the over_200k path: there's no audio_over_200k rate.)
+		if cacheRead > 0 {
+			inputTokenDetails["cache_read"] = cacheRead
+		}
+		// Audio input bills at a separate (higher) rate than text on some models.
+		if audioInput := modalityTokens(usage, "promptTokensDetails", "AUDIO"); audioInput > 0 {
+			inputTokenDetails["audio"] = audioInput
+		}
+	}
+
+	outputTokenDetails := map[string]any{}
+	switch {
+	case tier200k:
+		// Above the threshold all output (thinking included) bills at the
+		// output over_200k rate. Gemini has no separate reasoning price, so we
+		// put the whole output_tokens into over_200k rather than splitting out
+		// reasoning, which would leave the buckets not summing to output_tokens.
+		if outputTokens > 0 {
+			outputTokenDetails["over_200k"] = outputTokens
+		}
+	case thoughts > 0:
+		outputTokenDetails["reasoning"] = thoughts
+	}
+
+	usageMetadata = map[string]any{}
+	if totalInput > 0 {
+		usageMetadata["input_tokens"] = totalInput
 	}
 	if outputTokens > 0 {
-		span.SetAttributes(semconv.GenAIUsageOutputTokens(int(outputTokens)))
-		if parentSpan.SpanContext().IsValid() && parentSpan.IsRecording() {
-			parentSpan.SetAttributes(semconv.GenAIUsageOutputTokens(int(outputTokens)))
+		usageMetadata["output_tokens"] = outputTokens
+	}
+	if totalInput > 0 || outputTokens > 0 {
+		usageMetadata["total_tokens"] = totalTokens
+	}
+	if len(inputTokenDetails) > 0 {
+		usageMetadata["input_token_details"] = inputTokenDetails
+	}
+	if len(outputTokenDetails) > 0 {
+		usageMetadata["output_token_details"] = outputTokenDetails
+	}
+	return usageMetadata, totalInput, outputTokens, totalTokens
+}
+
+// setUsageAttributes records token usage on the span: the cost-driving
+// langsmith.usage_metadata JSON, the flat gen_ai.usage.* token counts, and the
+// legacy underscore-format cache/reasoning attributes. See the inline notes for
+// which consumer each group actually serves.
+func setUsageAttributes(span trace.Span, usage map[string]any, parentSpan trace.Span) {
+	usageMetadata, totalInput, outputTokens, totalTokens := buildUsageMetadata(usage)
+
+	if len(usageMetadata) > 0 {
+		if out, err := json.Marshal(usageMetadata); err == nil {
+			span.SetAttributes(genaiattr.UsageMetadataKey.String(string(out)))
 		}
 	}
 
+	// Flat gen_ai.usage.* attributes. On this span they are redundant for
+	// LangSmith (the converter prefers the usage_metadata JSON above and ignores
+	// these), but are kept for OpenTelemetry-standard consumers. Propagating
+	// input/output to the parent IS load-bearing: the root span has no
+	// usage_metadata of its own, so the converter's fallback path turns these
+	// propagated attrs into the root run's token totals, which Thread-list stats
+	// aggregate.
+	setSelfAndParent := func(kv attribute.KeyValue) {
+		span.SetAttributes(kv)
+		if parentSpan.SpanContext().IsValid() && parentSpan.IsRecording() {
+			parentSpan.SetAttributes(kv)
+		}
+	}
+	if totalInput > 0 {
+		setSelfAndParent(genaiattr.UsageInputTokensKey.Int64(totalInput))
+	}
+	if outputTokens > 0 {
+		setSelfAndParent(genaiattr.UsageOutputTokensKey.Int64(outputTokens))
+	}
+	if totalTokens > 0 {
+		span.SetAttributes(genaiattr.UsageTotalTokensKey.Int64(totalTokens))
+	}
+
+	// Legacy flat detail attributes (subsets of the totals above) for the
+	// converter's underscore-format path.
 	if v, ok := usage["cachedContentTokenCount"].(float64); ok && v > 0 {
 		span.SetAttributes(
 			genaiattr.CacheReadInputTokensKey.Int64(int64(v)),

--- a/instrumentation/tracegemini/tracegemini_test.go
+++ b/instrumentation/tracegemini/tracegemini_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -785,20 +786,211 @@ func TestSetUsageAttributes(t *testing.T) {
 		"candidatesTokenCount":    float64(50),
 		"cachedContentTokenCount": float64(10),
 		"thoughtsTokenCount":      float64(5),
+		"totalTokenCount":         float64(155),
 	}
 	setUsageAttributes(span, usage, parentSpan)
 
 	if v, ok := getAttr(span, "gen_ai.usage.input_tokens"); !ok || v.AsInt64() != 100 {
 		t.Errorf("input_tokens: %v", v)
 	}
-	if v, ok := getAttr(span, "gen_ai.usage.output_tokens"); !ok || v.AsInt64() != 50 {
-		t.Errorf("output_tokens: %v", v)
+	// output_tokens folds in thinking tokens (candidates 50 + thoughts 5).
+	if v, ok := getAttr(span, "gen_ai.usage.output_tokens"); !ok || v.AsInt64() != 55 {
+		t.Errorf("output_tokens: %v, want 55", v)
+	}
+	if v, ok := getAttr(span, "gen_ai.usage.total_tokens"); !ok || v.AsInt64() != 155 {
+		t.Errorf("total_tokens: %v, want 155", v)
 	}
 	if v, ok := getAttr(span, "gen_ai.usage.cache_read_input_tokens"); !ok || v.AsInt64() != 10 {
 		t.Errorf("cache_read: %v", v)
 	}
 	if v, ok := getAttr(span, "gen_ai.usage.details.reasoning_tokens"); !ok || v.AsInt64() != 5 {
 		t.Errorf("reasoning_tokens: %v", v)
+	}
+	// The cost-driving usage_metadata JSON should carry the full breakdown.
+	v, ok := getAttr(span, "langsmith.usage_metadata")
+	if !ok {
+		t.Fatal("expected langsmith.usage_metadata attribute")
+	}
+	var um map[string]any
+	if err := json.Unmarshal([]byte(v.AsString()), &um); err != nil {
+		t.Fatalf("usage_metadata is not valid JSON: %v", err)
+	}
+	want := map[string]any{
+		"input_tokens":         float64(100),
+		"output_tokens":        float64(55),
+		"total_tokens":         float64(155),
+		"input_token_details":  map[string]any{"cache_read": float64(10)},
+		"output_token_details": map[string]any{"reasoning": float64(5)},
+	}
+	if !reflect.DeepEqual(um, want) {
+		t.Errorf("usage_metadata mismatch:\n got: %#v\nwant: %#v", um, want)
+	}
+}
+
+// TestBuildUsageMetadata exercises the pure usageMetadata -> usage_metadata
+// mapping. Comparing the whole map with DeepEqual also guards against stray
+// keys leaking in.
+func TestBuildUsageMetadata(t *testing.T) {
+	tests := []struct {
+		name       string
+		usage      map[string]any
+		wantUM     map[string]any
+		wantInput  int64
+		wantOutput int64
+		wantTotal  int64
+	}{
+		{
+			name: "cache + thinking",
+			usage: map[string]any{
+				"promptTokenCount":        float64(2095),
+				"candidatesTokenCount":    float64(503),
+				"thoughtsTokenCount":      float64(64),
+				"cachedContentTokenCount": float64(1800),
+				"totalTokenCount":         float64(2662),
+			},
+			wantUM: map[string]any{
+				"input_tokens":         int64(2095),
+				"output_tokens":        int64(567),
+				"total_tokens":         int64(2662),
+				"input_token_details":  map[string]any{"cache_read": int64(1800)},
+				"output_token_details": map[string]any{"reasoning": int64(64)},
+			},
+			wantInput: 2095, wantOutput: 567, wantTotal: 2662,
+		},
+		{
+			name: "plain, total derived",
+			usage: map[string]any{
+				"promptTokenCount":     float64(10),
+				"candidatesTokenCount": float64(5),
+			},
+			wantUM: map[string]any{
+				"input_tokens":  int64(10),
+				"output_tokens": int64(5),
+				"total_tokens":  int64(15),
+			},
+			wantInput: 10, wantOutput: 5, wantTotal: 15,
+		},
+		{
+			// Audio input is a subset of promptTokenCount, surfaced from
+			// promptTokensDetails so it can be priced at the audio rate.
+			name: "audio input modality",
+			usage: map[string]any{
+				"promptTokenCount":     float64(1000),
+				"candidatesTokenCount": float64(20),
+				"totalTokenCount":      float64(1020),
+				"promptTokensDetails": []any{
+					map[string]any{"modality": "TEXT", "tokenCount": float64(200)},
+					map[string]any{"modality": "AUDIO", "tokenCount": float64(800)},
+				},
+			},
+			wantUM: map[string]any{
+				"input_tokens":        int64(1000),
+				"output_tokens":       int64(20),
+				"total_tokens":        int64(1020),
+				"input_token_details": map[string]any{"audio": int64(800)},
+			},
+			wantInput: 1000, wantOutput: 20, wantTotal: 1020,
+		},
+		{
+			// Audio + cache both subsets of input; over_200k path is not active.
+			name: "audio + cache",
+			usage: map[string]any{
+				"promptTokenCount":        float64(5000),
+				"candidatesTokenCount":    float64(30),
+				"cachedContentTokenCount": float64(1000),
+				"totalTokenCount":         float64(5030),
+				"promptTokensDetails": []any{
+					map[string]any{"modality": "AUDIO", "tokenCount": float64(2000)},
+				},
+			},
+			wantUM: map[string]any{
+				"input_tokens":        int64(5000),
+				"output_tokens":       int64(30),
+				"total_tokens":        int64(5030),
+				"input_token_details": map[string]any{"cache_read": int64(1000), "audio": int64(2000)},
+			},
+			wantInput: 5000, wantOutput: 30, wantTotal: 5030,
+		},
+		{
+			name:       "empty usage",
+			usage:      map[string]any{},
+			wantUM:     map[string]any{},
+			wantInput:  0,
+			wantOutput: 0,
+			wantTotal:  0,
+		},
+		{
+			// >200k prompt: whole request bills at the high tier. Cached input
+			// -> cache_read_over_200k, rest -> over_200k (summing to input);
+			// all output -> over_200k.
+			name: "over 200k with cache and thinking",
+			usage: map[string]any{
+				"promptTokenCount":        float64(300000),
+				"candidatesTokenCount":    float64(100000),
+				"thoughtsTokenCount":      float64(5000),
+				"cachedContentTokenCount": float64(50000),
+				"totalTokenCount":         float64(405000),
+			},
+			wantUM: map[string]any{
+				"input_tokens":         int64(300000),
+				"output_tokens":        int64(105000),
+				"total_tokens":         int64(405000),
+				"input_token_details":  map[string]any{"cache_read_over_200k": int64(50000), "over_200k": int64(250000)},
+				"output_token_details": map[string]any{"over_200k": int64(105000)},
+			},
+			wantInput: 300000, wantOutput: 105000, wantTotal: 405000,
+		},
+		{
+			name: "over 200k no cache",
+			usage: map[string]any{
+				"promptTokenCount":     float64(250000),
+				"candidatesTokenCount": float64(10000),
+				"totalTokenCount":      float64(260000),
+			},
+			wantUM: map[string]any{
+				"input_tokens":         int64(250000),
+				"output_tokens":        int64(10000),
+				"total_tokens":         int64(260000),
+				"input_token_details":  map[string]any{"over_200k": int64(250000)},
+				"output_token_details": map[string]any{"over_200k": int64(10000)},
+			},
+			wantInput: 250000, wantOutput: 10000, wantTotal: 260000,
+		},
+		{
+			// Above the threshold, audio is NOT broken out (no audio_over_200k
+			// rate): the whole prompt still partitions into over_200k /
+			// cache_read_over_200k, with no "audio" key.
+			name: "over 200k with audio details ignored",
+			usage: map[string]any{
+				"promptTokenCount":        float64(300000),
+				"candidatesTokenCount":    float64(1000),
+				"cachedContentTokenCount": float64(50000),
+				"totalTokenCount":         float64(301000),
+				"promptTokensDetails": []any{
+					map[string]any{"modality": "AUDIO", "tokenCount": float64(100000)},
+				},
+			},
+			wantUM: map[string]any{
+				"input_tokens":         int64(300000),
+				"output_tokens":        int64(1000),
+				"total_tokens":         int64(301000),
+				"input_token_details":  map[string]any{"cache_read_over_200k": int64(50000), "over_200k": int64(250000)},
+				"output_token_details": map[string]any{"over_200k": int64(1000)},
+			},
+			wantInput: 300000, wantOutput: 1000, wantTotal: 301000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			um, in, out, total := buildUsageMetadata(tt.usage)
+			if !reflect.DeepEqual(um, tt.wantUM) {
+				t.Errorf("usage_metadata mismatch:\n got: %#v\nwant: %#v", um, tt.wantUM)
+			}
+			if in != tt.wantInput || out != tt.wantOutput || total != tt.wantTotal {
+				t.Errorf("totals = (%d, %d, %d), want (%d, %d, %d)",
+					in, out, total, tt.wantInput, tt.wantOutput, tt.wantTotal)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Adds all of the dimensions of gemini's emitted usage metadata, including image modalities

## Testing

- existing unit tests pass
- New unit tests with example usage metadata from responses
- tracing to langmsith now shows the metadata
  - <img width="618" height="320" alt="image" src="https://github.com/user-attachments/assets/28be6327-0f98-4e02-922c-8d9c46d4bc07" />
