### PR TITLE
fix(traceopenai): error the span when a Responses call fails

### DIFF
--- a/instrumentation/traceopenai/openaitrace.go
+++ b/instrumentation/traceopenai/openaitrace.go
@@ -4,6 +4,7 @@ package traceopenai
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -227,11 +228,12 @@ func MiddlewareWithTracerProvider(req *http.Request, next MiddlewareNext, tp tra
 
 		var completion string
 		var usage usageInfo
+		var responseFailure error
 		if responsesAPI {
 			if streaming {
-				completion, usage = extractStreamingResponsesCompletion(data)
+				completion, usage, responseFailure = extractStreamingResponsesCompletion(data)
 			} else {
-				completion, usage = extractResponsesCompletion(data)
+				completion, usage, responseFailure = extractResponsesCompletion(data)
 			}
 		} else if streaming {
 			completion, usage = extractStreamingCompletion(data)
@@ -270,7 +272,11 @@ func MiddlewareWithTracerProvider(req *http.Request, next MiddlewareNext, tp tra
 				span.SetAttributes(serviceTierKey.String(usage.ServiceTier))
 			}
 		}
-		if resp.StatusCode < 400 && !incompleteStream {
+		if responseFailure != nil {
+			span.RecordError(responseFailure)
+			span.SetStatus(codes.Error, responseFailure.Error())
+		}
+		if resp.StatusCode < 400 && !incompleteStream && responseFailure == nil {
 			span.SetStatus(codes.Ok, "")
 		}
 		span.End()
@@ -1031,17 +1037,17 @@ func extractCompletionFromResponse(body []byte) (string, usageInfo) {
 
 // --- Responses API (/v1/responses) ---
 
-// extractResponsesCompletion extracts completion and usage from a non-streaming
-// Responses API response.
-func extractResponsesCompletion(body []byte) (string, usageInfo) {
+// extractResponsesCompletion extracts completion, usage, and any response-level
+// failure from a non-streaming Responses API response.
+func extractResponsesCompletion(body []byte) (string, usageInfo, error) {
 	var resp map[string]any
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return "", usageInfo{}
+		return "", usageInfo{}, nil
 	}
 	if object, _ := resp["object"].(string); object == "response.compaction" {
-		return extractResponsesCompactOutput(resp), extractResponsesUsage(resp)
+		return extractResponsesCompactOutput(resp), extractResponsesUsage(resp), responsesFailure(resp, "")
 	}
-	return extractResponsesOutput(resp), extractResponsesUsage(resp)
+	return extractResponsesOutput(resp), extractResponsesUsage(resp), responsesFailure(resp, "")
 }
 
 // extractStreamingResponsesCompletion extracts completion and usage from a
@@ -1049,21 +1055,57 @@ func extractResponsesCompletion(body []byte) (string, usageInfo) {
 // events that carry the full response object (including usage):
 // response.completed, response.incomplete, and response.failed.
 // See https://platform.openai.com/docs/api-reference/responses-streaming
-func extractStreamingResponsesCompletion(data []byte) (string, usageInfo) {
-	chunks, err := traceutil.ParseSSEChunks(bytes.NewReader(data))
-	if err != nil || len(chunks) == 0 {
-		return "", usageInfo{}
-	}
+func extractStreamingResponsesCompletion(data []byte) (string, usageInfo, error) {
+	// ParseSSEChunks returns the chunks it read alongside any error; a terminal
+	// event among them still carries the usage and status for the whole call.
+	chunks, parseErr := traceutil.ParseSSEChunks(bytes.NewReader(data))
 
 	for _, chunk := range chunks {
 		switch msgType, _ := chunk["type"].(string); msgType {
 		case "response.completed", "response.incomplete", "response.failed":
-			if response, ok := chunk["response"].(map[string]any); ok {
-				return extractResponsesOutput(response), extractResponsesUsage(response)
+			response, ok := chunk["response"].(map[string]any)
+			if !ok {
+				continue
 			}
+			// Terminal events are named response.<status>, so the event type
+			// supplies the status when the response object omits it.
+			failure := responsesFailure(response, strings.TrimPrefix(msgType, "response."))
+			return extractResponsesOutput(response), extractResponsesUsage(response), failure
 		}
 	}
-	return "", usageInfo{}
+	if parseErr != nil {
+		return "", usageInfo{}, fmt.Errorf("%w: %w", errResponsesUnreadableStream, parseErr)
+	}
+	return "", usageInfo{}, nil
+}
+
+// errResponsesFailed is a Responses API response the API accepted (HTTP 2xx)
+// but did not fulfil: status "failed", which OpenAI reports with usage: null.
+// See https://platform.openai.com/docs/api-reference/responses/object
+var errResponsesFailed = errors.New("response failed")
+
+// errResponsesUnreadableStream is a stream whose SSE would not parse, so no
+// terminal event or usage was recovered. Its bytes may still contain a terminal
+// marker, which is why the caller's truncation check cannot catch it.
+var errResponsesUnreadableStream = errors.New("unreadable response stream")
+
+// responsesFailure returns a non-nil error for a Responses API response object
+// whose status is "failed", falling back to eventStatus when the object omits
+// the field. Other statuses are not faults: "incomplete" is a truncated but
+// successful generation, and "queued"/"in_progress" are pending.
+func responsesFailure(resp map[string]any, eventStatus string) error {
+	status, ok := resp["status"].(string)
+	if !ok {
+		status = eventStatus
+	}
+	if status != "failed" {
+		return nil
+	}
+	respErr, _ := resp["error"].(map[string]any)
+	if msg, _ := respErr["message"].(string); msg != "" {
+		return fmt.Errorf("%w: %s", errResponsesFailed, msg)
+	}
+	return errResponsesFailed
 }
 
 // extractResponsesUsage extracts usage from a Responses API response object.

--- a/instrumentation/traceopenai/openaitrace.go
+++ b/instrumentation/traceopenai/openaitrace.go
@@ -273,6 +273,10 @@ func MiddlewareWithTracerProvider(req *http.Request, next MiddlewareNext, tp tra
 			}
 		}
 		if responseFailure != nil {
+			// A truncated JSON event is a symptom of the read failure.
+			if errors.Is(responseFailure, errResponsesUnreadableStream) && readErr != nil && readErr != io.EOF {
+				responseFailure = readErr
+			}
 			span.RecordError(responseFailure)
 			span.SetStatus(codes.Error, responseFailure.Error())
 		}

--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
@@ -602,7 +604,7 @@ func TestExtractResponsesCompletion(t *testing.T) {
 		"output": [{"type": "message", "content": [{"type": "output_text", "text": "Hi there"}]}],
 		"usage": {"input_tokens": 3, "output_tokens": 2}
 	}`
-	completion, usage := extractResponsesCompletion([]byte(body))
+	completion, usage, _ := extractResponsesCompletion([]byte(body))
 
 	if !strings.Contains(completion, "Hi there") {
 		t.Errorf("completion should contain 'Hi there': %s", completion)
@@ -620,7 +622,7 @@ func TestExtractResponsesCompletion_FunctionCall(t *testing.T) {
 		"output": [{"type": "function_call", "name": "search", "arguments": "{\"q\":\"Go\"}", "call_id": "fc_1"}],
 		"usage": {"input_tokens": 1, "output_tokens": 1}
 	}`
-	completion, _ := extractResponsesCompletion([]byte(body))
+	completion, _, _ := extractResponsesCompletion([]byte(body))
 
 	if !strings.Contains(completion, "search") {
 		t.Errorf("completion should contain function name: %s", completion)
@@ -645,7 +647,7 @@ func TestExtractResponsesCompletion_Compaction(t *testing.T) {
 			"total_tokens": 577
 		}
 	}`
-	completion, usage := extractResponsesCompletion([]byte(body))
+	completion, usage, _ := extractResponsesCompletion([]byte(body))
 
 	wantCompletion := `{"messages":[{"content":"Create a simple landing page for a dog petting cafe.","role":"user"}]}`
 	if completion != wantCompletion {
@@ -670,7 +672,7 @@ func TestExtractStreamingResponsesCompletion(t *testing.T) {
 	// response.completed event and the connection closes.
 	sse := "data: {\"type\":\"response.created\"}\n" +
 		"data: {\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"done\"}]}],\"usage\":{\"input_tokens\":7,\"output_tokens\":3}}}\n"
-	completion, usage := extractStreamingResponsesCompletion([]byte(sse))
+	completion, usage, _ := extractStreamingResponsesCompletion([]byte(sse))
 
 	if !strings.Contains(completion, "done") {
 		t.Errorf("completion should contain 'done': %s", completion)
@@ -685,7 +687,7 @@ func TestExtractStreamingResponsesCompletion_LargeCompletedEvent(t *testing.T) {
 		strings.Repeat("x", 70*1024) +
 		`"}],"usage":{"input_tokens":7,"output_tokens":3}}}
 `
-	completion, usage := extractStreamingResponsesCompletion([]byte(sse))
+	completion, usage, _ := extractStreamingResponsesCompletion([]byte(sse))
 
 	if !strings.Contains(completion, "done") {
 		t.Errorf("completion should contain 'done': %s", completion)
@@ -697,7 +699,7 @@ func TestExtractStreamingResponsesCompletion_LargeCompletedEvent(t *testing.T) {
 
 func TestExtractStreamingResponsesCompletion_NoCompletedEvent(t *testing.T) {
 	sse := "data: {\"type\":\"response.created\"}\n"
-	completion, usage := extractStreamingResponsesCompletion([]byte(sse))
+	completion, usage, _ := extractStreamingResponsesCompletion([]byte(sse))
 	if completion != "" {
 		t.Errorf("expected empty completion, got %q", completion)
 	}
@@ -708,7 +710,7 @@ func TestExtractStreamingResponsesCompletion_NoCompletedEvent(t *testing.T) {
 
 func TestExtractStreamingResponsesCompletion_IncompleteEvent(t *testing.T) {
 	sse := "data: {\"type\":\"response.incomplete\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hi\"}]}],\"usage\":{\"input_tokens\":10,\"output_tokens\":3},\"incomplete_details\":{\"reason\":\"max_output_tokens\"}}}\n"
-	completion, usage := extractStreamingResponsesCompletion([]byte(sse))
+	completion, usage, _ := extractStreamingResponsesCompletion([]byte(sse))
 	if !strings.Contains(completion, "Hi") {
 		t.Errorf("completion should contain 'Hi': %s", completion)
 	}
@@ -722,7 +724,11 @@ func TestExtractStreamingResponsesCompletion_IncompleteEvent(t *testing.T) {
 
 func TestExtractStreamingResponsesCompletion_FailedEvent(t *testing.T) {
 	sse := "data: {\"type\":\"response.failed\",\"response\":{\"output\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n"
-	_, usage := extractStreamingResponsesCompletion([]byte(sse))
+	_, usage, failure := extractStreamingResponsesCompletion([]byte(sse))
+	// The response object omits status, so the event type has to supply it.
+	if !errors.Is(failure, errResponsesFailed) {
+		t.Errorf("failure = %v, want errResponsesFailed", failure)
+	}
 	if usage.InputTokens != 5 || usage.OutputTokens != 0 {
 		t.Errorf("got %+v, want {5, 0}", usage)
 	}
@@ -1903,5 +1909,198 @@ func TestExtractStreamingCompletion_UsageMetadataAndServiceTier(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("usage mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestResponsesFailure(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{
+			name: "completed",
+			body: `{"status":"completed","usage":{"input_tokens":3,"output_tokens":2}}`,
+		},
+		{
+			name:    "failed carries null usage and an error message",
+			body:    `{"status":"failed","error":{"code":"server_error","message":"upstream exploded"},"usage":null}`,
+			wantErr: fmt.Errorf("%w: upstream exploded", errResponsesFailed),
+		},
+		{
+			name:    "failed with no error message",
+			body:    `{"status":"failed","error":{"code":"server_error"},"usage":null}`,
+			wantErr: errResponsesFailed,
+		},
+		{
+			name: "incomplete is not a failure",
+			body: `{"status":"incomplete","incomplete_details":{"reason":"max_tokens"},"usage":null}`,
+		},
+		{
+			name: "queued background create is not a failure",
+			body: `{"status":"queued","usage":null}`,
+		},
+		{
+			name: "status absent",
+			body: `{"usage":{"input_tokens":1,"output_tokens":1}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, failure := extractResponsesCompletion([]byte(tt.body))
+			if tt.wantErr == nil {
+				if failure != nil {
+					t.Fatalf("failure = %v, want nil", failure)
+				}
+				return
+			}
+			if !errors.Is(failure, errResponsesFailed) {
+				t.Fatalf("failure = %v, want errResponsesFailed", failure)
+			}
+			if failure.Error() != tt.wantErr.Error() {
+				t.Errorf("message = %q, want %q", failure.Error(), tt.wantErr.Error())
+			}
+		})
+	}
+}
+
+// A single unparseable SSE line used to discard the whole stream, losing the
+// usage and status of a terminal event that had already been read.
+func TestExtractStreamingResponsesCompletion_MalformedLine(t *testing.T) {
+	const (
+		failed    = "data: {\"type\":\"response.failed\",\"response\":{\"status\":\"failed\",\"error\":{\"message\":\"boom\"},\"usage\":null}}\n"
+		completed = "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":7,\"output_tokens\":3}}}\n"
+		malformed = "data: {oops not json}\n"
+	)
+	tests := []struct {
+		name            string
+		sse             string
+		wantErr         error
+		wantInputTokens int
+	}{
+		{
+			name:    "failed then malformed still reports the failure",
+			sse:     failed + malformed,
+			wantErr: errResponsesFailed,
+		},
+		{
+			name:            "completed then malformed still reports usage",
+			sse:             completed + malformed,
+			wantInputTokens: 7,
+		},
+		{
+			name:    "malformed before the terminal event is unreadable",
+			sse:     malformed + failed,
+			wantErr: errResponsesUnreadableStream,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, usage, err := extractStreamingResponsesCompletion([]byte(tt.sse))
+			if tt.wantErr == nil && err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if usage.InputTokens != tt.wantInputTokens {
+				t.Errorf("InputTokens = %d, want %d", usage.InputTokens, tt.wantInputTokens)
+			}
+		})
+	}
+}
+
+// doResponses sends a Responses API request through client and drains the body
+// so the wrapper sees the full response.
+func doResponses(t *testing.T, client *http.Client, stream bool) {
+	t.Helper()
+	body := fmt.Sprintf(`{"model":"gpt-5.1","input":"hi","stream":%t}`, stream)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.openai.com/v1/responses", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+}
+
+// The span status has to reflect the response, not just the HTTP code: a call
+// can return 200 and still report a failure with usage: null, which otherwise
+// reads downstream as a success that priced to nothing.
+func TestRoundTrip_ResponsesSpanStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		stream    bool
+		body      string
+		wantError bool
+		// wantMsg, when set, is the expected span status description.
+		wantMsg string
+	}{
+		{
+			name: "non-streaming completed",
+			body: `{"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"hi"}]}],"usage":{"input_tokens":3,"output_tokens":2}}`,
+		},
+		{
+			name:      "non-streaming failed",
+			body:      `{"status":"failed","error":{"code":"server_error","message":"upstream exploded"},"output":[],"usage":null}`,
+			wantError: true,
+			wantMsg:   "response failed: upstream exploded",
+		},
+		{
+			name: "non-streaming incomplete is not a fault",
+			body: `{"status":"incomplete","incomplete_details":{"reason":"max_tokens"},"output":[],"usage":null}`,
+		},
+		{
+			name: "non-streaming queued background create is not a fault",
+			body: `{"status":"queued","output":[],"usage":null}`,
+		},
+		{
+			name:   "streaming completed",
+			stream: true,
+			body:   "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}\n",
+		},
+		{
+			name:      "streaming failed",
+			stream:    true,
+			body:      "data: {\"type\":\"response.failed\",\"response\":{\"status\":\"failed\",\"error\":{\"code\":\"server_error\",\"message\":\"upstream exploded\"},\"output\":[],\"usage\":null}}\n",
+			wantError: true,
+			wantMsg:   "response failed: upstream exploded",
+		},
+		{
+			// The raw bytes still contain a terminal marker, so the truncation
+			// check alone leaves this codes.Ok.
+			name:   "streaming unreadable SSE",
+			stream: true,
+			body: "data: {oops not json}\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":7,\"output_tokens\":3}}}\n",
+			wantError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, exporter := newTracedClient(t, []byte(tt.body))
+			doResponses(t, client, tt.stream)
+
+			spans := exporter.GetSpans()
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 span, got %d", len(spans))
+			}
+			span := spans[0]
+			if gotError := span.Status.Code == codes.Error; gotError != tt.wantError {
+				t.Errorf("status = %v, want error=%v", span.Status, tt.wantError)
+			}
+			if tt.wantError && !hasEvent(spans, "exception") {
+				t.Error("expected a recorded exception event")
+			}
+			if tt.wantMsg != "" && span.Status.Description != tt.wantMsg {
+				t.Errorf("description = %q, want %q", span.Status.Description, tt.wantMsg)
+			}
+		})
 	}
 }

