### PR TITLE
feat: parse OpenAI realtime usage events [ENT-1011]

### DIFF
--- a/instrumentation/traceopenai/openaitrace.go
+++ b/instrumentation/traceopenai/openaitrace.go
@@ -237,34 +237,7 @@ func MiddlewareWithTracerProvider(req *http.Request, next MiddlewareNext, tp tra
 		if completion != "" {
 			span.SetAttributes(attribute.String("gen_ai.completion", completion))
 		}
-		if usage.HasUsage {
-			// langsmith.usage_metadata is the converter's preferred,
-			// cost-driving path (token-detail breakdown for cache/reasoning/audio).
-			if len(usage.UsageMetadata) > 0 {
-				if out, err := json.Marshal(usage.UsageMetadata); err == nil {
-					span.SetAttributes(usageMetadataKey.String(string(out)))
-				}
-			}
-			// Flat gen_ai.usage.* attributes drive Thread-list aggregation, which
-			// reads token counts from root spans; input/output propagate to the parent.
-			inputTokens := int64(usage.InputTokens)
-			span.SetAttributes(usageInputTokensKey.Int64(inputTokens))
-			outputTokens := int64(usage.OutputTokens)
-			span.SetAttributes(usageOutputTokensKey.Int64(outputTokens))
-			if usage.TotalTokens > 0 {
-				span.SetAttributes(usageTotalTokensKey.Int64(int64(usage.TotalTokens)))
-			}
-			if parentSpan.SpanContext().IsValid() && parentSpan.IsRecording() {
-				parentSpan.SetAttributes(
-					usageInputTokensKey.Int64(inputTokens),
-					usageOutputTokensKey.Int64(outputTokens),
-				)
-			}
-			// service_tier is a price modifier, not a token count, so it goes in metadata.
-			if usage.ServiceTier != "" {
-				span.SetAttributes(serviceTierKey.String(usage.ServiceTier))
-			}
-		}
+		SetUsageAttributes(span, parentSpan, usage)
 		if resp.StatusCode < 400 && !incompleteStream {
 			span.SetStatus(codes.Ok, "")
 		}
@@ -830,10 +803,10 @@ func extractStreamingCompletion(data []byte) (string, usageInfo) {
 	return marshalMessages([]any{msg}), usage
 }
 
-// usageInfo holds token usage information.
+// UsageInfo holds token usage information.
 // HasUsage distinguishes "provider returned usage with 0 tokens" from
 // "provider omitted the usage field entirely."
-type usageInfo struct {
+type UsageInfo struct {
 	InputTokens  int
 	OutputTokens int
 	TotalTokens  int
@@ -844,6 +817,57 @@ type usageInfo struct {
 	// ServiceTier is the response service tier (e.g. default/flex/priority), a
 	// price modifier recorded as run metadata rather than a token count.
 	ServiceTier string
+}
+
+type usageInfo = UsageInfo
+
+// SetUsageAttributes records OpenAI token usage on span and propagates flat token totals to parentSpan.
+func SetUsageAttributes(span trace.Span, parentSpan trace.Span, usage UsageInfo) {
+	if span == nil || !usage.HasUsage {
+		return
+	}
+	if len(usage.UsageMetadata) > 0 {
+		if out, err := json.Marshal(usage.UsageMetadata); err == nil {
+			span.SetAttributes(usageMetadataKey.String(string(out)))
+		}
+	}
+	inputTokens := int64(usage.InputTokens)
+	span.SetAttributes(usageInputTokensKey.Int64(inputTokens))
+	outputTokens := int64(usage.OutputTokens)
+	span.SetAttributes(usageOutputTokensKey.Int64(outputTokens))
+	if usage.TotalTokens > 0 {
+		span.SetAttributes(usageTotalTokensKey.Int64(int64(usage.TotalTokens)))
+	}
+	if parentSpan != nil && parentSpan.SpanContext().IsValid() && parentSpan.IsRecording() {
+		parentSpan.SetAttributes(
+			usageInputTokensKey.Int64(inputTokens),
+			usageOutputTokensKey.Int64(outputTokens),
+		)
+	}
+	if usage.ServiceTier != "" {
+		span.SetAttributes(serviceTierKey.String(usage.ServiceTier))
+	}
+}
+
+// ExtractRealtimeUsage extracts token usage from a single OpenAI Realtime server event.
+func ExtractRealtimeUsage(event []byte) UsageInfo {
+	var msg map[string]any
+	if err := json.Unmarshal(event, &msg); err != nil {
+		return UsageInfo{}
+	}
+	if response, ok := msg["response"].(map[string]any); ok {
+		if usage := extractResponsesUsage(response); usage.HasUsage {
+			return usage
+		}
+	}
+	if usageMap, ok := msg["usage"].(map[string]any); ok {
+		usage := buildOpenAIUsage(usageMap)
+		if st, ok := msg["service_tier"].(string); ok && st != "" {
+			usage.ServiceTier = st
+		}
+		return usage
+	}
+	return UsageInfo{}
 }
 
 // buildOpenAIUsage parses the two OpenAI usage shapes into usageInfo and the
@@ -887,6 +911,12 @@ func buildOpenAIUsage(usageMap map[string]any) usageInfo {
 		if m, ok := usageMap[key].(map[string]any); ok {
 			return m
 		}
+		if strings.HasSuffix(key, "tokens_details") {
+			alt := strings.Replace(key, "tokens_details", "token_details", 1)
+			if m, ok := usageMap[alt].(map[string]any); ok {
+				return m
+			}
+		}
 		return nil
 	}
 
@@ -915,8 +945,10 @@ func buildOpenAIUsage(usageMap map[string]any) usageInfo {
 		if v := getInt(d, "cached_tokens"); v > 0 {
 			inputTokenDetails["cache_read"] = v
 		}
-		if v := getInt(d, "audio_tokens"); v > 0 {
-			inputTokenDetails["audio"] = v
+		for _, detail := range []string{"audio", "image", "video"} {
+			if v := getInt(d, detail+"_tokens"); v > 0 {
+				inputTokenDetails[detail] = v
+			}
 		}
 	}
 	outputTokenDetails := map[string]any{}
@@ -924,8 +956,10 @@ func buildOpenAIUsage(usageMap map[string]any) usageInfo {
 		if v := getInt(d, "reasoning_tokens"); v > 0 {
 			outputTokenDetails["reasoning"] = v
 		}
-		if v := getInt(d, "audio_tokens"); v > 0 {
-			outputTokenDetails["audio"] = v
+		for _, detail := range []string{"audio", "image", "video"} {
+			if v := getInt(d, detail+"_tokens"); v > 0 {
+				outputTokenDetails[detail] = v
+			}
 		}
 	}
 

--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -756,6 +756,144 @@ func TestExtractResponsesUsage_HasUsageFlag(t *testing.T) {
 	})
 }
 
+func TestExtractRealtimeUsage_ResponseDone(t *testing.T) {
+	event := `{
+		"type":"response.done",
+		"response":{
+			"service_tier":"priority",
+			"usage":{
+				"total_tokens":253,
+				"input_tokens":132,
+				"output_tokens":121,
+				"input_token_details":{
+					"text_tokens":119,
+					"audio_tokens":13,
+					"image_tokens":4,
+					"cached_tokens":64
+				},
+				"output_token_details":{
+					"text_tokens":30,
+					"audio_tokens":91
+				}
+			}
+		}
+	}`
+
+	got := ExtractRealtimeUsage([]byte(event))
+	want := UsageInfo{
+		InputTokens: 132, OutputTokens: 121, TotalTokens: 253, HasUsage: true, ServiceTier: "priority",
+		UsageMetadata: map[string]any{
+			"input_tokens":  132,
+			"output_tokens": 121,
+			"total_tokens":  253,
+			"input_token_details": map[string]any{
+				"cache_read": 64, "audio": 13, "image": 4,
+			},
+			"output_token_details": map[string]any{"audio": 91},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("usage mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestExtractRealtimeUsage_TranscriptionCompleted(t *testing.T) {
+	event := `{
+		"type":"conversation.item.input_audio_transcription.completed",
+		"usage":{
+			"type":"tokens",
+			"total_tokens":26,
+			"input_tokens":17,
+			"input_token_details":{"text_tokens":0,"audio_tokens":17},
+			"output_tokens":9
+		}
+	}`
+
+	got := ExtractRealtimeUsage([]byte(event))
+	want := UsageInfo{
+		InputTokens: 17, OutputTokens: 9, TotalTokens: 26, HasUsage: true,
+		UsageMetadata: map[string]any{
+			"input_tokens":        17,
+			"output_tokens":       9,
+			"total_tokens":        26,
+			"input_token_details": map[string]any{"audio": 17},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("usage mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestExtractRealtimeUsage_NoUsage(t *testing.T) {
+	for _, event := range [][]byte{
+		[]byte(`{"type":"session.created"}`),
+		[]byte(`not-json`),
+	} {
+		if got := ExtractRealtimeUsage(event); got.HasUsage {
+			t.Errorf("expected no usage, got %#v", got)
+		}
+	}
+}
+
+func TestSetUsageAttributes(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	tracer := tp.Tracer("test")
+
+	ctx, parent := tracer.Start(context.Background(), "parent")
+	_, child := tracer.Start(ctx, "child")
+	SetUsageAttributes(child, parent, UsageInfo{
+		InputTokens: 10, OutputTokens: 5, TotalTokens: 15, HasUsage: true, ServiceTier: "flex",
+		UsageMetadata: map[string]any{"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+	})
+	child.End()
+	parent.End()
+
+	spans := exporter.GetSpans()
+	var childSpan, parentSpan tracetest.SpanStub
+	for _, span := range spans {
+		switch span.Name {
+		case "child":
+			childSpan = span
+		case "parent":
+			parentSpan = span
+		}
+	}
+	if got, ok := spanAttrInt64(childSpan, "gen_ai.usage.total_tokens"); !ok || got != 15 {
+		t.Errorf("child total tokens = %d, ok=%v", got, ok)
+	}
+	if got, ok := spanAttrString(childSpan, "langsmith.metadata.service_tier"); !ok || got != "flex" {
+		t.Errorf("child service tier = %q, ok=%v", got, ok)
+	}
+	if got, ok := spanAttrString(childSpan, "langsmith.usage_metadata"); !ok || got == "" {
+		t.Errorf("child usage metadata missing, got %q, ok=%v", got, ok)
+	}
+	if got, ok := spanAttrInt64(parentSpan, "gen_ai.usage.input_tokens"); !ok || got != 10 {
+		t.Errorf("parent input tokens = %d, ok=%v", got, ok)
+	}
+	if got, ok := spanAttrInt64(parentSpan, "gen_ai.usage.output_tokens"); !ok || got != 5 {
+		t.Errorf("parent output tokens = %d, ok=%v", got, ok)
+	}
+}
+
+func spanAttrString(span tracetest.SpanStub, key string) (string, bool) {
+	for _, attr := range span.Attributes {
+		if string(attr.Key) == key {
+			return attr.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func spanAttrInt64(span tracetest.SpanStub, key string) (int64, bool) {
+	for _, attr := range span.Attributes {
+		if string(attr.Key) == key {
+			return attr.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
 func TestExtractResponsesOutput_TextAndFunctionCalls(t *testing.T) {
 	resp := map[string]any{
 		"output": []any{
@@ -1589,10 +1727,14 @@ func TestBuildOpenAIUsage(t *testing.T) {
 				"prompt_tokens_details": map[string]any{
 					"cached_tokens": float64(768),
 					"audio_tokens":  float64(10),
+					"image_tokens":  float64(3),
+					"video_tokens":  float64(2),
 				},
 				"completion_tokens_details": map[string]any{
 					"reasoning_tokens": float64(64),
 					"audio_tokens":     float64(5),
+					"image_tokens":     float64(4),
+					"video_tokens":     float64(1),
 					// Intentionally ignored (priced via the output remainder).
 					"accepted_prediction_tokens": float64(7),
 					"rejected_prediction_tokens": float64(3),
@@ -1601,11 +1743,15 @@ func TestBuildOpenAIUsage(t *testing.T) {
 			want: usageInfo{
 				InputTokens: 1000, OutputTokens: 200, TotalTokens: 1200, HasUsage: true,
 				UsageMetadata: map[string]any{
-					"input_tokens":         1000,
-					"output_tokens":        200,
-					"total_tokens":         1200,
-					"input_token_details":  map[string]any{"cache_read": 768, "audio": 10},
-					"output_token_details": map[string]any{"reasoning": 64, "audio": 5},
+					"input_tokens":  1000,
+					"output_tokens": 200,
+					"total_tokens":  1200,
+					"input_token_details": map[string]any{
+						"cache_read": 768, "audio": 10, "image": 3, "video": 2,
+					},
+					"output_token_details": map[string]any{
+						"reasoning": 64, "audio": 5, "image": 4, "video": 1,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Description
Adds reusable OpenAI Realtime usage parsing helpers to `traceopenai` so downstream WebSocket proxies can map Realtime usage events into the same LangSmith usage attributes as existing OpenAI HTTP/SSE paths.

## Test Plan
- [x] `go test ./instrumentation/traceopenai -count=1`
- [x] `go vet ./instrumentation/traceopenai`

Made by [Open SWE](https://openswe.vercel.app/agents/4563748a-50f2-0f87-16f6-b164395de2df)