### PR TITLE
ci: document inapplicable OpenPGP advisory

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,4 @@
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+ignoreUntil = 2026-12-08T00:00:00Z
+reason = "Only affects golang.org/x/crypto/openpgp and its subpackages, which are not imported. Verified 2026-09-09 with go list -mod=readonly -tags=integration -deps -test ./... on linux/amd64, darwin/arm64, and windows/amd64. x/crypto is needed transitively by google.golang.org/genai via github.com/google/s2a-go for other crypto packages. Reassess if OpenPGP imports are introduced."


### PR DESCRIPTION
OSV alert #10 flags GO-2026-5932 for the x/crypto module, but the advisory only affects its openpgp packages. No patched version exists, and this SDK does not import the affected packages.

Add an advisory-specific OSV exception expiring December 8, 2026, with the dependency analysis recorded in its reason. This suppresses an inapplicable finding; it does not patch or remove x/crypto.

Validation: go list -mod=readonly -tags=integration -deps -test ./... succeeded for linux/amd64, darwin/arm64, and windows/amd64, with no openpgp imports. go mod tidy -diff was clean. TOML parsing and whitespace checks passed. GitHub scan behavior remains to be verified after merge.

Alert: https://github.com/langchain-ai/langsmith-go/security/code-scanning/10