--- a/instrumentation/traceopenai/openaitrace_test.go
+++ b/instrumentation/traceopenai/openaitrace_test.go
@@ -1916,7 +1916,7 @@ func TestResponsesFailure(t *testing.T) {
 	tests := []struct {
 		name    string
 		body    string
-		wantErr error
+		wantMsg string
 	}{
 		{
 			name: "completed",
@@ -1925,12 +1925,12 @@ func TestResponsesFailure(t *testing.T) {
 		{
 			name:    "failed carries null usage and an error message",
 			body:    `{"status":"failed","error":{"code":"server_error","message":"upstream exploded"},"usage":null}`,
-			wantErr: fmt.Errorf("%w: upstream exploded", errResponsesFailed),
+			wantMsg: "response failed: upstream exploded",
 		},
 		{
 			name:    "failed with no error message",
 			body:    `{"status":"failed","error":{"code":"server_error"},"usage":null}`,
-			wantErr: errResponsesFailed,
+			wantMsg: "response failed",
 		},
 		{
 			name: "incomplete is not a failure",
@@ -1948,7 +1948,7 @@ func TestResponsesFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, _, failure := extractResponsesCompletion([]byte(tt.body))
-			if tt.wantErr == nil {
+			if tt.wantMsg == "" {
 				if failure != nil {
 					t.Fatalf("failure = %v, want nil", failure)
 				}
@@ -1957,8 +1957,8 @@ func TestResponsesFailure(t *testing.T) {
 			if !errors.Is(failure, errResponsesFailed) {
 				t.Fatalf("failure = %v, want errResponsesFailed", failure)
 			}
-			if failure.Error() != tt.wantErr.Error() {
-				t.Errorf("message = %q, want %q", failure.Error(), tt.wantErr.Error())
+			if failure.Error() != tt.wantMsg {
+				t.Errorf("message = %q, want %q", failure.Error(), tt.wantMsg)
 			}
 		})
 	}


### PR DESCRIPTION
- Preserves available usage_metadata when encountering SSE parsing errors.
- correctly mark spans as failed when receiving appropriate SSE signals from OpenAI

Reference: https://developers.openai.com/api/reference/resources/responses