### PR TITLE
feat(sandbox): do not gate dataplane ops on sandbox status

### DIFF
--- a/sandbox_command_methods.go
+++ b/sandbox_command_methods.go
@@ -8,7 +8,7 @@ import (
 
 // Run executes a command and waits for completion.
 func (s *Sandbox) Run(ctx context.Context, body SandboxBoxRunParams, opts ...option.RequestOption) (*SandboxExecutionResult, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -17,7 +17,7 @@ func (s *Sandbox) Run(ctx context.Context, body SandboxBoxRunParams, opts ...opt
 
 // StartCommand starts a streaming command in this sandbox.
 func (s *Sandbox) StartCommand(ctx context.Context, body SandboxCommandStartParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func (s *Sandbox) StartCommand(ctx context.Context, body SandboxCommandStartPara
 // RunWithCallbacks starts a WebSocket command, invokes callbacks for output,
 // and waits for completion.
 func (s *Sandbox) RunWithCallbacks(ctx context.Context, body SandboxCommandStartParams, callbacks SandboxCommandCallbacks, opts ...option.RequestOption) (*SandboxExecutionResult, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (s *Sandbox) RunWithCallbacks(ctx context.Context, body SandboxCommandStart
 
 // ReconnectCommand reconnects to a command stream.
 func (s *Sandbox) ReconnectCommand(ctx context.Context, commandID string, body SandboxCommandReconnectParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}

--- a/sandbox_command_methods_test.go
+++ b/sandbox_command_methods_test.go
@@ -54,17 +54,27 @@ func TestSandboxCommandWrapperRunUsesCurrentDataplaneURL(t *testing.T) {
 	}
 }
 
-func TestSandboxCommandWrapperRejectsNotReadySandbox(t *testing.T) {
+func TestSandboxCommandWrapperDoesNotGateOnStatus(t *testing.T) {
+	// A non-ready box is NOT rejected client-side: the platform resumes a
+	// stopped box when the dataplane request arrives. (The call still errors
+	// here only because the test client has no configured base URL.)
 	sandbox := &Sandbox{
 		Name:         "box-a",
 		Status:       "starting",
 		DataplaneURL: "https://sandbox.example",
 		boxes:        NewSandboxBoxService(),
 	}
-
 	_, err := sandbox.Run(context.Background(), SandboxBoxRunParams{Command: String("echo ok")})
 	var notReady *SandboxNotReadyError
-	if !errors.As(err, &notReady) {
-		t.Fatalf("expected SandboxNotReadyError, got %T: %v", err, err)
+	if errors.As(err, &notReady) {
+		t.Fatalf("client must not gate on status, but got SandboxNotReadyError: %v", err)
+	}
+
+	// A missing dataplane URL is still rejected client-side, regardless of status.
+	noURL := &Sandbox{Name: "box-a", Status: "starting", boxes: NewSandboxBoxService()}
+	_, err = noURL.Run(context.Background(), SandboxBoxRunParams{Command: String("echo ok")})
+	var notConfigured *SandboxDataplaneNotConfiguredError
+	if !errors.As(err, &notConfigured) {
+		t.Fatalf("expected SandboxDataplaneNotConfiguredError, got %T: %v", err, err)
 	}
 }

--- a/sandbox_commands.go
+++ b/sandbox_commands.go
@@ -102,7 +102,7 @@ func (r *SandboxBoxService) Run(ctx context.Context, name string, body SandboxBo
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (r *SandboxBoxService) StartCommand(ctx context.Context, name string, body 
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (r *SandboxBoxService) StartCommandWithCallbacks(ctx context.Context, name 
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (r *SandboxBoxService) ReconnectCommand(ctx context.Context, name string, c
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}

--- a/sandbox_files.go
+++ b/sandbox_files.go
@@ -18,7 +18,7 @@ func (r *SandboxBoxService) ReadFile(ctx context.Context, name string, path stri
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (r *SandboxBoxService) WriteFile(ctx context.Context, name string, path str
 	if err != nil {
 		return err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (r *SandboxBoxService) WriteFileWithDataplaneURL(ctx context.Context, datap
 
 // ReadFile reads a file from this sandbox.
 func (s *Sandbox) ReadFile(ctx context.Context, path string, opts ...option.RequestOption) ([]byte, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (s *Sandbox) ReadFile(ctx context.Context, path string, opts ...option.Requ
 
 // WriteFile writes bytes to a file in this sandbox.
 func (s *Sandbox) WriteFile(ctx context.Context, path string, content []byte, opts ...option.RequestOption) error {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return err
 	}

--- a/sandbox_internal.go
+++ b/sandbox_internal.go
@@ -34,10 +34,7 @@ func sandboxFieldValue[T any](field param.Field[T], fallback T) T {
 	return fallback
 }
 
-func requireSandboxDataplaneURL(name string, status string, dataplaneURL string) (string, error) {
-	if status != "" && status != "ready" {
-		return "", &SandboxNotReadyError{SandboxName: name, Status: status}
-	}
+func requireSandboxDataplaneURL(name string, dataplaneURL string) (string, error) {
 	if dataplaneURL == "" {
 		return "", &SandboxDataplaneNotConfiguredError{SandboxName: name}
 	}

--- a/sandbox_internal_test.go
+++ b/sandbox_internal_test.go
@@ -61,7 +61,10 @@ func TestSandboxInternalURLHelpers(t *testing.T) {
 }
 
 func TestRequireSandboxDataplaneURL(t *testing.T) {
-	got, err := requireSandboxDataplaneURL("box-a", "ready", "https://sandbox.example")
+	// The client does not gate on sandbox status (there is no status arg): any
+	// box with a dataplane URL proceeds, and the platform resumes a stopped box
+	// when the dataplane request arrives.
+	got, err := requireSandboxDataplaneURL("box-a", "https://sandbox.example")
 	if err != nil {
 		t.Fatalf("requireSandboxDataplaneURL returned error: %v", err)
 	}
@@ -69,13 +72,8 @@ func TestRequireSandboxDataplaneURL(t *testing.T) {
 		t.Fatalf("unexpected dataplane URL: %q", got)
 	}
 
-	var notReady *SandboxNotReadyError
-	if _, err := requireSandboxDataplaneURL("box-a", "starting", "https://sandbox.example"); !errors.As(err, &notReady) {
-		t.Fatalf("expected SandboxNotReadyError, got %T: %v", err, err)
-	}
-
 	var notConfigured *SandboxDataplaneNotConfiguredError
-	if _, err := requireSandboxDataplaneURL("box-a", "ready", ""); !errors.As(err, &notConfigured) {
+	if _, err := requireSandboxDataplaneURL("box-a", ""); !errors.As(err, &notConfigured) {
 		t.Fatalf("expected SandboxDataplaneNotConfiguredError, got %T: %v", err, err)
 	}
 }

--- a/sandbox_tunnel.go
+++ b/sandbox_tunnel.go
@@ -103,7 +103,7 @@ func (r *SandboxBoxService) Tunnel(ctx context.Context, name string, remotePort 
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (r *SandboxBoxService) OpenTunnelStream(ctx context.Context, name string, r
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (r *SandboxBoxService) TunnelWithDataplaneURL(ctx context.Context, dataplan
 
 // OpenTunnelStream opens a single TCP stream to a port inside this sandbox.
 func (s *Sandbox) OpenTunnelStream(ctx context.Context, remotePort int, opts ...option.RequestOption) (*SandboxTunnelStream, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (s *Sandbox) OpenTunnelStream(ctx context.Context, remotePort int, opts ...
 
 // Tunnel opens a TCP tunnel from localhost to a port inside this sandbox.
 func (s *Sandbox) Tunnel(ctx context.Context, remotePort int, params SandboxTunnelParams, opts ...option.RequestOption) (*SandboxTunnel, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

A stopped LangSmith sandbox is resumed **by the platform** when a dataplane request arrives, and its dataplane URL is stable across stop/resume. But the SDK refused client-side on any non-`ready` status (`SandboxNotReadyError`) before sending the request, so callers had to manage start/stop themselves and a box that idle-stopped between turns became a hard failure.

This makes the Go client stop gating dataplane operations on lifecycle status.

## What changed

- `requireSandboxDataplaneURL` no longer inspects `status` — the `status` argument is removed entirely. It now requires only that a `dataplane_url` is present, returning `SandboxDataplaneNotConfiguredError` otherwise.
- All 16 call sites (commands: run/start/reconnect; files: read/write; tunnel) updated to drop the `status` argument. Since it's the single chokepoint, every dataplane op is covered.
- A genuinely not-ready box still surfaces a not-ready error from the server's response; the `SandboxNotReadyError` type is retained.

## Test plan

- [x] `go build ./...` and `go vet .` pass; `gofmt` clean.
- [x] Root-package tests pass (`go test .`), including the updated `TestSandboxCommandWrapperDoesNotGateOnStatus` (a non-ready box is not rejected client-side; a missing dataplane URL still raises `SandboxDataplaneNotConfiguredError`) and `TestRequireSandboxDataplaneURL`.
