### PR TITLE
chore: update release-please to 5.0.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updating due to node 20 deprecation, and attempt to fix 

- `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`

- `❯ commit could not be parsed: 8f5193dfda044190a8570844ecb0ab3995499450 openai tier fanout (#137)`

- https://github.com/langchain-ai/langsmith-go/actions/runs/28356628687/job/84001850760#step:2:54