### PR TITLE
fix(sandbox): surface HTTP status when the command WebSocket upgrade is refused

### DIFF
--- a/sandbox_errors.go
+++ b/sandbox_errors.go
@@ -36,6 +36,9 @@ func (e *SandboxNotReadyError) Error() string {
 // cannot be established or is interrupted unexpectedly.
 type SandboxConnectionError struct {
 	Message string
+	// StatusCode is the HTTP status the server returned when it refused the
+	// WebSocket upgrade, or 0 when the failure was not an HTTP response.
+	StatusCode int
 }
 
 func (e *SandboxConnectionError) Error() string {

--- a/sandbox_internal.go
+++ b/sandbox_internal.go
@@ -1,11 +1,18 @@
 package langsmith
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"crypto/tls"
+	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/langchain-ai/langsmith-go/internal/param"
@@ -107,19 +114,131 @@ func dialSandboxWebSocketURL(ctx context.Context, wsURL string, opts ...option.R
 	}
 	ch := make(chan dialResult, 1)
 	go func() {
-		ws, err := websocket.DialConfig(config)
+		ws, err := dialSandboxWebSocketConfig(ctx, config)
 		ch <- dialResult{ws: ws, err: err}
 	}()
 
 	select {
 	case res := <-ch:
 		if res.err != nil {
-			return nil, &SandboxConnectionError{Message: fmt.Sprintf("langsmith: failed to connect to sandbox command WebSocket: %v", res.err)}
+			return nil, res.err
 		}
 		return res.ws, nil
 	case <-ctx.Done():
+		go func() {
+			if res := <-ch; res.ws != nil {
+				_ = res.ws.Close()
+			}
+		}()
 		return nil, ctx.Err()
 	}
+}
+
+// dialSandboxWebSocketConfig handshakes over a connection that records the
+// server's reply, so a refused upgrade reports its HTTP status and body rather
+// than websocket.ErrBadStatus, which drops both.
+func dialSandboxWebSocketConfig(ctx context.Context, config *websocket.Config) (*websocket.Conn, error) {
+	conn, err := dialSandboxWebSocketTransport(ctx, config)
+	if err != nil {
+		return nil, &SandboxConnectionError{Message: sandboxWebSocketDialErrorf("%v", err)}
+	}
+	recorder := &sandboxHandshakeRecorder{Conn: conn}
+	ws, err := websocket.NewClient(config, recorder)
+	if err != nil {
+		_ = conn.Close()
+		status, detail := recorder.handshakeResponse()
+		if detail == "" {
+			return nil, &SandboxConnectionError{Message: sandboxWebSocketDialErrorf("%v", err)}
+		}
+		return nil, &SandboxConnectionError{
+			Message:    sandboxWebSocketDialErrorf("%s", detail),
+			StatusCode: status,
+		}
+	}
+	recorder.stop()
+	return ws, nil
+}
+
+func sandboxWebSocketDialErrorf(format string, args ...any) string {
+	return "langsmith: failed to connect to sandbox command WebSocket: " + fmt.Sprintf(format, args...)
+}
+
+func dialSandboxWebSocketTransport(ctx context.Context, config *websocket.Config) (net.Conn, error) {
+	if config.Location == nil {
+		return nil, errors.New("missing WebSocket URL")
+	}
+	dialer := config.Dialer
+	if dialer == nil {
+		dialer = &net.Dialer{}
+	}
+	host := config.Location.Host
+	switch config.Location.Scheme {
+	case "ws":
+		if config.Location.Port() == "" {
+			host = net.JoinHostPort(host, "80")
+		}
+		return dialer.DialContext(ctx, "tcp", host)
+	case "wss":
+		if config.Location.Port() == "" {
+			host = net.JoinHostPort(host, "443")
+		}
+		return (&tls.Dialer{NetDialer: dialer, Config: config.TlsConfig}).DialContext(ctx, "tcp", host)
+	default:
+		return nil, fmt.Errorf("unsupported WebSocket URL scheme %q", config.Location.Scheme)
+	}
+}
+
+const (
+	sandboxHandshakeRecordLimitBytes = 8 << 10
+	sandboxHandshakeDetailMaxBytes   = 512
+)
+
+type sandboxHandshakeRecorder struct {
+	net.Conn
+
+	mu      sync.Mutex
+	buf     bytes.Buffer
+	stopped bool
+}
+
+func (r *sandboxHandshakeRecorder) Read(p []byte) (int, error) {
+	n, err := r.Conn.Read(p)
+	if n > 0 {
+		r.mu.Lock()
+		if room := sandboxHandshakeRecordLimitBytes - r.buf.Len(); !r.stopped && room > 0 {
+			r.buf.Write(p[:min(n, room)])
+		}
+		r.mu.Unlock()
+	}
+	return n, err
+}
+
+func (r *sandboxHandshakeRecorder) stop() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stopped = true
+	r.buf.Reset()
+}
+
+// handshakeResponse returns the status code and a "<status>: <body>" summary of
+// the recorded reply, or (0, "") when it was not a readable HTTP response.
+func (r *sandboxHandshakeRecorder) handshakeResponse() (int, string) {
+	r.mu.Lock()
+	raw := bytes.Clone(r.buf.Bytes())
+	r.mu.Unlock()
+
+	resp, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(raw)), nil)
+	if err != nil {
+		return 0, ""
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, sandboxHandshakeDetailMaxBytes))
+	detail := strings.Join(strings.Fields(string(body)), " ")
+	if detail == "" {
+		return resp.StatusCode, resp.Status
+	}
+	return resp.StatusCode, resp.Status + ": " + detail
 }
 
 func sandboxWebSocketOrigin(wsURL string) (string, error) {

--- a/sandbox_internal_test.go
+++ b/sandbox_internal_test.go
@@ -3,6 +3,10 @@ package langsmith
 import (
 	"context"
 	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,6 +81,53 @@ func TestRequireSandboxDataplaneURL(t *testing.T) {
 	var notConfigured *SandboxDataplaneNotConfiguredError
 	if _, err := requireSandboxDataplaneURL("box-a", "ready", ""); !errors.As(err, &notConfigured) {
 		t.Fatalf("expected SandboxDataplaneNotConfiguredError, got %T: %v", err, err)
+	}
+}
+
+func TestDialSandboxWebSocketURLRejectedUpgrade(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":{"error":"Forbidden","message":"insufficient sandbox access"}}`))
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/execute/ws"
+	_, err := dialSandboxWebSocketURL(context.Background(), wsURL, option.WithAPIKey("test-api-key"))
+
+	var connErr *SandboxConnectionError
+	if !errors.As(err, &connErr) {
+		t.Fatalf("expected SandboxConnectionError, got %T: %v", err, err)
+	}
+	if connErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", connErr.StatusCode)
+	}
+	if !strings.Contains(connErr.Message, "403 Forbidden") {
+		t.Fatalf("expected status text in error, got %q", connErr.Message)
+	}
+	if !strings.Contains(connErr.Message, "insufficient sandbox access") {
+		t.Fatalf("expected response body in error, got %q", connErr.Message)
+	}
+}
+
+func TestDialSandboxWebSocketURLUnreachable(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	_, err = dialSandboxWebSocketURL(context.Background(), "ws://"+addr+"/execute/ws")
+
+	var connErr *SandboxConnectionError
+	if !errors.As(err, &connErr) {
+		t.Fatalf("expected SandboxConnectionError, got %T: %v", err, err)
+	}
+	if connErr.StatusCode != 0 {
+		t.Fatalf("expected no status code for transport failure, got %d", connErr.StatusCode)
 	}
 }
 


### PR DESCRIPTION
`websocket.DialConfig` throws away the handshake response, so every refused upgrade came back as:

```
langsmith: failed to connect to sandbox command WebSocket: websocket.Dial wss://.../execute/ws: bad status
```

401, 403, 404 and 503 were indistinguishable — `langsmith sandbox console` gave the user nothing to act on.

The dial now runs the handshake over a connection that records the server's reply, so a refused upgrade reports what the server actually said, and `SandboxConnectionError` carries the status code for callers that want to branch on it (e.g. skip reconnect on 4xx):

```
langsmith: failed to connect to sandbox command WebSocket: 403 Forbidden: {"detail":{"error":"Forbidden","message":"insufficient sandbox access"}}
```

Transport-level failures are unchanged apart from now honoring the caller's context during connect, and a WebSocket that completes after the context is cancelled is closed instead of leaked.

## Test Plan

- [x] `go test ./...` (root package, plus `-race` on the new tests)
- [x] Ran a client built from this branch against `api.smith.langchain.com` — a sandbox the caller cannot exec into now reports `403 Forbidden` with the server's message instead of `bad status`