### PR TITLE
feat: add responses/compact tracing to openai responses

### DIFF
--- a/instrumentation/traceopenai/openaitrace.go
+++ b/instrumentation/traceopenai/openaitrace.go
@@ -147,7 +147,7 @@ func MiddlewareWithTracerProvider(req *http.Request, next MiddlewareNext, tp tra
 		streaming = reqFields.streaming
 	}
 
-	responsesAPI := strings.HasSuffix(req.URL.Path, "/responses")
+	responsesAPI := strings.HasSuffix(req.URL.Path, "/responses") || strings.HasSuffix(req.URL.Path, "/responses/compact")
 
 	// Inject span context into request headers and update request context
 	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
@@ -326,7 +326,8 @@ func isOpenAIEndpoint(path string) bool {
 	return strings.HasSuffix(path, "/chat/completions") ||
 		strings.HasSuffix(path, "/completions") ||
 		strings.HasSuffix(path, "/embeddings") ||
-		strings.HasSuffix(path, "/responses")
+		strings.HasSuffix(path, "/responses") ||
+		strings.HasSuffix(path, "/responses/compact")
 }
 
 // getSpanName returns an appropriate span name based on the API endpoint.
@@ -339,6 +340,9 @@ func getSpanName(path string) string {
 	}
 	if strings.HasSuffix(path, "/embeddings") {
 		return "openai.embedding"
+	}
+	if strings.HasSuffix(path, "/responses/compact") {
+		return "openai.responses.compact"
 	}
 	if strings.HasSuffix(path, "/responses") {
 		return "openai.responses"
@@ -356,6 +360,9 @@ func getOperationName(path string) string {
 	}
 	if strings.HasSuffix(path, "/embeddings") {
 		return "embedding"
+	}
+	if strings.HasSuffix(path, "/responses/compact") {
+		return "responses.compact"
 	}
 	if strings.HasSuffix(path, "/responses") {
 		return "responses"

--- a/instrumentation/traceopenai/openaitrace.go
+++ b/instrumentation/traceopenai/openaitrace.go
@@ -996,6 +996,9 @@ func extractResponsesCompletion(body []byte) (string, usageInfo) {
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return "", usageInfo{}
 	}
+	if object, _ := resp["object"].(string); object == "response.compaction" {
+		return extractResponsesCompactOutput(resp), extractResponsesUsage(resp)
+	}
 	return extractResponsesOutput(resp), extractResponsesUsage(resp)
 }
 
@@ -1101,6 +1104,46 @@ func extractResponsesOutput(resp map[string]any) string {
 		return ""
 	}
 	return marshalMessages([]any{msg})
+}
+
+func extractResponsesCompactOutput(resp map[string]any) string {
+	output, ok := resp["output"].([]any)
+	if !ok || len(output) == 0 {
+		return ""
+	}
+
+	var messages []any
+	for _, item := range output {
+		itemMap, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		itemType, _ := itemMap["type"].(string)
+		role, ok := itemMap["role"].(string)
+		if itemType != "message" || !ok {
+			continue
+		}
+
+		msg := map[string]any{"role": role}
+		switch content := itemMap["content"].(type) {
+		case string:
+			msg["content"] = content
+		case []any:
+			if text := flattenContentParts(content); text != "" {
+				msg["content"] = text
+			} else {
+				b, _ := json.Marshal(content)
+				msg["content"] = string(b)
+			}
+		}
+		if len(msg) > 1 {
+			messages = append(messages, msg)
+		}
+	}
+	if len(messages) == 0 {
+		return ""
+	}
+	return marshalMessages(messages)
 }
 
 // chatToolCall builds a tool_call in the chat-completions format.

