### PR TITLE
test(auth): failing integration test for OAuth-profile X-User-Id 403

### DIFF
--- a/integration/oauth_profile_test.go
+++ b/integration/oauth_profile_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/langchain-ai/langsmith-go"
+)
+
+// oauthProfileName is the config profile the OAuth integration test uses. It
+// must be an OAuth-logged-in profile (`langsmith auth login`), not API-key.
+func oauthProfileName() string {
+	if p := os.Getenv("LANGSMITH_OAUTH_PROFILE"); p != "" {
+		return p
+	}
+	return "dev"
+}
+
+// TestOAuthProfile_AuthenticatedRequest exercises the OAuth-bearer auth path
+// against the real backend — the one mode `langsmith auth login` produces and
+// the only one no other integration test covers (the rest use API keys).
+//
+// langsmith-go sends an X-User-Id header derived from the access-token JWT
+// `sub`. The backend rejects the request with 403 when that id does not match
+// the user it resolves from the same token, so a regression there is invisible
+// to API-key auth and to the httptest-mocked unit tests.
+func TestOAuthProfile_AuthenticatedRequest(t *testing.T) {
+	profile := oauthProfileName()
+	requireOAuthProfile(t, profile)
+
+	// The profile is the only credential source: clear env so a stray
+	// LANGSMITH_API_KEY/ENDPOINT can't mask the OAuth path under test.
+	for _, k := range []string{"LANGSMITH_API_KEY", "LANGSMITH_ENDPOINT", "LANGSMITH_TENANT_ID", "LANGSMITH_WORKSPACE_ID"} {
+		if v, ok := os.LookupEnv(k); ok {
+			os.Unsetenv(k)
+			t.Cleanup(func() { os.Setenv(k, v) })
+		}
+	}
+
+	client := langsmith.NewClient(langsmith.WithProfile(profile))
+
+	// Hit a smith-go /v2/sandboxes route — those run under the auth middleware
+	// that compares X-User-Id against the user resolved from the token, so the
+	// mismatch surfaces here as a 403 (the original report was this same call).
+	if _, err := client.Sandboxes.Boxes.List(context.Background(), langsmith.SandboxBoxListParams{}); err != nil {
+		var apiErr *langsmith.Error
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 403 {
+			t.Fatalf("OAuth-profile request was forbidden (403) — likely the X-User-Id mismatch regression: %v", err)
+		}
+		t.Fatalf("OAuth-profile request failed: %v", err)
+	}
+}
+
+// requireOAuthProfile skips unless profile exists and carries an OAuth access
+// token. API-key profiles don't exercise the X-User-Id path, so they're skipped.
+func requireOAuthProfile(t *testing.T, profile string) {
+	t.Helper()
+	path := os.Getenv("LANGSMITH_CONFIG_FILE")
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skipf("cannot resolve home dir: %v", err)
+		}
+		path = filepath.Join(home, ".langsmith", "config.json")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("no langsmith config at %s; run `langsmith auth login --profile %s`", path, profile)
+	}
+	var cfg struct {
+		Profiles map[string]struct {
+			OAuth struct {
+				AccessToken string `json:"access_token"`
+			} `json:"oauth"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Skipf("cannot parse %s: %v", path, err)
+	}
+	p, ok := cfg.Profiles[profile]
+	if !ok {
+		t.Skipf("profile %q not found in %s", profile, path)
+	}
+	if p.OAuth.AccessToken == "" {
+		t.Skipf("profile %q has no OAuth access token (API-key profiles don't exercise this path); run `langsmith auth login --profile %s`", profile, profile)
+	}
+}

--- a/integration/oauth_profile_test.go
+++ b/integration/oauth_profile_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +20,7 @@ func oauthProfileName() string {
 	if p := os.Getenv("LANGSMITH_OAUTH_PROFILE"); p != "" {
 		return p
 	}
-	return "dev"
+	return "default"
 }
 
 // TestOAuthProfile_AuthenticatedRequest exercises the OAuth-bearer auth path
@@ -71,7 +72,7 @@ func requireOAuthProfile(t *testing.T, profile string) {
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Skipf("no langsmith config at %s; run `langsmith auth login --profile %s`", path, profile)
+		t.Skipf("no langsmith config at %s; %s", path, loginHint(profile))
 	}
 	var cfg struct {
 		Profiles map[string]struct {
@@ -85,9 +86,14 @@ func requireOAuthProfile(t *testing.T, profile string) {
 	}
 	p, ok := cfg.Profiles[profile]
 	if !ok {
-		t.Skipf("profile %q not found in %s", profile, path)
+		t.Skipf("profile %q not found in %s; %s", profile, path, loginHint(profile))
 	}
 	if p.OAuth.AccessToken == "" {
-		t.Skipf("profile %q has no OAuth access token (API-key profiles don't exercise this path); run `langsmith auth login --profile %s`", profile, profile)
+		t.Skipf("profile %q has no OAuth access token (API-key profiles don't exercise this path); %s", profile, loginHint(profile))
 	}
+}
+
+// loginHint is the command to create the OAuth profile this test needs.
+func loginHint(profile string) string {
+	return fmt.Sprintf("run `langsmith auth login --profile %s`", profile)
 }


### PR DESCRIPTION
## Problem

OAuth-profile requests (`langsmith auth login`) are rejected with **403** by the backend. `WithProfile` auth sends an `X-User-Id` header derived from the access-token JWT `sub` (added in #98). The backend's auth middleware returns 403 when `X-User-Id` doesn't equal the user it resolves from the same token — and the AS `sub` does not match the resolved `ls_user_id`, so the call fails.

Reproduced live with a fresh OAuth login on **both dev and prod** (it is not environment-specific):

```
GET https://api.smith.langchain.com/v2/sandboxes/boxes:     403 Forbidden
GET https://dev.api.smith.langchain.com/v2/sandboxes/boxes: 403 Forbidden
  x_user_id (token sub)   != auth_user_id (resolved ls_user_id)
```

## Why nothing caught it

- The existing integration tests authenticate with `WithAPIKey` — the API-key path strips `Authorization`/`X-User-Id`, so it never exercises this.
- The unit tests use an `httptest` mock that records the header but does no identity resolution, so they pass regardless.

This PR adds the missing coverage: an integration test that uses `WithProfile` (the OAuth-bearer path) and hits `GET /v2/sandboxes/boxes`, which runs under the auth middleware that enforces the `X-User-Id` check. It **fails (403)** against a real backend today, and skips unless an OAuth-logged-in profile is present (so API-key-only CI is unaffected). Defaults to the `default` (production) profile; override with `LANGSMITH_OAUTH_PROFILE`.

This PR intentionally contains only the failing test — no fix — to capture the regression.

## Test Plan
- [x] `go test -tags integration -run TestOAuthProfile_AuthenticatedRequest ./integration/` fails with 403 against prod and dev using an OAuth profile
- [x] Skips cleanly when no OAuth profile is configured