### PR TITLE
fix(oauth): resolve the token endpoint from the deployment metadata

### DIFF
--- a/config.go
+++ b/config.go
@@ -392,7 +392,7 @@ func refreshOAuthToken(ctx context.Context, apiURL, refreshToken string) (*oauth
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
-		strings.TrimRight(normalizeConfigURL(apiURL), "/")+"/oauth/token",
+		resolveTokenEndpoint(ctx, apiURL),
 		bytes.NewBufferString(values.Encode()),
 	)
 	if err != nil {

--- a/oauth_discovery.go
+++ b/oauth_discovery.go
@@ -1,0 +1,127 @@
+package langsmith
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	wellKnownOAuthPath      = "/.well-known/oauth-authorization-server"
+	oauthDiscoveryMaxBody   = 1 << 20
+	oauthDiscoveryPerTryTTL = 5 * time.Second
+)
+
+type oauthServerMetadata struct {
+	Issuer                      string `json:"issuer"`
+	DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
+	TokenEndpoint               string `json:"token_endpoint"`
+}
+
+// oauthConfigURL reduces a configured API URL to the mount point the
+// authorization server is served from. Unlike normalizeConfigURL it keeps a
+// trailing "/api": REST lives at <origin>/api/v1 so its base URL is the origin,
+// but on self-hosted the authorization server lives under <origin>/api.
+func oauthConfigURL(apiURL string) string {
+	u := strings.TrimRight(apiURL, "/")
+	return strings.TrimSuffix(u, "/api/v1")
+}
+
+// resolveTokenEndpoint returns the token endpoint for apiURL, preferring the
+// RFC 8414 metadata document the deployment serves and falling back to
+// <mount>/oauth/token when none is available. It never fails: callers treat an
+// unreachable endpoint as a failed refresh.
+func resolveTokenEndpoint(ctx context.Context, apiURL string) string {
+	for _, base := range oauthDiscoveryCandidates(apiURL) {
+		if meta := fetchOAuthMetadata(ctx, base); meta != nil {
+			return meta.TokenEndpoint
+		}
+	}
+	return strings.TrimRight(oauthConfigURL(apiURL), "/") + "/oauth/token"
+}
+
+// oauthDiscoveryCandidates lists metadata base URLs to probe, most specific
+// first: the configured mount point, then the self-hosted and SaaS locations.
+func oauthDiscoveryCandidates(apiURL string) []string {
+	given := strings.TrimRight(oauthConfigURL(apiURL), "/")
+	origin := strings.TrimRight(normalizeConfigURL(apiURL), "/")
+
+	out := make([]string, 0, 3)
+	seen := make(map[string]bool, 3)
+	for _, c := range []string{given, origin + "/api", origin} {
+		if c == "" || c == "/api" || seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	return out
+}
+
+func fetchOAuthMetadata(ctx context.Context, base string) *oauthServerMetadata {
+	reqCtx, cancel := context.WithTimeout(ctx, oauthDiscoveryPerTryTTL)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+wellKnownOAuthPath, nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, oauthDiscoveryMaxBody))
+	if err != nil {
+		return nil
+	}
+
+	var doc oauthServerMetadata
+	// The self-hosted SPA catch-all answers unknown paths with an HTML 200.
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil
+	}
+	if doc.TokenEndpoint == "" || doc.DeviceAuthorizationEndpoint == "" {
+		return nil
+	}
+	if err := validateOAuthMetadata(&doc, base); err != nil {
+		return nil
+	}
+	return &doc
+}
+
+// validateOAuthMetadata enforces that the document describes the deployment we
+// probed: RFC 8414 requires the issuer to match the URL the well-known path was
+// built from, and every endpoint must share the issuer's origin. Refresh tokens
+// are posted to these URLs, so an unvalidated document could redirect
+// credentials to another host.
+func validateOAuthMetadata(doc *oauthServerMetadata, base string) error {
+	if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(base, "/") {
+		return fmt.Errorf("issuer %q does not match %q", doc.Issuer, base)
+	}
+	issuer, err := url.Parse(doc.Issuer)
+	if err != nil {
+		return err
+	}
+	for _, ep := range []string{doc.DeviceAuthorizationEndpoint, doc.TokenEndpoint} {
+		u, err := url.Parse(ep)
+		if err != nil {
+			return err
+		}
+		if u.Scheme != issuer.Scheme || u.Host != issuer.Host {
+			return fmt.Errorf("endpoint %q is not on issuer origin", ep)
+		}
+	}
+	return nil
+}

