### PR TITLE
chore: deprecated Emit() to String()

### DIFF
--- a/instrumentation/tracegemini/tracegemini_test.go
+++ b/instrumentation/tracegemini/tracegemini_test.go
@@ -110,7 +110,7 @@ func getSpanAttr(spans tracetest.SpanStubs, key string) (string, bool) {
 	for _, s := range spans {
 		for _, attr := range s.Attributes {
 			if string(attr.Key) == key {
-				return attr.Value.Emit(), true
+				return attr.Value.String(), true
 			}
 		}
 	}

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -118,7 +118,7 @@ func getSpanAttr(spans tracetest.SpanStubs, key string) (string, bool) {
 	for _, s := range spans {
 		for _, attr := range s.Attributes {
 			if string(attr.Key) == key {
-				return attr.Value.Emit(), true
+				return attr.Value.String(), true
 			}
 		}
 	}


### PR DESCRIPTION
Golangci-lint notes a deprecation in methods in otel libraries.

```
 util/trace.go:242:34: SA1019: attr.Value.Emit is deprecated: Use [Value.String] instead. (staticcheck)
  			span.SetTag(string(attr.Key), attr.Value.Emit())
```

Folowup: add golangci-lint to this repo