### PR TITLE
fix: allow stopped sandboxes to reach dataplane

### DIFF
--- a/sandbox_command_methods.go
+++ b/sandbox_command_methods.go
@@ -8,7 +8,7 @@ import (
 
 // Run executes a command and waits for completion.
 func (s *Sandbox) Run(ctx context.Context, body SandboxBoxRunParams, opts ...option.RequestOption) (*SandboxExecutionResult, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -17,7 +17,7 @@ func (s *Sandbox) Run(ctx context.Context, body SandboxBoxRunParams, opts ...opt
 
 // StartCommand starts a streaming command in this sandbox.
 func (s *Sandbox) StartCommand(ctx context.Context, body SandboxCommandStartParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func (s *Sandbox) StartCommand(ctx context.Context, body SandboxCommandStartPara
 // RunWithCallbacks starts a WebSocket command, invokes callbacks for output,
 // and waits for completion.
 func (s *Sandbox) RunWithCallbacks(ctx context.Context, body SandboxCommandStartParams, callbacks SandboxCommandCallbacks, opts ...option.RequestOption) (*SandboxExecutionResult, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (s *Sandbox) RunWithCallbacks(ctx context.Context, body SandboxCommandStart
 
 // ReconnectCommand reconnects to a command stream.
 func (s *Sandbox) ReconnectCommand(ctx context.Context, commandID string, body SandboxCommandReconnectParams, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}

--- a/sandbox_command_methods_test.go
+++ b/sandbox_command_methods_test.go
@@ -3,7 +3,6 @@ package langsmith
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -54,17 +53,45 @@ func TestSandboxCommandWrapperRunUsesCurrentDataplaneURL(t *testing.T) {
 	}
 }
 
-func TestSandboxCommandWrapperRejectsNotReadySandbox(t *testing.T) {
+func TestSandboxCommandWrapperAllowsStoppedSandbox(t *testing.T) {
+	var gotPayload map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/execute" {
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"stdout":    "ok",
+			"stderr":    "",
+			"exit_code": 0,
+		})
+	}))
+	defer srv.Close()
+
 	sandbox := &Sandbox{
 		Name:         "box-a",
-		Status:       "starting",
-		DataplaneURL: "https://sandbox.example",
-		boxes:        NewSandboxBoxService(),
+		Status:       "stopped",
+		DataplaneURL: srv.URL,
+		boxes: NewSandboxBoxService(
+			option.WithBaseURL("http://control-plane.test"),
+			option.WithAPIKey("test-api-key"),
+			option.WithMaxRetries(0),
+		),
 	}
 
-	_, err := sandbox.Run(context.Background(), SandboxBoxRunParams{Command: String("echo ok")})
-	var notReady *SandboxNotReadyError
-	if !errors.As(err, &notReady) {
-		t.Fatalf("expected SandboxNotReadyError, got %T: %v", err, err)
+	result, err := sandbox.Run(context.Background(), SandboxBoxRunParams{Command: String("echo ok")})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Stdout != "ok" || !result.Success() {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if gotPayload["command"] != "echo ok" {
+		t.Fatalf("unexpected command payload: %#v", gotPayload["command"])
 	}
 }

--- a/sandbox_commands.go
+++ b/sandbox_commands.go
@@ -102,7 +102,7 @@ func (r *SandboxBoxService) Run(ctx context.Context, name string, body SandboxBo
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (r *SandboxBoxService) StartCommand(ctx context.Context, name string, body 
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (r *SandboxBoxService) StartCommandWithCallbacks(ctx context.Context, name 
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (r *SandboxBoxService) ReconnectCommand(ctx context.Context, name string, c
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}

--- a/sandbox_files.go
+++ b/sandbox_files.go
@@ -18,7 +18,7 @@ func (r *SandboxBoxService) ReadFile(ctx context.Context, name string, path stri
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (r *SandboxBoxService) WriteFile(ctx context.Context, name string, path str
 	if err != nil {
 		return err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (r *SandboxBoxService) WriteFileWithDataplaneURL(ctx context.Context, datap
 
 // ReadFile reads a file from this sandbox.
 func (s *Sandbox) ReadFile(ctx context.Context, path string, opts ...option.RequestOption) ([]byte, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (s *Sandbox) ReadFile(ctx context.Context, path string, opts ...option.Requ
 
 // WriteFile writes bytes to a file in this sandbox.
 func (s *Sandbox) WriteFile(ctx context.Context, path string, content []byte, opts ...option.RequestOption) error {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return err
 	}

--- a/sandbox_internal.go
+++ b/sandbox_internal.go
@@ -34,10 +34,7 @@ func sandboxFieldValue[T any](field param.Field[T], fallback T) T {
 	return fallback
 }
 
-func requireSandboxDataplaneURL(name string, status string, dataplaneURL string) (string, error) {
-	if status != "" && status != "ready" {
-		return "", &SandboxNotReadyError{SandboxName: name, Status: status}
-	}
+func requireSandboxDataplaneURL(name string, dataplaneURL string) (string, error) {
 	if dataplaneURL == "" {
 		return "", &SandboxDataplaneNotConfiguredError{SandboxName: name}
 	}

--- a/sandbox_internal_test.go
+++ b/sandbox_internal_test.go
@@ -61,7 +61,7 @@ func TestSandboxInternalURLHelpers(t *testing.T) {
 }
 
 func TestRequireSandboxDataplaneURL(t *testing.T) {
-	got, err := requireSandboxDataplaneURL("box-a", "ready", "https://sandbox.example")
+	got, err := requireSandboxDataplaneURL("box-a", "https://sandbox.example")
 	if err != nil {
 		t.Fatalf("requireSandboxDataplaneURL returned error: %v", err)
 	}
@@ -69,13 +69,8 @@ func TestRequireSandboxDataplaneURL(t *testing.T) {
 		t.Fatalf("unexpected dataplane URL: %q", got)
 	}
 
-	var notReady *SandboxNotReadyError
-	if _, err := requireSandboxDataplaneURL("box-a", "starting", "https://sandbox.example"); !errors.As(err, &notReady) {
-		t.Fatalf("expected SandboxNotReadyError, got %T: %v", err, err)
-	}
-
 	var notConfigured *SandboxDataplaneNotConfiguredError
-	if _, err := requireSandboxDataplaneURL("box-a", "ready", ""); !errors.As(err, &notConfigured) {
+	if _, err := requireSandboxDataplaneURL("box-a", ""); !errors.As(err, &notConfigured) {
 		t.Fatalf("expected SandboxDataplaneNotConfiguredError, got %T: %v", err, err)
 	}
 }

--- a/sandbox_tunnel.go
+++ b/sandbox_tunnel.go
@@ -103,7 +103,7 @@ func (r *SandboxBoxService) Tunnel(ctx context.Context, name string, remotePort 
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (r *SandboxBoxService) OpenTunnelStream(ctx context.Context, name string, r
 	if err != nil {
 		return nil, err
 	}
-	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.Status, box.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(box.Name, box.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (r *SandboxBoxService) TunnelWithDataplaneURL(ctx context.Context, dataplan
 
 // OpenTunnelStream opens a single TCP stream to a port inside this sandbox.
 func (s *Sandbox) OpenTunnelStream(ctx context.Context, remotePort int, opts ...option.RequestOption) (*SandboxTunnelStream, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (s *Sandbox) OpenTunnelStream(ctx context.Context, remotePort int, opts ...
 
 // Tunnel opens a TCP tunnel from localhost to a port inside this sandbox.
 func (s *Sandbox) Tunnel(ctx context.Context, remotePort int, params SandboxTunnelParams, opts ...option.RequestOption) (*SandboxTunnel, error) {
-	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.Status, s.DataplaneURL)
+	dataplaneURL, err := requireSandboxDataplaneURL(s.Name, s.DataplaneURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Remove the client-side sandbox status gate from dataplane convenience helpers so stopped/idle sandboxes with a dataplane URL can auto-resume via the platform. Missing dataplane URLs still fail locally.

## Test Plan
- [x] `PATH=/usr/local/go/bin:$PATH go -C /langsmith-go test . -run 'TestRequireSandboxDataplaneURL|TestSandboxCommandWrapper' -count=1 -v`
- [x] `PATH=/usr/local/go/bin:$PATH /langsmith-go/scripts/lint`

Made by [Open SWE](https://openswe.vercel.app/agents/a4bb18d2-6aa8-f0e2-de8c-24d699c047f6)