### PR TITLE
feat: anthropic tier breakdowns

### DIFF
--- a/instrumentation/traceanthropic/traceanthropic.go
+++ b/instrumentation/traceanthropic/traceanthropic.go
@@ -625,6 +625,80 @@ func buildUsageMetadata(usage map[string]interface{}) (usageMetadata map[string]
 	return usageMetadata, totalInput, outputTokens
 }
 
+// anthropicTierKey returns the price-map breakdown key from usage tier fields.
+// Key order: <geo>_<speed|service_tier>. Empty string → base rates.
+func anthropicTierKey(inferenceGeo, serviceTier, speed string) string {
+	var parts []string
+	switch inferenceGeo {
+	case "", "global", "not_available": // neutral, base geo pricing
+	default:
+		parts = append(parts, inferenceGeo) // e.g. "us"
+	}
+	switch speed {
+	case "", "standard": // neutral, base speed pricing
+	default:
+		parts = append(parts, speed) // e.g. "fast"; wins over service_tier
+		return strings.Join(parts, "_")
+	}
+	switch serviceTier {
+	case "", "standard", "priority": // neutral, no priority_* in price map
+	default:
+		parts = append(parts, serviceTier) // e.g. "batch"
+	}
+	return strings.Join(parts, "_")
+}
+
+// applyAnthropicTierPrefixes rewrites usage_metadata token-detail keys so they
+// match the tier-prefixed entries in model_price_map (e.g. us_cache_read,
+// batch, us_fast). Mirrors langsmith/wrappers/_openai.py service_tier prefixing.
+func applyAnthropicTierPrefixes(usageMetadata map[string]any, usage map[string]interface{}) {
+	var geo, tier, speed string
+	if v, ok := usage["inference_geo"].(string); ok {
+		geo = v
+	}
+	if v, ok := usage["service_tier"].(string); ok {
+		tier = v
+	}
+	if v, ok := usage["speed"].(string); ok {
+		speed = v
+	}
+	tierKey := anthropicTierKey(geo, tier, speed)
+	if tierKey == "" || len(usageMetadata) == 0 {
+		return
+	}
+	prefix := tierKey + "_"
+	prefixUsageDetails(usageMetadata, prefix, tierKey, "input_token_details", "input_tokens")
+	prefixUsageDetails(usageMetadata, prefix, tierKey, "output_token_details", "output_tokens")
+}
+
+func prefixUsageDetails(usageMetadata map[string]any, prefix, tierKey, detailsKey, totalKey string) {
+	totalTokens, ok := usageMetadata[totalKey].(int64)
+	if !ok || totalTokens == 0 {
+		return
+	}
+
+	breakdown, ok := usageMetadata[detailsKey].(map[string]any)
+	tierDetails := make(map[string]any)
+
+	var breakdownTokens int64
+	if ok {
+		for key, value := range breakdown {
+			count, ok := value.(int64)
+			if !ok || count <= 0 {
+				continue
+			}
+			tierDetails[prefix+key] = count
+			breakdownTokens += count
+		}
+	}
+
+	// Tokens not in the breakdown use the tier base rate (e.g. us, batch).
+	if baseTokens := totalTokens - breakdownTokens; baseTokens > 0 {
+		tierDetails[tierKey] = baseTokens
+	}
+	usageMetadata[detailsKey] = tierDetails
+}
+
 // setUsageAttributes records token usage on the span. It emits a single
 // langsmith.usage_metadata JSON attribute (the converter's preferred,
 // cost-driving path) plus the flat gen_ai.usage.* attributes that
