### PR TITLE
feat: add sandbox registry creation

### DIFF
--- a/api.md
+++ b/api.md
@@ -498,6 +498,16 @@ Methods:
 - <code title="post /v2/sandboxes/boxes/{name}/start">client.Sandboxes.Boxes.<a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go#SandboxBoxService.Start">Start</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, name <a href="https://pkg.go.dev/builtin#string">string</a>) (\*<a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go">langsmith</a>.<a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go#SandboxBoxStartResponse">SandboxBoxStartResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
 - <code title="post /v2/sandboxes/boxes/{name}/stop">client.Sandboxes.Boxes.<a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go#SandboxBoxService.Stop">Stop</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, name <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code>
 
+## Registries
+
+Response Types:
+
+- <a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go">langsmith</a>.<a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go#SandboxRegistryNewResponse">SandboxRegistryNewResponse</a>
+
+Methods:
+
+- <code title="post /v2/sandboxes/registries">client.Sandboxes.Registries.<a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go#SandboxRegistryService.New">New</a>(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, body <a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go">langsmith</a>.<a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go#SandboxRegistryNewParams">SandboxRegistryNewParams</a>) (\*<a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go">langsmith</a>.<a href="https://pkg.go.dev/github.com/langchain-ai/langsmith-go#SandboxRegistryNewResponse">SandboxRegistryNewResponse</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code>
+
 ## Snapshots
 
 Response Types:

--- a/sandbox.go
+++ b/sandbox.go
@@ -13,9 +13,10 @@ import (
 // automatically. You should not instantiate this service directly, and instead use
 // the [NewSandboxService] method instead.
 type SandboxService struct {
-	Options   []option.RequestOption
-	Boxes     *SandboxBoxService
-	Snapshots *SandboxSnapshotService
+	Options    []option.RequestOption
+	Boxes      *SandboxBoxService
+	Registries *SandboxRegistryService
+	Snapshots  *SandboxSnapshotService
 }
 
 // NewSandboxService generates a new service that applies the given options to each
@@ -25,6 +26,7 @@ func NewSandboxService(opts ...option.RequestOption) (r *SandboxService) {
 	r = &SandboxService{}
 	r.Options = opts
 	r.Boxes = NewSandboxBoxService(opts...)
+	r.Registries = NewSandboxRegistryService(opts...)
 	r.Snapshots = NewSandboxSnapshotService(opts...)
 	return
 }

--- a/sandboxregistry.go
+++ b/sandboxregistry.go
@@ -1,0 +1,85 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package langsmith
+
+import (
+	"context"
+	"net/http"
+	"slices"
+
+	"github.com/langchain-ai/langsmith-go/internal/apijson"
+	"github.com/langchain-ai/langsmith-go/internal/param"
+	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+// SandboxRegistryService contains methods and other services that help with
+// interacting with the langChain API.
+//
+// Note, unlike clients, this service does not read variables from the environment
+// automatically. You should not instantiate this service directly, and instead use
+// the [NewSandboxRegistryService] method instead.
+type SandboxRegistryService struct {
+	Options []option.RequestOption
+}
+
+// NewSandboxRegistryService generates a new service that applies the given options
+// to each request. These options are applied after the parent client's options (if
+// there is one), and before any request-specific options.
+func NewSandboxRegistryService(opts ...option.RequestOption) (r *SandboxRegistryService) {
+	r = &SandboxRegistryService{}
+	r.Options = opts
+	return
+}
+
+// Create a sandbox registry for pulling private images.
+func (r *SandboxRegistryService) New(ctx context.Context, body SandboxRegistryNewParams, opts ...option.RequestOption) (res *SandboxRegistryNewResponse, err error) {
+	opts = slices.Concat(r.Options, opts)
+	path := "v2/sandboxes/registries"
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
+	return res, err
+}
+
+type SandboxRegistryNewResponse struct {
+	ID        string                         `json:"id"`
+	Name      string                         `json:"name"`
+	URL       string                         `json:"url"`
+	CreatedAt string                         `json:"created_at"`
+	CreatedBy string                         `json:"created_by"`
+	UpdatedAt string                         `json:"updated_at"`
+	UpdatedBy string                         `json:"updated_by"`
+	JSON      sandboxRegistryNewResponseJSON `json:"-"`
+}
+
+// sandboxRegistryNewResponseJSON contains the JSON metadata for the struct
+// [SandboxRegistryNewResponse]
+type sandboxRegistryNewResponseJSON struct {
+	ID          apijson.Field
+	Name        apijson.Field
+	URL         apijson.Field
+	CreatedAt   apijson.Field
+	CreatedBy   apijson.Field
+	UpdatedAt   apijson.Field
+	UpdatedBy   apijson.Field
+	raw         string
+	ExtraFields map[string]apijson.Field
+}
+
+func (r *SandboxRegistryNewResponse) UnmarshalJSON(data []byte) (err error) {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r sandboxRegistryNewResponseJSON) RawJSON() string {
+	return r.raw
+}
+
+type SandboxRegistryNewParams struct {
+	Name     param.Field[string] `json:"name" api:"required"`
+	URL      param.Field[string] `json:"url" api:"required"`
+	Username param.Field[string] `json:"username" api:"required"`
+	Password param.Field[string] `json:"password" api:"required"`
+}
+
+func (r SandboxRegistryNewParams) MarshalJSON() (data []byte, err error) {
+	return apijson.MarshalRoot(r)
+}

--- a/sandboxregistry_test.go
+++ b/sandboxregistry_test.go
@@ -1,0 +1,43 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package langsmith_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/internal/testutil"
+	"github.com/langchain-ai/langsmith-go/option"
+)
+
+func TestSandboxRegistryNew(t *testing.T) {
+	t.Skip("Mock server tests are disabled")
+	baseURL := "http://localhost:4010"
+	if envURL, ok := os.LookupEnv("TEST_API_BASE_URL"); ok {
+		baseURL = envURL
+	}
+	if !testutil.CheckTestServer(t, baseURL) {
+		return
+	}
+	client := langsmith.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey("My API Key"),
+		option.WithTenantID("My Tenant ID"),
+	)
+	_, err := client.Sandboxes.Registries.New(context.TODO(), langsmith.SandboxRegistryNewParams{
+		Name:     langsmith.F("name"),
+		URL:      langsmith.F("url"),
+		Username: langsmith.F("username"),
+		Password: langsmith.F("password"),
+	})
+	if err != nil {
+		var apierr *langsmith.Error
+		if errors.As(err, &apierr) {
+			t.Log(string(apierr.DumpRequest(true)))
+		}
+		t.Fatalf("err should be nil: %s", err.Error())
+	}
+}


### PR DESCRIPTION
## Description
Add typed sandbox registry creation under `client.Sandboxes.Registries.New` so callers can create private registries and pass the returned ID to snapshot creation.

## Test Plan
- [x] `git diff --check`
- [ ] `gofmt` and `go test ./...` were not run because Go is not installed in the sandbox.

Made by [Open SWE](https://openswe.vercel.app/agents/d22cdfb4-6120-dde5-1c66-307e27c4d982)