### PR TITLE
fix(sandbox): retry WebSocket connect failures when starting a command

### DIFF
--- a/sandbox_command_handle.go
+++ b/sandbox_command_handle.go
@@ -186,7 +186,7 @@ func (h *SandboxCommandHandle) Reconnect(ctx context.Context) (*SandboxCommandHa
 	if h.CommandID == "" {
 		return nil, &SandboxOperationError{Operation: "reconnect", Message: "cannot reconnect: command ID is not available"}
 	}
-	ws, err := dialSandboxCommandWebSocket(ctx, h.dataplaneURL, h.opts...)
+	ws, err := dialSandboxCommandWebSocket(ctx, h.dataplaneURL, sandboxCommandConnectTimeout, h.opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (h *SandboxCommandHandle) reconnectForReadLoop(attempt int) bool {
 		return false
 	}
 
-	ws, err := dialSandboxCommandWebSocket(context.Background(), h.dataplaneURL, h.opts...)
+	ws, err := dialSandboxCommandWebSocket(context.Background(), h.dataplaneURL, sandboxCommandConnectTimeout, h.opts...)
 	if err != nil {
 		return false
 	}

--- a/sandbox_command_start_retry_test.go
+++ b/sandbox_command_start_retry_test.go
@@ -1,0 +1,110 @@
+package langsmith_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
+)
+
+func retryTestClient() *langsmith.Client {
+	return langsmith.NewClient(
+		option.WithBaseURL("http://control-plane.test"),
+		option.WithAPIKey("test-api-key"),
+		option.WithMaxRetries(0),
+	)
+}
+
+func TestSandboxCommandStartRetriesStreamEndedBeforeStarted(t *testing.T) {
+	var attempts atomic.Int32
+	commandIDs := make(chan string, 4)
+
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		var msg map[string]any
+		if err := websocket.JSON.Receive(ws, &msg); err != nil {
+			return
+		}
+		commandID, _ := msg["command_id"].(string)
+		commandIDs <- commandID
+		// First attempt closes before "started"; the second one succeeds.
+		if attempts.Add(1) == 1 {
+			_ = ws.Close()
+			return
+		}
+		_ = websocket.Message.Send(ws, `{"type":"started","command_id":"`+commandID+`","pid":7}`)
+		_ = websocket.Message.Send(ws, `{"type":"exit","exit_code":0}`)
+	}))
+	defer srv.Close()
+
+	handle, err := retryTestClient().Sandboxes.Boxes.StartCommandWithDataplaneURL(
+		context.Background(),
+		srv.URL,
+		langsmith.SandboxCommandStartParams{Command: langsmith.String("echo hi")},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+
+	require.EqualValues(t, 2, attempts.Load())
+	first := <-commandIDs
+	second := <-commandIDs
+	require.NotEmpty(t, first, "client must supply a command_id for idempotent re-issue")
+	assert.Equal(t, first, second, "retry must reuse the command_id so the server dedupes")
+	assert.Equal(t, first, handle.CommandID)
+}
+
+func TestSandboxCommandStartDoesNotRetryRejectedHandshake(t *testing.T) {
+	var attempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := retryTestClient().Sandboxes.Boxes.StartCommandWithDataplaneURL(
+		context.Background(),
+		srv.URL,
+		langsmith.SandboxCommandStartParams{Command: langsmith.String("echo hi")},
+	)
+	require.Error(t, err)
+
+	var permanent *langsmith.SandboxConnectionError
+	require.ErrorAs(t, err, &permanent)
+	var retryable *langsmith.SandboxConnectTimeoutError
+	assert.NotErrorAs(t, err, &retryable, "a rejected upgrade must not be classified retryable")
+	assert.EqualValues(t, 1, attempts.Load(), "a rejected upgrade must not be retried")
+}
+
+func TestSandboxCommandStartHonorsContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		var msg map[string]any
+		_ = websocket.JSON.Receive(ws, &msg)
+		_ = ws.Close() // always retryable, so the loop keeps backing off
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := retryTestClient().Sandboxes.Boxes.StartCommandWithDataplaneURL(
+		ctx,
+		srv.URL,
+		langsmith.SandboxCommandStartParams{Command: langsmith.String("echo hi")},
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), sandboxRetryTestBudgetGuard,
+		"cancellation must win over the remaining connect budget")
+}
+
+// Well under the 120s connect budget: cancellation should end the loop long
+// before the budget or the retry count does.
+const sandboxRetryTestBudgetGuard = 10 * time.Second