@@ -632,6 +706,7 @@ func buildUsageMetadata(usage map[string]interface{}) (usageMetadata map[string]
 // recorded as run metadata.
 func setUsageAttributes(span trace.Span, usage map[string]interface{}, parentSpan trace.Span) {
 	usageMetadata, totalInput, outputTokens := buildUsageMetadata(usage)
+	applyAnthropicTierPrefixes(usageMetadata, usage)
 	totalTokens := totalInput + outputTokens
 
 	if len(usageMetadata) > 0 {

--- a/instrumentation/traceanthropic/traceanthropic_test.go
+++ b/instrumentation/traceanthropic/traceanthropic_test.go
@@ -629,17 +629,20 @@ func TestSetUsageAttributes_AllTokenTypes(t *testing.T) {
 	// full comparison also asserts the cache_creation total is dropped in favor
 	// of the ephemeral breakdown and that non-token fields never leak in.
 	// Inclusive input: 2095 + 2051 + 1800 = 5946.
+	// inference_geo=us + speed=fast → us_fast_* tier keys for costing.
 	wantUM := map[string]any{
 		"input_tokens":  float64(5946),
 		"output_tokens": float64(503),
 		"total_tokens":  float64(6449),
 		"input_token_details": map[string]any{
-			"cache_read":                float64(1800),
-			"ephemeral_5m_input_tokens": float64(1951),
-			"ephemeral_1h_input_tokens": float64(100),
+			"us_fast_cache_read":                float64(1800),
+			"us_fast_ephemeral_5m_input_tokens": float64(1951),
+			"us_fast_ephemeral_1h_input_tokens": float64(100),
+			"us_fast":                           float64(2095),
 		},
 		"output_token_details": map[string]any{
-			"reasoning": float64(64),
+			"us_fast_reasoning": float64(64),
+			"us_fast":           float64(439),
 		},
 	}
 	if um := parseUsageMetadata(t, span); !reflect.DeepEqual(um, wantUM) {
@@ -757,6 +760,175 @@ func TestBuildUsageMetadata(t *testing.T) {
 			}
 			if !reflect.DeepEqual(um, tt.wantUM) {
 				t.Errorf("usage_metadata mismatch:\n got: %#v\nwant: %#v", um, tt.wantUM)
+			}
+		})
+	}
+}
+
+func TestAnthropicTierKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		geo   string
+		tier  string
+		speed string
+		want  string
+	}{
+		{
+			name:  "empty when all modifiers neutral",
+			geo:   "global",
+			tier:  "standard",
+			speed: "standard",
+			want:  "",
+		},
+		{
+			name: "us from inference_geo",
+			geo:  "us",
+			want: "us",
+		},
+		{
+			name: "batch from service_tier",
+			tier: "batch",
+			want: "batch",
+		},
+		{
+			name:  "fast from speed",
+			speed: "fast",
+			want:  "fast",
+		},
+		{
+			name: "stacks us and batch",
+			geo:  "us",
+			tier: "batch",
+			want: "us_batch",
+		},
+		{
+			name:  "stacks us and fast",
+			geo:   "us",
+			speed: "fast",
+			want:  "us_fast",
+		},
+		{
+			name:  "fast preempts batch",
+			geo:   "us",
+			tier:  "batch",
+			speed: "fast",
+			want:  "us_fast",
+		},
+		{
+			name: "empty for priority service_tier",
+			tier: "priority",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := anthropicTierKey(tt.geo, tt.tier, tt.speed); got != tt.want {
+				t.Errorf("anthropicTierKey(%q, %q, %q) = %q, want %q", tt.geo, tt.tier, tt.speed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyAnthropicTierPrefixes(t *testing.T) {
+	tests := []struct {
+		name       string
+		geo        string
+		tier       string
+		speed      string
+		metadata   map[string]any
+		wantInput  map[string]any
+		wantOutput map[string]any
+	}{
+		{
+			name: "unchanged when usage modifiers are neutral",
+			metadata: map[string]any{
+				"input_tokens": int64(10),
+				"input_token_details": map[string]any{
+					"cache_read": int64(3),
+				},
+			},
+			wantInput: map[string]any{
+				"cache_read": int64(3),
+			},
+		},
+		{
+			name: "prefixes breakdown and remainder for us geo",
+			geo:  "us",
+			metadata: map[string]any{
+				"input_tokens":  int64(115),
+				"output_tokens": int64(50),
+				"input_token_details": map[string]any{
+					"cache_read":     int64(5),
+					"cache_creation": int64(10),
+				},
+				"output_token_details": map[string]any{
+					"reasoning": int64(10),
+				},
+			},
+			wantInput: map[string]any{
+				"us_cache_read":     int64(5),
+				"us_cache_creation": int64(10),
+				"us":                int64(100),
+			},
+			wantOutput: map[string]any{
+				"us_reasoning": int64(10),
+				"us":           int64(40),
+			},
+		},
+		{
+			name: "prefixes breakdown and remainder for batch",
+			tier: "batch",
+			metadata: map[string]any{
+				"input_tokens": int64(20),
+				"input_token_details": map[string]any{
+					"cache_read": int64(8),
+				},
+			},
+			wantInput: map[string]any{
+				"batch_cache_read": int64(8),
+				"batch":            int64(12),
+			},
+		},
+		{
+			name: "assigns tier key when no token breakdown",
+			geo:  "us",
+			metadata: map[string]any{
+				"output_tokens": int64(25),
+			},
+			wantOutput: map[string]any{
+				"us": int64(25),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usage := map[string]interface{}{}
+			if tt.geo != "" {
+				usage["inference_geo"] = tt.geo
+			}
+			if tt.tier != "" {
+				usage["service_tier"] = tt.tier
+			}
+			if tt.speed != "" {
+				usage["speed"] = tt.speed
+			}
+
+			um := tt.metadata
+			applyAnthropicTierPrefixes(um, usage)
+
+			gotIn, _ := um["input_token_details"].(map[string]any)
+			if tt.wantInput != nil {
+				if !reflect.DeepEqual(gotIn, tt.wantInput) {
+					t.Errorf("input_token_details:\n got %#v\nwant %#v", gotIn, tt.wantInput)
+				}
+			} else if gotIn != nil {
+				t.Errorf("input_token_details: got %#v, want nil", gotIn)
+			}
+			if tt.wantOutput != nil {
+				gotOut, _ := um["output_token_details"].(map[string]any)
+				if !reflect.DeepEqual(gotOut, tt.wantOutput) {
+					t.Errorf("output_token_details:\n got %#v\nwant %#v", gotOut, tt.wantOutput)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
- Adds pricing tier breakdowns for anthropic requests, so that LangSmith can price these tiers more accurately.

## Testing

- new unit tests, extended unit test
- manual tests against langsmith

<img width="582" height="830" alt="image" src="https://github.com/user-attachments/assets/cf6a9f6f-de3e-40a7-a68d-b1660439a15c" />