--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -244,8 +244,15 @@ func TestRoundTrip_ResponsesAPIStreamingCompleteIsNotError(t *testing.T) {
 func TestRoundTrip_ResponsesCompactAPINonStreamingCompaction(t *testing.T) {
 	responseBody := `{
 		"object": "response.compaction",
-		"output": [{"type": "compaction", "encrypted_content": "gAAAAABencrypted"}],
-		"usage": {"input_tokens": 136, "output_tokens": 617, "total_tokens": 753}
+		"output": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "input_text", "text": "Create a simple landing page for a dog petting cafe."}]
+			},
+			{"type": "compaction", "encrypted_content": "gAAAAABencrypted"}
+		],
+		"usage": {"input_tokens": 139, "output_tokens": 438, "total_tokens": 577}
 	}`
 	client, exporter := newTracedClient(t, []byte(responseBody))
 
@@ -274,6 +281,17 @@ func TestRoundTrip_ResponsesCompactAPINonStreamingCompaction(t *testing.T) {
 	}
 	if span.Status.Code == codes.Error {
 		t.Errorf("span %q should not be errored, got status %v", span.Name, span.Status)
+	}
+
+	var completion string
+	for _, attr := range span.Attributes {
+		if string(attr.Key) == "gen_ai.completion" {
+			completion = attr.Value.AsString()
+		}
+	}
+	wantCompletion := `{"messages":[{"content":"Create a simple landing page for a dog petting cafe.","role":"user"}]}`
+	if completion != wantCompletion {
+		t.Errorf("gen_ai.completion mismatch:\n got: %s\nwant: %s", completion, wantCompletion)
 	}
 }
 
@@ -613,29 +631,33 @@ func TestExtractResponsesCompletion_Compaction(t *testing.T) {
 	body := `{
 		"object": "response.compaction",
 		"output": [
-			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Create a page"}]},
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "input_text", "text": "Create a simple landing page for a dog petting cafe."}]
+			},
 			{"type": "compaction", "encrypted_content": "gAAAAABencrypted"}
 		],
 		"usage": {
-			"input_tokens": 136,
-			"input_tokens_details": {"cached_tokens": 0},
-			"output_tokens": 617,
-			"output_tokens_details": {"reasoning_tokens": 384},
-			"total_tokens": 753
+			"input_tokens": 139,
+			"output_tokens": 438,
+			"output_tokens_details": {"reasoning_tokens": 64},
+			"total_tokens": 577
 		}
 	}`
 	completion, usage := extractResponsesCompletion([]byte(body))
 
-	if completion != "" {
-		t.Errorf("completion should not include compact encrypted content, got %q", completion)
+	wantCompletion := `{"messages":[{"content":"Create a simple landing page for a dog petting cafe.","role":"user"}]}`
+	if completion != wantCompletion {
+		t.Errorf("completion mismatch:\n got: %s\nwant: %s", completion, wantCompletion)
 	}
 	want := usageInfo{
-		InputTokens: 136, OutputTokens: 617, TotalTokens: 753, HasUsage: true,
+		InputTokens: 139, OutputTokens: 438, TotalTokens: 577, HasUsage: true,
 		UsageMetadata: map[string]any{
-			"input_tokens":         136,
-			"output_tokens":        617,
-			"total_tokens":         753,
-			"output_token_details": map[string]any{"reasoning": 384},
+			"input_tokens":         139,
+			"output_tokens":        438,
+			"total_tokens":         577,
+			"output_token_details": map[string]any{"reasoning": 64},
 		},
 	}
 	if !reflect.DeepEqual(usage, want) {
@@ -757,6 +779,22 @@ func TestExtractResponsesOutput_TextAndFunctionCalls(t *testing.T) {
 	}
 	if !strings.Contains(output, "search") {
 		t.Errorf("output should contain function call: %s", output)
+	}
+}
+
+func TestExtractResponsesOutput_UserMessageIgnored(t *testing.T) {
+	resp := map[string]any{
+		"output": []any{
+			map[string]any{
+				"type": "message", "role": "user",
+				"content": []any{map[string]any{"type": "input_text", "text": "Follow-up question"}},
+			},
+		},
+	}
+
+	output := extractResponsesOutput(resp)
+	if output != "" {
+		t.Errorf("normal Responses output should ignore user messages, got %q", output)
 	}
 }
 

--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -241,6 +241,42 @@ func TestRoundTrip_ResponsesAPIStreamingCompleteIsNotError(t *testing.T) {
 	}
 }
 
+func TestRoundTrip_ResponsesCompactAPINonStreamingCompaction(t *testing.T) {
+	responseBody := `{
+		"object": "response.compaction",
+		"output": [{"type": "compaction", "encrypted_content": "gAAAAABencrypted"}],
+		"usage": {"input_tokens": 136, "output_tokens": 617, "total_tokens": 753}
+	}`
+	client, exporter := newTracedClient(t, []byte(responseBody))
+
+	body := `{"model":"gpt-5.1-codex-max","input":[{"role":"user","content":"Create a page"}]}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.openai.com/v1/responses/compact", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	spans := exporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+	span := spans[0]
+	if span.Name != "openai.responses.compact" {
+		t.Errorf("span name = %q, want openai.responses.compact", span.Name)
+	}
+	if span.Status.Code == codes.Error {
+		t.Errorf("span %q should not be errored, got status %v", span.Name, span.Status)
+	}
+}
+
 func TestRoundTrip_ResponsesAPIStreamingIncompleteIsError(t *testing.T) {
 	// A Responses API stream that ends WITHOUT response.completed should be
 	// flagged as incomplete (e.g. cancelled or network failure).
@@ -327,6 +363,7 @@ func TestIsOpenAIEndpoint(t *testing.T) {
 		{"/v1/completions", true},
 		{"/v1/embeddings", true},
 		{"/v1/responses", true},
+		{"/v1/responses/compact", true},
 		{"/openai/deployments/gpt-4/chat/completions", true},
 		{"/v1/models", false},
 		{"/v1/files", false},
@@ -348,6 +385,7 @@ func TestGetSpanName(t *testing.T) {
 		{"/v1/completions", "openai.completion"},
 		{"/v1/embeddings", "openai.embedding"},
 		{"/v1/responses", "openai.responses"},
+		{"/v1/responses/compact", "openai.responses.compact"},
 		{"/v1/models", "openai.request"},
 	}
 	for _, tt := range tests {
@@ -366,6 +404,7 @@ func TestGetOperationName(t *testing.T) {
 		{"/v1/completions", "completion"},
 		{"/v1/embeddings", "embedding"},
 		{"/v1/responses", "responses"},
+		{"/v1/responses/compact", "responses.compact"},
 		{"/v1/models", "request"},
 	}
 	for _, tt := range tests {
@@ -567,6 +606,40 @@ func TestExtractResponsesCompletion_FunctionCall(t *testing.T) {
 
 	if !strings.Contains(completion, "search") {
 		t.Errorf("completion should contain function name: %s", completion)
+	}
+}
+
+func TestExtractResponsesCompletion_Compaction(t *testing.T) {
+	body := `{
+		"object": "response.compaction",
+		"output": [
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Create a page"}]},
+			{"type": "compaction", "encrypted_content": "gAAAAABencrypted"}
+		],
+		"usage": {
+			"input_tokens": 136,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens": 617,
+			"output_tokens_details": {"reasoning_tokens": 384},
+			"total_tokens": 753
+		}
+	}`
+	completion, usage := extractResponsesCompletion([]byte(body))
+
+	if completion != "" {
+		t.Errorf("completion should not include compact encrypted content, got %q", completion)
+	}
+	want := usageInfo{
+		InputTokens: 136, OutputTokens: 617, TotalTokens: 753, HasUsage: true,
+		UsageMetadata: map[string]any{
+			"input_tokens":         136,
+			"output_tokens":        617,
+			"total_tokens":         753,
+			"output_token_details": map[string]any{"reasoning": 384},
+		},
+	}
+	if !reflect.DeepEqual(usage, want) {
+		t.Errorf("usage mismatch:\n got: %#v\nwant: %#v", usage, want)
 	}
 }
 


### PR DESCRIPTION
Adds tracing to calls to the openai responses/compact API


Corresponds to requests of the form:


```shell
 curl -X POST https://api.openai.com/v1/responses/compact \ 
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $OPENAI_API_KEY" \
    -d '{
      "model": "gpt-5.1-codex-max",
      "input": [
        {
          "role": "user",
          "content": "Create a simple landing page for a dog petting café."
        },
        {
          "id": "msg_001",
          "type": "message",
          "status": "completed",
          "content": [
            {
              "type": "output_text",
              "annotations": [],
              "logprobs": [],
              "text": "Below is a single file, ready-to-use landing page for a dog petting café:..."
            }
          ],
          "role": "assistant"
        }
      ]
    }'

```


see https://developers.openai.com/api/reference/resources/responses/methods/compact


For outputs API has:

```json
{
  "id": "resp_001",
  "object": "response.compaction",
  "created_at": 1764967971,
  "output": [
    {
      "id": "msg_000",
      "type": "message",
      "status": "completed",
      "content": [
        {
          "type": "input_text",
          "text": "Create a simple landing page for a dog petting cafe."
        }
      ],
      "role": "user"
    },
    {
      "id": "cmp_001",
      "type": "compaction", // Skipping this for now. non standard message type for OTEL
      "encrypted_content": "gAAAAABpM0Yj-...="
    }
  ],
  "usage": {
    "input_tokens": 139,
    "input_tokens_details": {
      "cached_tokens": 0
    },
    "output_tokens": 438,
    "output_tokens_details": {
      "reasoning_tokens": 64
    },
    "total_tokens": 577
  }
}
```

<img width="2286" height="1868" alt="image" src="https://github.com/user-attachments/assets/e56e5430-6e6e-4d59-9d0d-4ba151f4607b" />