--- a/sandbox_commands.go
+++ b/sandbox_commands.go
@@ -8,6 +8,8 @@ import (
 	"slices"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/langchain-ai/langsmith-go/internal/apijson"
 	"github.com/langchain-ai/langsmith-go/internal/param"
 	"github.com/langchain-ai/langsmith-go/internal/requestconfig"
@@ -21,6 +23,8 @@ const (
 	defaultSandboxCommandIdleTimeout    = int64(300)
 	defaultSandboxCommandTTLSeconds     = int64(600)
 	sandboxCommandMaxAutoReconnects     = 5
+	sandboxCommandConnectTimeout        = 30 * time.Second
+	sandboxCommandConnectBudget         = 120 * time.Second
 	sandboxCommandReconnectBackoffBase  = 500 * time.Millisecond
 	sandboxCommandReconnectBackoffMax   = 8 * time.Second
 )
@@ -195,18 +199,82 @@ func (r *SandboxBoxService) startCommandWithDataplaneURL(ctx context.Context, da
 		return nil, err
 	}
 
-	ws, err := dialSandboxCommandWebSocket(ctx, dataplaneURL, opts...)
+	// The daemon does get-or-create on command_id, so a re-issue reattaches instead of spawning a second command.
+	commandID, err := uuid.NewV7()
+	if err != nil {
+		return nil, fmt.Errorf("langsmith: failed to generate sandbox command id: %w", err)
+	}
+	payload.CommandID = F(commandID.String())
+
+	deadline := time.Now().Add(sandboxCommandConnectBudget)
+	for attempt := 0; ; attempt++ {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, &SandboxConnectTimeoutError{Message: fmt.Sprintf("langsmith: gave up connecting to sandbox command WebSocket after %s", sandboxCommandConnectBudget)}
+		}
+		handle, err := startSandboxCommandAttempt(ctx, dataplaneURL, payload, min(sandboxCommandConnectTimeout, remaining), opts...)
+		if err == nil {
+			handle.callbacks = callbacks
+			handle.start()
+			return handle, nil
+		}
+		if !sandboxCommandStartRetryable(err) || attempt >= sandboxCommandMaxAutoReconnects {
+			return nil, err
+		}
+		backoff := min(sandboxCommandReconnectBackoffBase<<attempt, sandboxCommandReconnectBackoffMax)
+		if left := time.Until(deadline); left <= 0 {
+			return nil, err
+		} else if backoff > left {
+			backoff = left
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+}
+
+// sandboxCommandStartRetryable reports whether a failed attempt left the command unstarted, and so can be re-issued.
+func sandboxCommandStartRetryable(err error) bool {
+	var connErr *SandboxConnectTimeoutError
+	if errors.As(err, &connErr) {
+		return true
+	}
+	var earlyClose *sandboxStreamEndedBeforeStartedError
+	return errors.As(err, &earlyClose)
+}
+
+// sandboxStreamEndedBeforeStartedError marks a stream closed before the "started" frame, as distinct from a command failure.
+type sandboxStreamEndedBeforeStartedError struct {
+	Message string
+}
+
+func (e *sandboxStreamEndedBeforeStartedError) Error() string {
+	return e.Message
+}
+
+func (e *sandboxStreamEndedBeforeStartedError) Unwrap() error {
+	return &SandboxConnectionError{Message: e.Message}
+}
+
+func startSandboxCommandAttempt(ctx context.Context, dataplaneURL string, payload sandboxCommandStartRequest, connectTimeout time.Duration, opts ...option.RequestOption) (*SandboxCommandHandle, error) {
+	ws, err := dialSandboxCommandWebSocket(ctx, dataplaneURL, connectTimeout, opts...)
 	if err != nil {
 		return nil, err
 	}
 	if err := websocket.JSON.Send(ws, payload); err != nil {
 		_ = ws.Close()
-		return nil, &SandboxConnectionError{Message: fmt.Sprintf("langsmith: failed to send sandbox command request: %v", err)}
+		return nil, &sandboxStreamEndedBeforeStartedError{Message: fmt.Sprintf("langsmith: failed to send sandbox command request: %v", err)}
 	}
 
 	started, err := receiveSandboxWSMessage(ctx, ws)
 	if err != nil {
 		_ = ws.Close()
+		var connErr *SandboxConnectionError
+		if errors.As(err, &connErr) {
+			return nil, &sandboxStreamEndedBeforeStartedError{Message: connErr.Message}
+		}
 		return nil, err
 	}
 	if started.Type == "error" {
@@ -221,10 +289,7 @@ func (r *SandboxBoxService) startCommandWithDataplaneURL(ctx context.Context, da
 		}
 	}
 
-	handle := newSandboxCommandHandle(ws, dataplaneURL, opts, started.CommandID, started.PID, 0, 0)
-	handle.callbacks = callbacks
-	handle.start()
-	return handle, nil
+	return newSandboxCommandHandle(ws, dataplaneURL, opts, started.CommandID, started.PID, 0, 0), nil
 }
 
 // ReconnectCommand reconnects to a running or recently-finished command in the
@@ -254,7 +319,7 @@ func (r *SandboxBoxService) ReconnectCommandWithDataplaneURL(ctx context.Context
 	stdoutOffset := sandboxFieldValue(body.StdoutOffset, int64(0))
 	stderrOffset := sandboxFieldValue(body.StderrOffset, int64(0))
 
-	ws, err := dialSandboxCommandWebSocket(ctx, dataplaneURL, opts...)
+	ws, err := dialSandboxCommandWebSocket(ctx, dataplaneURL, sandboxCommandConnectTimeout, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -277,6 +342,7 @@ func (r *SandboxBoxService) ReconnectCommandWithDataplaneURL(ctx context.Context
 type sandboxCommandStartRequest struct {
 	Type               param.Field[string]            `json:"type" api:"required"`
 	Command            param.Field[string]            `json:"command" api:"required"`
+	CommandID          param.Field[string]            `json:"command_id"`
 	TimeoutSeconds     param.Field[int64]             `json:"timeout_seconds"`
 	Env                param.Field[map[string]string] `json:"env"`
 	CWD                param.Field[string]            `json:"cwd"`

--- a/sandbox_errors.go
+++ b/sandbox_errors.go
@@ -42,6 +42,25 @@ func (e *SandboxConnectionError) Error() string {
 	return e.Message
 }
 
+// SandboxConnectTimeoutError is returned when the socket fails or times out
+// before the WebSocket handshake completes.
+//
+// Distinct from SandboxConnectionError because it is safely retryable: the
+// execute frame was never sent, so re-issuing the same command ID cannot
+// double-run a command. It unwraps to SandboxConnectionError so callers
+// matching the broader type are unaffected.
+type SandboxConnectTimeoutError struct {
+	Message string
+}
+
+func (e *SandboxConnectTimeoutError) Error() string {
+	return e.Message
+}
+
+func (e *SandboxConnectTimeoutError) Unwrap() error {
+	return &SandboxConnectionError{Message: e.Message}
+}
+
 // SandboxOperationError is returned when the sandbox dataplane reports a
 // command operation error.
 type SandboxOperationError struct {

--- a/sandbox_internal.go
+++ b/sandbox_internal.go
@@ -2,7 +2,9 @@ package langsmith
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -75,15 +77,16 @@ func sandboxWebSocketURL(dataplaneURL string) (string, error) {
 	return u.String(), nil
 }
 
-func dialSandboxCommandWebSocket(ctx context.Context, dataplaneURL string, opts ...option.RequestOption) (*websocket.Conn, error) {
+func dialSandboxCommandWebSocket(ctx context.Context, dataplaneURL string, connectTimeout time.Duration, opts ...option.RequestOption) (*websocket.Conn, error) {
 	wsURL, err := sandboxWebSocketURL(dataplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	return dialSandboxWebSocketURL(ctx, wsURL, opts...)
+	return dialSandboxWebSocketURL(ctx, wsURL, connectTimeout, opts...)
 }
 
-func dialSandboxWebSocketURL(ctx context.Context, wsURL string, opts ...option.RequestOption) (*websocket.Conn, error) {
+// dialSandboxWebSocketURL dials wsURL; connectTimeout must be positive, since net.Dialer treats zero as no timeout.
+func dialSandboxWebSocketURL(ctx context.Context, wsURL string, connectTimeout time.Duration, opts ...option.RequestOption) (*websocket.Conn, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -100,6 +103,10 @@ func dialSandboxWebSocketURL(ctx context.Context, wsURL string, opts ...option.R
 		return nil, err
 	}
 	config.Header = headers
+	if connectTimeout <= 0 {
+		connectTimeout = sandboxCommandConnectTimeout
+	}
+	config.Dialer = &net.Dialer{Timeout: connectTimeout}
 
 	type dialResult struct {
 		ws  *websocket.Conn
@@ -114,7 +121,18 @@ func dialSandboxWebSocketURL(ctx context.Context, wsURL string, opts ...option.R
 	select {
 	case res := <-ch:
 		if res.err != nil {
-			return nil, &SandboxConnectionError{Message: fmt.Sprintf("langsmith: failed to connect to sandbox command WebSocket: %v", res.err)}
+			msg := fmt.Sprintf("langsmith: failed to connect to sandbox command WebSocket: %v", res.err)
+			// A rejected handshake is permanent, any other failure is retryable; DialError has no Unwrap, hence the manual step.
+			cause := res.err
+			var dialErr *websocket.DialError
+			if errors.As(cause, &dialErr) && dialErr.Err != nil {
+				cause = dialErr.Err
+			}
+			var protoErr *websocket.ProtocolError
+			if errors.As(cause, &protoErr) {
+				return nil, &SandboxConnectionError{Message: msg}
+			}
+			return nil, &SandboxConnectTimeoutError{Message: msg}
 		}
 		return res.ws, nil
 	case <-ctx.Done():

--- a/sandbox_tunnel_bridge.go
+++ b/sandbox_tunnel_bridge.go
@@ -157,7 +157,7 @@ func connectSandboxTunnelSession(ctx context.Context, dataplaneURL string, opts 
 	if err != nil {
 		return nil, err
 	}
-	ws, err := dialSandboxWebSocketURL(ctx, wsURL, opts...)
+	ws, err := dialSandboxWebSocketURL(ctx, wsURL, sandboxCommandConnectTimeout, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Go port of langchain-ai/langsmith-sdk#3282 (Python, merged) and langchain-ai/langsmith-sdk#3283 (JS). A WebSocket connect failure when starting a sandbox command failed the call outright, which a cold-starting sandbox hits routinely.

Go started from further back than the other two SDKs: it dialed **once**, with **no dial timeout at all** (`config.Dialer` unset, bounded only by the caller's `ctx`), and it had no retry loop to widen — nor the client-generated command ID that makes a re-issue safe.

### Changes

- **Idempotent re-issue.** `sandboxCommandStartRequest` gains `command_id`, generated once per call with `uuid.NewV7()` and reused across attempts. The daemon does get-or-create on it, so a retry reattaches instead of spawning a second command. This is the precondition that makes retrying safe at all — without it a retry could double-run a command.
- **Bounded retry loop** around dial → send → `started`: reuses the existing `sandboxCommandMaxAutoReconnects` (5) and 500ms→8s backoff constants, with a new 120s `sandboxCommandConnectBudget` ceiling on the whole connect phase. Backoff is clamped to the remaining budget, and the loop refuses to start an attempt with none left — `net.Dialer{Timeout: 0}` means *no* timeout in Go, so converting exhaustion to zero would silently unbound the final attempt.
- **Per-attempt dial timeout** of 30s (`min(30s, remaining budget)`) via `config.Dialer`. The tunnel dial path picks this up too, where it previously had no bound either.
- **Error classification.** New `SandboxConnectTimeoutError` for socket-level, pre-handshake failures; it unwraps to `SandboxConnectionError`, so the existing `errors.As` check in `shouldReconnect` keeps matching. A rejected or malformed handshake (`*websocket.ProtocolError`, e.g. `websocket.ErrBadStatus`) stays a plain `SandboxConnectionError` and propagates immediately — retrying a 404 only delays the error. Note `*websocket.DialError` has no `Unwrap`, so the cause is unwrapped explicitly; a test covers this (it failed before that step was added).
- Cancellation still wins: the backoff sleeps on `select` over `ctx.Done()`.

`receiveSandboxWSMessage` failing before `started` is treated as retryable too, matching Python's `_StreamEndedBeforeStarted`.

## Test Plan
- [x] `go test ./...` — all packages pass
- [x] `go vet .` clean
- [x] New: a stream that closes before `started` retries and reuses the same `command_id` (asserted on both wire payloads)
- [x] New: a 404 upgrade is not retried — one attempt, classified permanent, not `SandboxConnectTimeoutError`
- [x] New: `ctx` cancellation ends the loop well inside the connect budget