### PR TITLE
fix: parse large SSE events for response usage

### DIFF
--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -680,6 +680,21 @@ func TestExtractStreamingResponsesCompletion(t *testing.T) {
 	}
 }
 
+func TestExtractStreamingResponsesCompletion_LargeCompletedEvent(t *testing.T) {
+	sse := `data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"done"}],"payload":"` +
+		strings.Repeat("x", 70*1024) +
+		`"}],"usage":{"input_tokens":7,"output_tokens":3}}}
+`
+	completion, usage := extractStreamingResponsesCompletion([]byte(sse))
+
+	if !strings.Contains(completion, "done") {
+		t.Errorf("completion should contain 'done': %s", completion)
+	}
+	if usage.InputTokens != 7 || usage.OutputTokens != 3 || !usage.HasUsage {
+		t.Errorf("usage = %+v, want input 7 output 3", usage)
+	}
+}
+
 func TestExtractStreamingResponsesCompletion_NoCompletedEvent(t *testing.T) {
 	sse := "data: {\"type\":\"response.created\"}\n"
 	completion, usage := extractStreamingResponsesCompletion([]byte(sse))

--- a/internal/traceutil/sse.go
+++ b/internal/traceutil/sse.go
@@ -7,11 +7,14 @@ import (
 	"strings"
 )
 
+const maxSSELineBytes = 16 << 20
+
 // ParseSSEChunks reads an SSE stream and returns the parsed JSON objects
 // from each "data: " line. It skips event/id/retry/empty lines and stops
 // when it encounters a "data: [DONE]" sentinel.
 func ParseSSEChunks(r io.Reader) ([]map[string]any, error) {
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxSSELineBytes)
 	var chunks []map[string]any
 
 	for scanner.Scan() {

--- a/internal/traceutil/sse_test.go
+++ b/internal/traceutil/sse_test.go
@@ -75,3 +75,19 @@ func TestParseSSEChunks_NoDone(t *testing.T) {
 		t.Fatalf("expected 2 chunks, got %d", len(chunks))
 	}
 }
+
+func TestParseSSEChunks_LargeDataLine(t *testing.T) {
+	input := `data: {"type":"response.completed","payload":"` + strings.Repeat("x", 70*1024) + `","usage":{"input_tokens":1,"output_tokens":2}}
+`
+	chunks, err := ParseSSEChunks(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	usage := chunks[0]["usage"].(map[string]any)
+	if usage["input_tokens"] != float64(1) || usage["output_tokens"] != float64(2) {
+		t.Fatalf("usage mismatch: %v", usage)
+	}
+}


### PR DESCRIPTION
## Description
Increase the bounded SSE scanner buffer so large Responses API terminal events can still be parsed for usage metadata.

## Self-Hosted Release Note
Fixes OpenAI Responses streaming usage extraction for large SSE events.

## Test Plan
- [x] Added large SSE data-line regression for traceutil and traceopenai Responses usage extraction.

Made by [Open SWE](https://openswe.vercel.app/agents/5f64223b-27be-3a81-7e89-1a3862086e2b)