--- a/oauth_discovery_test.go
+++ b/oauth_discovery_test.go
@@ -1,0 +1,144 @@
+package langsmith
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// selfHostedASServer serves authorization server metadata under /api, as
+// self-hosted LangSmith does, and an HTML 200 at the bare-root .well-known path
+// like the SPA catch-all.
+func selfHostedASServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                        srv.URL + "/api",
+				"device_authorization_endpoint": srv.URL + "/api/oauth/device/code",
+				"token_endpoint":                srv.URL + "/api/oauth/token",
+			})
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<!doctype html><html><body>app</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestResolveTokenEndpoint_SelfHostedBareOrigin(t *testing.T) {
+	srv := selfHostedASServer(t)
+
+	got := resolveTokenEndpoint(context.Background(), srv.URL)
+	if want := srv.URL + "/api/oauth/token"; got != want {
+		t.Errorf("resolveTokenEndpoint(%q) = %q, want %q", srv.URL, got, want)
+	}
+}
+
+func TestResolveTokenEndpoint_SelfHostedApiSuffix(t *testing.T) {
+	srv := selfHostedASServer(t)
+
+	got := resolveTokenEndpoint(context.Background(), srv.URL+"/api")
+	if want := srv.URL + "/api/oauth/token"; got != want {
+		t.Errorf("resolveTokenEndpoint(%q) = %q, want %q", srv.URL+"/api", got, want)
+	}
+}
+
+func TestResolveTokenEndpoint_SaaSAtRoot(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                        srv.URL,
+				"device_authorization_endpoint": srv.URL + "/oauth/device/code",
+				"token_endpoint":                srv.URL + "/oauth/token",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	got := resolveTokenEndpoint(context.Background(), srv.URL)
+	if want := srv.URL + "/oauth/token"; got != want {
+		t.Errorf("resolveTokenEndpoint = %q, want %q", got, want)
+	}
+}
+
+// Without a metadata document the endpoint keeps the configured mount point.
+// The /api segment must survive here: normalizeBaseURL strips it for REST, but
+// the authorization server on self-hosted lives under it.
+func TestResolveTokenEndpoint_FallbackKeepsApiMount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	got := resolveTokenEndpoint(context.Background(), srv.URL+"/api")
+	if want := srv.URL + "/api/oauth/token"; got != want {
+		t.Errorf("resolveTokenEndpoint = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTokenEndpoint_FallbackStripsApiV1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	got := resolveTokenEndpoint(context.Background(), srv.URL+"/api/v1")
+	if want := srv.URL + "/oauth/token"; got != want {
+		t.Errorf("resolveTokenEndpoint = %q, want %q", got, want)
+	}
+}
+
+// Credentials are posted to this endpoint, so a document naming a different
+// issuer or an off-origin endpoint must be ignored in favour of the fallback.
+func TestResolveTokenEndpoint_RejectsUntrustedMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		doc  func(base string) map[string]any
+	}{
+		{"issuer mismatch", func(base string) map[string]any {
+			return map[string]any{
+				"issuer":                        "https://evil.example.com",
+				"device_authorization_endpoint": base + "/oauth/device/code",
+				"token_endpoint":                base + "/oauth/token",
+			}
+		}},
+		{"foreign endpoint", func(base string) map[string]any {
+			return map[string]any{
+				"issuer":                        base,
+				"device_authorization_endpoint": base + "/oauth/device/code",
+				"token_endpoint":                "https://evil.example.com/oauth/token",
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var srv *httptest.Server
+			srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/.well-known/oauth-authorization-server" {
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(tc.doc(srv.URL))
+					return
+				}
+				http.NotFound(w, r)
+			}))
+			defer srv.Close()
+
+			got := resolveTokenEndpoint(context.Background(), srv.URL)
+			if want := srv.URL + "/oauth/token"; got != want {
+				t.Errorf("resolveTokenEndpoint = %q, want fallback %q", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

OAuth token refresh cannot work against self-hosted LangSmith, for any configured `api_url`.

`refreshOAuthToken` built its URL as `normalizeConfigURL(apiURL) + "/oauth/token"`. `normalizeConfigURL` delegates to `normalizeBaseURL`, which strips a trailing `/api` as well as `/api/v1`, so every input collapses to the origin:

| `api_url` | refresh POST |
|---|---|
| `<origin>` | `<origin>/oauth/token` |
| `<origin>/api` | `<origin>/oauth/token` |
| `<origin>/api/v1` | `<origin>/oauth/token` |

That is correct on SaaS, but self-hosted mounts the authorization server under `<origin>/api`, so the request lands on the SPA catch-all and returns **405**. The same `/api` stripping that makes the REST base URL correct is what breaks OAuth, because both reuse one normalizer.

The failure is silent — `profileAuth.refreshProfileToken` discards the error and returns the unrefreshed profile, so it surfaces only as `401 {"detail":"Invalid token"}` on the next request, with nothing written back to `~/.langsmith/config.json`. If the previous access token is still valid the call succeeds and the broken refresh is invisible.

## Change

Resolve the token endpoint from the deployment's RFC 8414 metadata document.

- Probe `.well-known/oauth-authorization-server` at the configured mount point, then `<origin>/api`, then `<origin>`, so both a bare origin and an explicit `/api` resolve.
- Fall back to `<mount>/oauth/token` when no document is served. `oauthConfigURL` keeps a trailing `/api` — the segment REST must strip and the authorization server must retain — so the fallback is correct on self-hosted too.
- Only trust a document whose `issuer` matches the URL the well-known path was built from and whose endpoints share the issuer's origin. Refresh tokens are posted to these URLs. Self-hosted answers unknown paths with an HTML `200`, so a non-metadata response is ignored rather than trusted.

REST routing is unchanged; `normalizeConfigURL` and `normalizeBaseURL` keep their current behavior.

## Test Plan

- [x] Unit tests: self-hosted from a bare origin, self-hosted with `/api`, SaaS at root, fallback keeping `/api`, fallback stripping `/api/v1`, and rejection of issuer-mismatch / off-origin documents
- [x] Against a live self-hosted deployment, `Sessions.List` with a cleared access token now refreshes and persists a new `expires_at` — from both `api_url = <origin>` and `api_url = <origin>/api`. Both returned 401 before this change
- [x] `go build ./...`, `go test ./...` clean (the pre-existing `gofmt`/`vet` findings in `insights_test.go`, `lib/langsmithtracing/...` and `internal/apijson` are unchanged by this PR)